### PR TITLE
Fix reifier: handle self-loops, cycles, and ternary relations

### DIFF
--- a/spytial/dataclass_builder.py
+++ b/spytial/dataclass_builder.py
@@ -17,7 +17,7 @@ import json
 import tempfile
 import webbrowser
 import yaml
-from dataclasses import fields, is_dataclass
+from dataclasses import MISSING, fields, is_dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Type, get_type_hints
 
@@ -99,16 +99,40 @@ def _collect_dataclass_types(
 
 
 def _make_dataclass_reifier(dc_type: Type):
-    """Create a reifier function that constructs an actual dataclass instance."""
+    """Create a reifier that reconstructs an instance of ``dc_type``.
 
-    def reifier(atom: Dict, relations: Dict, reify_atom):
-        kwargs = {}
+    Allocates the instance with ``object.__new__`` and populates fields
+    directly — this lets cyclic structures (self-loops, A↔B) reify by
+    registering the partially-constructed instance *before* recursing into
+    children, and also works for frozen dataclasses. Fields with no relation
+    in the data instance fall back to their declared default.
+
+    Note: ``__post_init__`` is intentionally not invoked (matches pickle's
+    behaviour). Post-init validation can't safely run against a half-built
+    cyclic instance; callers that need it can re-run it themselves.
+    """
+
+    field_defs = fields(dc_type)
+
+    def _apply_defaults(obj: Any) -> None:
+        for f in field_defs:
+            if f.default is not MISSING:
+                object.__setattr__(obj, f.name, f.default)
+            elif f.default_factory is not MISSING:  # type: ignore[misc]
+                object.__setattr__(obj, f.name, f.default_factory())
+
+    def reifier(atom: Dict, relations: Dict, reify_atom, register=None):
+        obj = object.__new__(dc_type)
+        if register is not None:
+            register(obj)
+        _apply_defaults(obj)
         for field_name, target_ids in relations.items():
             if len(target_ids) == 1:
-                kwargs[field_name] = reify_atom(target_ids[0])
+                value = reify_atom(target_ids[0])
             else:
-                kwargs[field_name] = [reify_atom(tid) for tid in target_ids]
-        return dc_type(**kwargs)
+                value = [reify_atom(tid) for tid in target_ids]
+            object.__setattr__(obj, field_name, value)
+        return obj
 
     return reifier
 
@@ -405,6 +429,10 @@ if HAS_ANYWIDGET:
             # Store type info for reification (not synced to frontend)
             self._dataclass_type: Type = dc_type
             self._dc_types: Set[Type] = _collect_dataclass_types(dc_type)
+            # Remember the root atom id from the initial build. spytial-core's
+            # JSONDataInstance strips extra keys on round-trip, so rootId does
+            # not survive frontend sync; we keep it Python-side as a fallback.
+            self._root_atom_id: Optional[str] = initial_data.get("rootId")
 
         @property
         def value(self) -> Any:
@@ -414,7 +442,7 @@ if HAS_ANYWIDGET:
                 reifier.register_reifier(
                     dc_type.__name__, _make_dataclass_reifier(dc_type)
                 )
-            return reifier.reify(self._data_instance)
+            return reifier.reify(self._data_instance, root_id=self._root_atom_id)
 
         @property
         def data_instance(self) -> Dict:

--- a/spytial/provider_system.py
+++ b/spytial/provider_system.py
@@ -12,6 +12,37 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Type
 from .domain_relationalizers.base import RelationalizerBase, Atom, Relation
 
 
+def _invoke_custom_reifier(fn, atom, relations, reify_atom, register):
+    """Call a user-registered reifier, passing ``register`` only if it accepts it.
+
+    Keeps backwards compatibility with the original 3-arg signature
+    ``(atom, relations, reify_atom)`` while enabling cycle-safe reifiers that
+    register a placeholder with ``(atom, relations, reify_atom, register)``.
+    """
+    try:
+        sig = inspect.signature(fn)
+    except (TypeError, ValueError):
+        return fn(atom, relations, reify_atom)
+
+    params = sig.parameters
+    if "register" in params:
+        return fn(atom, relations, reify_atom, register=register)
+    if any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()):
+        return fn(atom, relations, reify_atom, register=register)
+    positional = [
+        p
+        for p in params.values()
+        if p.kind
+        in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        )
+    ]
+    if len(positional) >= 4:
+        return fn(atom, relations, reify_atom, register)
+    return fn(atom, relations, reify_atom)
+
+
 def relationalizer(cls: Type = None, *, priority: int = 0):
     """
     Decorator to register a class as a relationalizer.
@@ -108,6 +139,7 @@ class CnDDataInstanceBuilder:
             None  # Store caller's namespace for variable name lookup
         )
         self._as_type = None  # Store type for root object
+        self._last_root_id: Optional[str] = None  # Root atom from most recent build
 
     def build_instance(self, obj: Any, as_type: Optional[Any] = None) -> Dict:
         """Build a complete data instance from an object.
@@ -166,11 +198,16 @@ class CnDDataInstanceBuilder:
             self._caller_namespace = None
 
         try:
-            self._walk(obj)
+            root_atom_id = self._walk(obj)
         except Exception as e:
             print(f"Error during data instance building: {e}")
             print("Object:", obj)
             raise
+
+        # Cache the root so a later reify() call can reconstruct the same
+        # object even when the graph is cyclic (topology alone can't pick the
+        # root when every source also appears as a target).
+        self._last_root_id = root_atom_id
 
         # Convert relations to include types (matching IRelation interface)
         relations = []
@@ -228,7 +265,12 @@ class CnDDataInstanceBuilder:
         for atom in deduplicated_atoms:
             atom.pop("type_hierarchy", None)
 
-        return {"atoms": deduplicated_atoms, "relations": relations, "types": typs}
+        return {
+            "atoms": deduplicated_atoms,
+            "relations": relations,
+            "types": typs,
+            "rootId": root_atom_id,
+        }
 
     def get_collected_decorators(self) -> Dict:
         """Get all decorators collected during the build process, deduplicated.
@@ -450,7 +492,7 @@ class CnDDataInstanceBuilder:
         # Convert the type_map dictionary to a list of its values
         return list(type_map.values())
 
-    def reify(self, data_instance: Dict) -> Any:
+    def reify(self, data_instance: Dict, root_id: Optional[str] = None) -> Any:
         """
         Reconstruct Python objects from a Spytial-Core data instance.
 
@@ -458,8 +500,11 @@ class CnDDataInstanceBuilder:
         back into Python objects.
 
         Args:
-            data_instance: Dictionary containing 'atoms', 'relations', and 'types'
-                          as returned by build_instance()
+            data_instance: Dictionary containing 'atoms', 'relations', and optionally
+                'rootId' as returned by build_instance().
+            root_id: Optional atom id to use as the reconstruction root. Overrides any
+                'rootId' present in data_instance. When neither is provided the root is
+                inferred from the relation topology.
 
         Returns:
             The reconstructed Python object corresponding to the root atom
@@ -483,8 +528,15 @@ class CnDDataInstanceBuilder:
         # Build maps for efficient lookup
         atom_map = {atom["id"]: atom for atom in atoms}
 
-        # Build relation map: atom_id -> {relation_name: [target_atom_ids]}
-        relation_map = {}
+        # Two views of the relations keyed by source atom:
+        #   relation_map   — flat concatenation of every target across tuples.
+        #                    Kept for backwards compatibility with user-supplied
+        #                    custom reifiers registered via register_reifier().
+        #   relation_tuples — preserves the target tuple structure, which is
+        #                    required to reconstruct n-ary relations (notably
+        #                    the ternary ``kv`` used for dicts).
+        relation_map: Dict[str, Dict[str, List[str]]] = {}
+        relation_tuples: Dict[str, Dict[str, List[List[str]]]] = {}
         for relation in relations:
             rel_name = relation["name"]
             for tuple_info in relation["tuples"]:
@@ -493,15 +545,20 @@ class CnDDataInstanceBuilder:
 
                 if source_id not in relation_map:
                     relation_map[source_id] = {}
+                    relation_tuples[source_id] = {}
                 if rel_name not in relation_map[source_id]:
                     relation_map[source_id][rel_name] = []
+                    relation_tuples[source_id][rel_name] = []
                 relation_map[source_id][rel_name].extend(target_ids)
+                relation_tuples[source_id][rel_name].append(list(target_ids))
 
-        # Track reconstructed objects to handle circular references
-        reconstructed = {}
+        # Memoize reconstructed objects. For mutable containers we register an
+        # empty placeholder *before* recursing into their children so that any
+        # self- or back-reference resolves to the same object — this is what
+        # makes cyclic structures (self-loops, A↔B, A→B→C→A) reifiable.
+        reconstructed: Dict[str, Any] = {}
 
         def reify_atom(atom_id: str) -> Any:
-            """Recursively reconstruct an object from its atom ID."""
             if atom_id in reconstructed:
                 return reconstructed[atom_id]
 
@@ -512,64 +569,114 @@ class CnDDataInstanceBuilder:
             atom_type = atom["type"]
             atom_label = atom["label"]
 
-            # Handle primitive types
             if atom_type in {"str", "int", "float", "bool", "NoneType"}:
                 obj = self._reify_primitive(atom_type, atom_label)
                 reconstructed[atom_id] = obj
                 return obj
 
-            # Handle collections and complex types
             relations_for_atom = relation_map.get(atom_id, {})
 
-            # Check for custom reifier first
+            def register(placeholder: Any) -> Any:
+                reconstructed[atom_id] = placeholder
+                return placeholder
+
             if atom_type in self._custom_reifiers:
-                obj = self._custom_reifiers[atom_type](
-                    atom, relations_for_atom, reify_atom
+                obj = _invoke_custom_reifier(
+                    self._custom_reifiers[atom_type],
+                    atom,
+                    relations_for_atom,
+                    reify_atom,
+                    register,
                 )
             elif atom_type == "dict":
-                obj = self._reify_dict(atom_id, relations_for_atom, reify_atom)
+                obj = self._reify_dict(
+                    atom_id,
+                    relation_tuples.get(atom_id, {}),
+                    reify_atom,
+                    register,
+                )
             elif atom_type == "list":
-                obj = self._reify_list(atom_id, relations_for_atom, reify_atom)
+                obj = self._reify_list(
+                    atom_id,
+                    relation_tuples.get(atom_id, {}),
+                    reify_atom,
+                    register,
+                )
             elif atom_type == "tuple":
-                obj = self._reify_tuple(atom_id, relations_for_atom, reify_atom)
+                obj = self._reify_tuple(
+                    atom_id, relations_for_atom, reify_atom
+                )
             elif atom_type == "set":
-                obj = self._reify_set(atom_id, relations_for_atom, reify_atom)
+                obj = self._reify_set(
+                    atom_id, relations_for_atom, reify_atom, register
+                )
             else:
-                # Handle generic objects or custom types
-                obj = self._reify_generic_object(atom, relations_for_atom, reify_atom)
+                obj = self._reify_generic_object(
+                    atom, relations_for_atom, reify_atom, register
+                )
 
+            # Register the final value. For reifiers that already registered a
+            # mutable placeholder this is effectively a no-op (same object);
+            # for tuples and primitive-style reifiers it installs the result.
             reconstructed[atom_id] = obj
             return obj
 
-        # Find the root atom - it's the one that appears as source in relations
-        # but never appears as a target, OR if no relations exist, use the last atom
-        # (which is typically the root object processed by _walk)
+        root_atom_id = self._resolve_root_id(data_instance, atoms, relations, root_id)
+        return reify_atom(root_atom_id)
+
+    def _resolve_root_id(
+        self,
+        data_instance: Dict,
+        atoms: List[Dict],
+        relations: List[Dict],
+        explicit_root_id: Optional[str],
+    ) -> str:
+        """Pick the atom id to start reification from.
+
+        Precedence:
+          1. Explicit ``root_id`` argument to reify().
+          2. ``rootId`` field in the data instance (written by build_instance).
+          3. Topology — prefer sources that are never targets; then sources that
+             are only ever their own target (self-loops); else fall back to the
+             last atom.
+        """
+        known_ids = {atom["id"] for atom in atoms}
+
+        if explicit_root_id is not None and explicit_root_id in known_ids:
+            return explicit_root_id
+
+        stored_root = data_instance.get("rootId")
+        if isinstance(stored_root, str) and stored_root in known_ids:
+            return stored_root
 
         if not relations:
-            # No relations - use the only atom or the last one
-            root_atom_id = atoms[-1]["id"]
-        else:
-            # Find atoms that are sources but not targets
-            source_atoms = set()
-            target_atoms = set()
+            return atoms[-1]["id"]
 
-            for relation in relations:
-                for tuple_info in relation["tuples"]:
-                    atom_ids = tuple_info["atoms"]
-                    source_atoms.add(atom_ids[0])
-                    target_atoms.update(atom_ids[1:])
+        source_atoms: set = set()
+        # Targets from another atom (i.e. non-self-loop targets). Self-loops
+        # should not disqualify an atom from being a root.
+        non_self_targets: set = set()
+        all_targets: set = set()
 
-            # Root candidates are sources that are not targets
-            root_candidates = source_atoms - target_atoms
+        for relation in relations:
+            for tuple_info in relation["tuples"]:
+                atom_ids = tuple_info["atoms"]
+                src = atom_ids[0]
+                source_atoms.add(src)
+                for tgt in atom_ids[1:]:
+                    all_targets.add(tgt)
+                    if tgt != src:
+                        non_self_targets.add(tgt)
 
-            if root_candidates:
-                # Use the first root candidate
-                root_atom_id = next(iter(root_candidates))
-            else:
-                # Fallback: use the last atom (usually the root in our walk order)
-                root_atom_id = atoms[-1]["id"]
+        root_candidates = source_atoms - all_targets
+        if root_candidates:
+            return next(iter(root_candidates))
 
-        return reify_atom(root_atom_id)
+        root_candidates = source_atoms - non_self_targets
+        if root_candidates:
+            return next(iter(root_candidates))
+
+        return atoms[-1]["id"]
 
     def _reify_primitive(self, atom_type: str, atom_label: str) -> Any:
         """Reconstruct a primitive value from its type and label."""
@@ -586,100 +693,139 @@ class CnDDataInstanceBuilder:
         else:
             raise ValueError(f"Unknown primitive type: {atom_type}")
 
-    def _reify_dict(self, atom_id: str, relations: Dict, reify_atom) -> dict:
-        """Reconstruct a dictionary from its relations."""
-        result = {}
-        for rel_name, target_ids in relations.items():
-            # Dictionary relations use the key name as the relation name
-            for target_id in target_ids:
-                key = rel_name
-                value = reify_atom(target_id)
+    def _reify_dict(
+        self, atom_id: str, relation_tuples: Dict, reify_atom, register
+    ) -> dict:
+        """Reconstruct a dictionary from its relations.
+
+        Expects ``relation_tuples`` (source-grouped, tuple-preserving) because
+        DictRelationalizer emits a ternary ``kv(dict, key, value)`` relation.
+        Registers the empty dict before recursing so self- or back-references
+        to this dict see the same object.
+        """
+        result: dict = {}
+        register(result)
+
+        kv_tuples = relation_tuples.get("kv", [])
+        for targets in kv_tuples:
+            if len(targets) < 2:
+                continue
+            key = reify_atom(targets[0])
+            value = reify_atom(targets[1])
+            try:
                 result[key] = value
+            except TypeError:
+                # Unhashable key (e.g. a mutable object that the build side
+                # allowed through a synthetic key atom). Fall back to string.
+                result[str(key)] = value
+
+        # Back-compat path: earlier versions emitted per-key binary relations
+        # where the relation name itself was the dict key. Handle any leftover
+        # relations of that shape so older data instances still reify.
+        for rel_name, tuples in relation_tuples.items():
+            if rel_name == "kv":
+                continue
+            for targets in tuples:
+                if not targets:
+                    continue
+                result[rel_name] = reify_atom(targets[0])
         return result
 
-    def _reify_list(self, atom_id: str, relations: Dict, reify_atom) -> list:
-        """Reconstruct a list from its relations."""
-        result = []
-        # List relations use numeric indices as relation names
-        indexed_items = []
-        for rel_name, target_ids in relations.items():
-            try:
-                index = int(rel_name)
-                for target_id in target_ids:
-                    value = reify_atom(target_id)
-                    indexed_items.append((index, value))
-            except ValueError:
-                # Skip non-numeric relation names
-                continue
+    def _reify_list(
+        self, atom_id: str, relation_tuples: Dict, reify_atom, register
+    ) -> list:
+        """Reconstruct a list from its relations.
 
-        # Sort by index and build the list
+        Expects ``relation_tuples`` (tuple-preserving) because ListRelationalizer
+        emits a ternary ``idx(list, index_atom, value_atom)``. Registers the
+        empty list before recursing so self-references resolve to the same
+        object, then populates in place.
+        """
+        result: list = []
+        register(result)
+
+        indexed_items = []
+        for targets in relation_tuples.get("idx", []):
+            if len(targets) < 2:
+                continue
+            index_value = reify_atom(targets[0])
+            try:
+                index = int(index_value)
+            except (TypeError, ValueError):
+                continue
+            indexed_items.append((index, reify_atom(targets[1])))
+
         indexed_items.sort(key=lambda x: x[0])
-        result = [item[1] for item in indexed_items]
+        # Populate in place so the already-registered list instance is the one
+        # filled — preserves identity for back-references that resolved mid-flight.
+        result.extend(item[1] for item in indexed_items)
         return result
 
     def _reify_tuple(self, atom_id: str, relations: Dict, reify_atom) -> tuple:
-        """Reconstruct a tuple from its relations."""
-        # Tuples are reconstructed like lists, then converted
-        list_result = self._reify_list(atom_id, relations, reify_atom)
-        return tuple(list_result)
+        """Reconstruct a tuple from its relations.
 
-    def _reify_set(self, atom_id: str, relations: Dict, reify_atom) -> set:
+        TupleRelationalizer emits one binary relation per index named
+        ``t0``, ``t1``, … Tuples are immutable so we cannot register a
+        placeholder; a genuinely self-referential tuple is not representable
+        in Python. Non-self shared references still resolve via memoization.
+        """
+        indexed_items = []
+        for rel_name, target_ids in relations.items():
+            if not rel_name.startswith("t"):
+                continue
+            try:
+                index = int(rel_name[1:])
+            except ValueError:
+                continue
+            for target_id in target_ids:
+                indexed_items.append((index, reify_atom(target_id)))
+        indexed_items.sort(key=lambda x: x[0])
+        return tuple(item[1] for item in indexed_items)
+
+    def _reify_set(
+        self, atom_id: str, relations: Dict, reify_atom, register
+    ) -> set:
         """Reconstruct a set from its relations."""
-        result = set()
-        # Sets use "contains" relation name for elements
+        result: set = set()
+        register(result)
         if "contains" in relations:
             for target_id in relations["contains"]:
-                value = reify_atom(target_id)
-                result.add(value)
+                result.add(reify_atom(target_id))
         return result
 
-    def _reify_generic_object(self, atom: Dict, relations: Dict, reify_atom) -> Any:
-        """
-        Reconstruct a generic object from its atom and relations.
+    def _reify_generic_object(
+        self, atom: Dict, relations: Dict, reify_atom, register
+    ) -> Any:
+        """Reconstruct a generic object from its atom and relations.
 
-        This handles objects with __dict__ or custom classes.
-        For complex reconstruction scenarios, this method can be extended
-        or overridden to provide custom reification logic.
+        Allocates the attribute-bag instance and registers it *before*
+        recursing into relations so self-loops and back-pointers resolve to
+        the same instance.
         """
         atom_type = atom["type"]
 
-        # Try to get the class from built-in types first
-        try:
-            # For simple types, try to create an empty instance
-            if atom_type in {"dict", "list", "tuple", "set"}:
-                # These should have been handled by specific methods above
-                raise ValueError(
-                    f"Type {atom_type} should be handled by specific method"
-                )
+        if atom_type in {"dict", "list", "tuple", "set"}:
+            raise ValueError(f"Type {atom_type} should be handled by specific method")
 
-            # For other types, create a simple namespace object
-            # This is a fallback that creates an object with attributes set from relations
-            class ReconstructedObject:
-                def __init__(self):
-                    pass
+        class ReconstructedObject:
+            def __init__(self):
+                pass
 
-                def __repr__(self):
-                    attrs = [f"{k}={v!r}" for k, v in self.__dict__.items()]
-                    return f"{atom_type}({', '.join(attrs)})"
+            def __repr__(self):
+                attrs = [f"{k}={v!r}" for k, v in self.__dict__.items()]
+                return f"{atom_type}({', '.join(attrs)})"
 
-            obj = ReconstructedObject()
-            obj.__class__.__name__ = atom_type
+        obj = ReconstructedObject()
+        obj.__class__.__name__ = atom_type
+        register(obj)
 
-            # Set attributes from relations
-            for rel_name, target_ids in relations.items():
-                if len(target_ids) == 1:
-                    # Single value relation
-                    value = reify_atom(target_ids[0])
-                    setattr(obj, rel_name, value)
-                else:
-                    # Multiple value relation - create a list
-                    values = [reify_atom(tid) for tid in target_ids]
-                    setattr(obj, rel_name, values)
+        for rel_name, target_ids in relations.items():
+            if len(target_ids) == 1:
+                setattr(obj, rel_name, reify_atom(target_ids[0]))
+            else:
+                setattr(obj, rel_name, [reify_atom(tid) for tid in target_ids])
 
-            return obj
-
-        except Exception as e:
-            raise ValueError(f"Cannot reconstruct object of type {atom_type}: {e}")
+        return obj
 
     def can_reify(self, data_instance: Dict) -> bool:
         """

--- a/test/test_reify.py
+++ b/test/test_reify.py
@@ -1,0 +1,283 @@
+"""Tests for CnDDataInstanceBuilder.reify — the inverse of build_instance.
+
+These cover the regression reported as sidprasad/spytial#90:
+
+* self-loops (``n.next = n``, ``lst.append(lst)``, ``d['self'] = d``)
+* bidirectional references (``a.next = b; b.next = a``)
+* longer cycles (``a -> b -> c -> a``)
+* rootId survives a build -> reify round-trip
+* rootId is honoured even when topology alone would pick a different atom
+"""
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+import pytest
+
+from spytial.provider_system import CnDDataInstanceBuilder
+from spytial.dataclass_builder import _make_dataclass_reifier
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_reifier_for(*dc_types):
+    r = CnDDataInstanceBuilder()
+    for t in dc_types:
+        r.register_reifier(t.__name__, _make_dataclass_reifier(t))
+    return r
+
+
+# ---------------------------------------------------------------------------
+# Happy path: acyclic reconstruction still works
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Point:
+    x: int
+    y: int
+
+
+@dataclass
+class Line:
+    start: Optional[Point] = None
+    end: Optional[Point] = None
+
+
+def test_reify_acyclic_dataclass():
+    line = Line(start=Point(1, 2), end=Point(3, 4))
+    di = CnDDataInstanceBuilder().build_instance(line)
+    out = _make_reifier_for(Line, Point).reify(di)
+    assert isinstance(out, Line)
+    assert out.start == Point(1, 2)
+    assert out.end == Point(3, 4)
+
+
+def test_reify_nested_list_and_dict():
+    data = {"nums": [1, 2, 3], "meta": {"k": "v"}}
+    di = CnDDataInstanceBuilder().build_instance(data)
+    out = CnDDataInstanceBuilder().reify(di)
+    assert out == data
+
+
+# ---------------------------------------------------------------------------
+# Self-loops
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Node:
+    val: int = 0
+    nxt: Optional["Node"] = None
+
+
+def test_reify_dataclass_self_loop():
+    n = Node(42)
+    n.nxt = n
+    di = CnDDataInstanceBuilder().build_instance(n)
+    out = _make_reifier_for(Node).reify(di)
+
+    assert isinstance(out, Node)
+    assert out.val == 42
+    assert out.nxt is out
+
+
+def test_reify_list_self_loop():
+    lst: list = [1, 2]
+    lst.append(lst)
+    di = CnDDataInstanceBuilder().build_instance(lst)
+    out = CnDDataInstanceBuilder().reify(di)
+
+    assert isinstance(out, list)
+    assert len(out) == 3
+    assert out[0] == 1
+    assert out[1] == 2
+    assert out[2] is out
+
+
+def test_reify_dict_self_loop():
+    d: dict = {"a": 1}
+    d["self"] = d
+    di = CnDDataInstanceBuilder().build_instance(d)
+    out = CnDDataInstanceBuilder().reify(di)
+
+    assert isinstance(out, dict)
+    assert out["a"] == 1
+    assert out["self"] is out
+
+
+# ---------------------------------------------------------------------------
+# Multi-node cycles
+# ---------------------------------------------------------------------------
+
+
+def test_reify_bidirectional_cycle():
+    a = Node(1)
+    b = Node(2)
+    a.nxt = b
+    b.nxt = a
+    di = CnDDataInstanceBuilder().build_instance(a)
+    out = _make_reifier_for(Node).reify(di)
+
+    assert isinstance(out, Node)
+    assert out.val == 1
+    assert out.nxt is not None
+    assert out.nxt.val == 2
+    # The cycle must close back onto the original root.
+    assert out.nxt.nxt is out
+
+
+@dataclass
+class Triple:
+    label: str = ""
+    nxt: Optional["Triple"] = None
+
+
+def test_reify_three_cycle():
+    a = Triple("a")
+    b = Triple("b")
+    c = Triple("c")
+    a.nxt = b
+    b.nxt = c
+    c.nxt = a
+    di = CnDDataInstanceBuilder().build_instance(a)
+    out = _make_reifier_for(Triple).reify(di)
+
+    assert out.label == "a"
+    assert out.nxt.label == "b"
+    assert out.nxt.nxt.label == "c"
+    assert out.nxt.nxt.nxt is out
+
+
+# ---------------------------------------------------------------------------
+# Generic (non-dataclass) object with self-loop
+# ---------------------------------------------------------------------------
+
+
+class Bag:
+    pass
+
+
+def test_reify_generic_object_self_loop():
+    b = Bag()
+    b.self_ref = b
+    b.tag = "hello"
+    di = CnDDataInstanceBuilder().build_instance(b)
+    out = CnDDataInstanceBuilder().reify(di)
+
+    # _reify_generic_object produces an attribute-bag, not the original class,
+    # but the self-reference should still resolve to the same object.
+    assert getattr(out, "self_ref") is out
+    assert getattr(out, "tag") == "hello"
+
+
+# ---------------------------------------------------------------------------
+# rootId handling
+# ---------------------------------------------------------------------------
+
+
+def test_build_instance_emits_root_id():
+    n = Node(7)
+    di = CnDDataInstanceBuilder().build_instance(n)
+    assert "rootId" in di
+    root_atom = next(a for a in di["atoms"] if a["id"] == di["rootId"])
+    assert root_atom["type"] == "Node"
+
+
+def test_reify_uses_stored_root_id_for_self_loop():
+    """Without a cached root, topology can't pick the right atom in a self-loop."""
+    n = Node(99)
+    n.nxt = n
+    di = CnDDataInstanceBuilder().build_instance(n)
+    # Sanity: root is the Node atom.
+    assert di["rootId"].startswith("n")
+    out = _make_reifier_for(Node).reify(di)
+    assert isinstance(out, Node) and out.val == 99
+
+
+def test_reify_explicit_root_id_overrides_stored():
+    # Graph with two disconnected components: a Node and a standalone int.
+    # The stored rootId is the Node; we force reify to start from the int.
+    n = Node(5)
+    di = CnDDataInstanceBuilder().build_instance(n)
+    # Feed the reifier an explicit root_id that is a different atom.
+    int_atom_id = next(
+        a["id"] for a in di["atoms"] if a["type"] == "int"
+    )
+    out = _make_reifier_for(Node).reify(di, root_id=int_atom_id)
+    assert out == 5
+
+
+def test_reify_falls_back_when_stored_root_is_missing():
+    n = Node(3)
+    di = CnDDataInstanceBuilder().build_instance(n)
+    di["rootId"] = "does-not-exist"
+    # Topology fallback still recovers the Node.
+    out = _make_reifier_for(Node).reify(di)
+    assert isinstance(out, Node) and out.val == 3
+
+
+def test_reify_survives_stripped_root_id():
+    """Simulates the widget round-trip where spytial-core drops rootId."""
+    n = Node(11)
+    n.nxt = n
+    di = CnDDataInstanceBuilder().build_instance(n)
+    cached_root = di.pop("rootId")
+    # Without rootId in the dict, passing it explicitly still works.
+    out = _make_reifier_for(Node).reify(di, root_id=cached_root)
+    assert isinstance(out, Node)
+    assert out.val == 11
+    assert out.nxt is out
+
+
+# ---------------------------------------------------------------------------
+# Dataclass reifier details
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class WithDefaults:
+    a: int = 1
+    b: int = 2
+    tags: List[str] = field(default_factory=list)
+
+
+def test_dataclass_reifier_fills_defaults_for_missing_fields():
+    # Build an instance that only sets `a`; drop the relations for `b` and `tags`
+    # to mimic a data instance that the frontend stripped fields from.
+    inst = WithDefaults(a=7, b=9, tags=["x"])
+    di = CnDDataInstanceBuilder().build_instance(inst)
+    di["relations"] = [r for r in di["relations"] if r["name"] == "a"]
+
+    out = _make_reifier_for(WithDefaults).reify(di)
+    assert isinstance(out, WithDefaults)
+    assert out.a == 7
+    assert out.b == 2           # default
+    assert out.tags == []        # default_factory
+
+
+def test_dataclass_reifier_backcompat_3arg_signature():
+    """Reifiers registered with the old (atom, relations, reify_atom) signature
+    must keep working for acyclic data — we only fall back to the cycle-safe
+    path if they opt in.
+    """
+
+    @dataclass
+    class Simple:
+        x: int = 0
+
+    def old_style_reifier(atom, relations, reify_atom):
+        kwargs = {}
+        for name, targets in relations.items():
+            kwargs[name] = reify_atom(targets[0])
+        return Simple(**kwargs)
+
+    r = CnDDataInstanceBuilder()
+    r.register_reifier("Simple", old_style_reifier)
+
+    di = CnDDataInstanceBuilder().build_instance(Simple(x=42))
+    out = r.reify(di)
+    assert out == Simple(x=42)


### PR DESCRIPTION
Fixes #90.

## Summary
- Reify now handles self-loops, bidirectional references, and longer cycles by registering each mutable container in the memo table **before** recursing into its children.
- `build_instance` emits a top-level `rootId` so reify can pick the right root even when topology alone can't (in a cycle, every source is also a target). `reify()` also accepts an explicit `root_id` override, which `DataClassBuilder.value` now passes through so the widget path survives spytial-core stripping extra keys on round-trip.
- Fixed a separate preexisting bug: `_reify_dict` and `_reify_list` misread their ternary relations (`kv(dict, key, value)` / `idx(list, index, value)`) as per-key/per-index binary relations, producing garbled output for any non-trivial dict or list. Tuples now also parse their `tN`-style binary relation names.
- `_make_dataclass_reifier` allocates via `object.__new__` and populates fields with `object.__setattr__`, which both works for frozen dataclasses and makes cyclic reconstruction possible. Missing fields fall back to their declared default / `default_factory`. `__post_init__` is intentionally not invoked — matches pickle and is the only safe option when the instance is half-built.
- Custom reifiers registered via `register_reifier` keep the existing 3-arg signature `(atom, relations, reify_atom)`. A 4th optional `register` parameter opts in to the cycle-safe path; the dispatcher detects it via `inspect.signature`.

## Test plan
- [x] `pytest test/` — 93 passed, 1 skipped (78 prior + 15 new in `test/test_reify.py`)
- [x] New tests cover: acyclic dataclass, nested list+dict, self-loop (dataclass, list, dict, generic object), bidirectional A↔B, 3-cycle A→B→C→A, `rootId` emitted by build, stored `rootId` honoured for self-loop, explicit `root_id` override, fallback when stored `rootId` is stale, round-trip where `rootId` is stripped, default/default_factory filling, 3-arg reifier backcompat.
- [x] Simulated DataClassBuilder widget round-trip (build → strip `rootId` → reify with cached id) confirmed for acyclic, bidirectional, and self-loop dataclasses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)