### PR TITLE
Add step labels and notes to spytial.sequence()

### DIFF
--- a/demos/balancing.ipynb
+++ b/demos/balancing.ipynb
@@ -150,7 +150,7 @@
     "\n",
     "    def _snap(self, label: str = \"\"):\n",
     "        \"\"\"Record the current tree state as the next sequence frame.\"\"\"\n",
-    "        self._seq.record(self.root)\n",
+    "        self._seq.record(self.root, label=label)\n",
     "\n",
     "    # ── Read-only helpers ──────────────────────────────────────────────────────\n",
     "\n",

--- a/docs/usage/sequences.md
+++ b/docs/usage/sequences.md
@@ -19,6 +19,44 @@ seq.diagram()
 
 `sequence()` returns a `SequenceRecorder`. Each `.record(obj)` call captures the current state of `obj` as the next frame. `.diagram()` renders all frames into an interactive viewer with Previous / Next navigation.
 
+## Labelling steps
+
+`record()` accepts two optional keyword arguments that give frames semantic meaning in the viewer:
+
+- `label` — a short one-liner shown in the status bar (`Step 3 / 24 — rotate left at node 5`) and as the scrubber tooltip. Whitespace is stripped; truncated to 200 characters.
+- `note` — a longer description (multi-line OK) shown in a collapsible panel below the controls. Hidden on frames where no note was recorded.
+
+```python
+with spytial.sequence() as seq:
+    seq.record(tree, label="initial state")
+    rotate_left(tree, node)
+    seq.record(tree, label="left-rotate at root",
+               note="Promotes the right child so the new tree is height-balanced.")
+    seq.record(tree)  # no label / no note — viewer falls back to "Step 3 / 3"
+seq.diagram()
+```
+
+Both arguments are optional and independent — a frame can have a label, a note, both, or neither. The zero-kwarg form (`seq.record(obj)`) keeps working unchanged.
+
+This is the recommended way to narrate algorithms. A typical pattern is to wrap `record()` in a helper that takes the label as its first argument:
+
+```python
+class RBTree:
+    def __init__(self, seq):
+        self._seq = seq
+        self.root = NIL
+
+    def _snap(self, label):
+        self._seq.record(self.root, label=label)
+
+    def insert(self, key):
+        ...
+        self._snap(f"BST insert: {key} (color=RED)")
+        self._insert_fixup(z)
+```
+
+See [`demos/balancing.ipynb`](../../demos/balancing.ipynb) for a full Red-Black tree example with labelled fixup cases.
+
 ## Sequence policies
 
 The `sequence_policy` controls how the frontend positions atoms across frames:

--- a/spytial/_version.py
+++ b/spytial/_version.py
@@ -1,3 +1,3 @@
 """Package version source of truth."""
 
-__version__ = "1.2.1"
+__version__ = "1.2.2"

--- a/spytial/sequence_visualizer_template.html
+++ b/spytial/sequence_visualizer_template.html
@@ -165,6 +165,43 @@
             display: none;
         }
 
+        .note-panel {
+            background: #f1f5f9;
+            border: 1px solid #e2e8f0;
+            border-radius: 6px;
+            padding: 8px 12px;
+            margin: 8px 16px 0 16px;
+            font-size: 13px;
+            line-height: 1.5;
+            color: #334155;
+        }
+
+        .note-panel[hidden] {
+            display: none;
+        }
+
+        .note-panel summary {
+            cursor: pointer;
+            font-weight: 500;
+            color: #475569;
+            user-select: none;
+        }
+
+        .note-panel #note-body {
+            margin-top: 6px;
+            white-space: pre-wrap;
+        }
+
+        .sequence-label {
+            font-weight: 500;
+            color: #1f2937;
+        }
+
+        .sequence-label-sep {
+            color: #9ca3af;
+            margin: 0 6px;
+        }
+
         #error-message {
             margin: 12px 16px 0 16px;
         }
@@ -207,6 +244,11 @@
             </div>
         </div>
 
+        <details id="note-panel" class="note-panel" hidden>
+            <summary>Note</summary>
+            <div id="note-body"></div>
+        </details>
+
         <div class="graph-wrapper">
             <span id="loading-indicator">Loading step...</span>
             <webcola-cnd-graph id="graph-container" width="{{ width }}" height="{{ height }}" layoutFormat="default"
@@ -221,6 +263,8 @@
     <script>
         const cndSpec = `{{ cnd_spec | safe }}`;
         const sequenceData = {{ sequence_data | safe }};
+        const frameLabels = {{ frame_labels | safe }};
+        const frameNotes = {{ frame_notes | safe }};
         const sequencePolicyName = `{{ sequence_policy }}`;
 
         let graphElement = null;
@@ -325,6 +369,29 @@
             }
         }
 
+        function getFrameLabel(index) {
+            return Array.isArray(frameLabels) ? frameLabels[index] : null;
+        }
+
+        function getFrameNote(index) {
+            return Array.isArray(frameNotes) ? frameNotes[index] : null;
+        }
+
+        function updateNotePanel(index) {
+            const panel = document.getElementById("note-panel");
+            const body = document.getElementById("note-body");
+            if (!panel || !body) return;
+            const note = getFrameNote(index);
+            if (note) {
+                body.textContent = note;
+                panel.hidden = false;
+            } else {
+                body.textContent = "";
+                panel.hidden = true;
+                panel.open = false;
+            }
+        }
+
         function updateNavigation() {
             const prevButton = document.getElementById("prev-step");
             const nextButton = document.getElementById("next-step");
@@ -332,13 +399,34 @@
             const status = document.getElementById("step-status");
             const totalSteps = sequenceData.length;
             const displayIndex = currentIndex === null ? 0 : currentIndex;
+            const label = getFrameLabel(displayIndex);
 
-            status.textContent = `Step ${displayIndex + 1} / ${totalSteps}`;
+            const baseStatus = `Step ${displayIndex + 1} / ${totalSteps}`;
+            if (label) {
+                status.textContent = "";
+                status.appendChild(document.createTextNode(baseStatus));
+                const sep = document.createElement("span");
+                sep.className = "sequence-label-sep";
+                sep.textContent = "—";
+                status.appendChild(sep);
+                const labelSpan = document.createElement("span");
+                labelSpan.className = "sequence-label";
+                labelSpan.textContent = label;
+                status.appendChild(labelSpan);
+            } else {
+                status.textContent = baseStatus;
+            }
+
             prevButton.disabled = isRendering || displayIndex <= 0;
             nextButton.disabled = isRendering || displayIndex >= totalSteps - 1;
             scrubber.max = String(totalSteps - 1);
             scrubber.value = String(displayIndex);
             scrubber.disabled = isRendering;
+            scrubber.title = label
+                ? `${displayIndex + 1}/${totalSteps}: ${label}`
+                : `Step ${displayIndex + 1}`;
+
+            updateNotePanel(displayIndex);
         }
 
         function resolveSequencePolicy(core) {

--- a/spytial/visualizer.py
+++ b/spytial/visualizer.py
@@ -46,6 +46,39 @@ def _normalize_as_type(as_type: Optional[Any]) -> Optional[Any]:
     return as_type
 
 
+_LABEL_MAX_LEN = 200
+
+
+def _safe_json_for_script(value: Any) -> str:
+    """JSON-encode a value safely for embedding inside a <script> block.
+
+    `json.dumps` does not escape ``</``, so a string containing ``</script>``
+    would close the tag and allow markup injection. Escaping ``/`` after ``<``
+    is the standard mitigation; the result is still valid JSON.
+    """
+    return json.dumps(value).replace("</", "<\\/")
+
+
+def _normalize_label(label: Optional[str]) -> Optional[str]:
+    """Coerce, strip, and truncate a frame label; empty becomes None."""
+    if label is None:
+        return None
+    text = str(label).strip()
+    if not text:
+        return None
+    if len(text) > _LABEL_MAX_LEN:
+        text = text[:_LABEL_MAX_LEN]
+    return text
+
+
+def _normalize_note(note: Optional[str]) -> Optional[str]:
+    """Coerce and strip a frame note; empty becomes None. No length cap."""
+    if note is None:
+        return None
+    text = str(note).strip()
+    return text or None
+
+
 def _merge_decorator_registries(*registries: Dict[str, Any]) -> Dict[str, Any]:
     """Merge multiple decorator registries while preserving stable order."""
     from .annotations import _deduplicate_entries
@@ -302,6 +335,8 @@ class SequenceRecorder:
             identity_resolver=identity,
         )
         self._data_instances = []
+        self._frame_labels: list = []
+        self._frame_notes: list = []
         self._merged_decorators = {"constraints": [], "directives": []}
 
     def __enter__(self):
@@ -310,10 +345,27 @@ class SequenceRecorder:
     def __exit__(self, exc_type, exc_val, exc_tb):
         return False  # never suppress exceptions
 
-    def record(self, obj: Any) -> None:
-        """Capture a snapshot of *obj* as the next frame in the sequence."""
+    def record(
+        self,
+        obj: Any,
+        label: Optional[str] = None,
+        note: Optional[str] = None,
+    ) -> None:
+        """Capture a snapshot of *obj* as the next frame in the sequence.
+
+        Args:
+            obj: The object to snapshot.
+            label: Optional short label describing this step (e.g. "rotate left").
+                Shown in the status bar and as a scrubber tooltip. Whitespace is
+                stripped; empty results are treated as no label. Truncated to 200
+                characters because the header is one line.
+            note: Optional longer description, shown in a collapsible panel.
+                Multi-line text is fine; whitespace is stripped.
+        """
         instance = self._builder.build_instance(obj, as_type=self._as_type)
         self._data_instances.append(instance)
+        self._frame_labels.append(_normalize_label(label))
+        self._frame_notes.append(_normalize_note(note))
         self._merged_decorators = _merge_decorator_registries(
             self._merged_decorators,
             self._builder.get_collected_decorators(),
@@ -363,6 +415,8 @@ class SequenceRecorder:
         spytial_spec = serialize_to_yaml_string(self._merged_decorators)
         html_content = _generate_sequence_visualizer_html(
             data_instances=self._data_instances,
+            frame_labels=self._frame_labels,
+            frame_notes=self._frame_notes,
             spytial_spec=spytial_spec,
             sequence_policy=_policy,
             width=_width,
@@ -591,6 +645,8 @@ def _generate_sequence_visualizer_html(
     width=800,
     height=600,
     title=None,
+    frame_labels=None,
+    frame_notes=None,
 ):
     """Generate HTML content for a sequence visualizer using Jinja2 templating."""
     if not HAS_JINJA2:
@@ -608,8 +664,15 @@ def _generate_sequence_visualizer_html(
             f"sequence_visualizer_template.html not found in {current_dir}: {e}"
         )
 
+    if frame_labels is None:
+        frame_labels = [None] * len(data_instances)
+    if frame_notes is None:
+        frame_notes = [None] * len(data_instances)
+
     html_content = template.render(
         sequence_data=json.dumps(data_instances),
+        frame_labels=_safe_json_for_script(frame_labels),
+        frame_notes=_safe_json_for_script(frame_notes),
         cnd_spec=spytial_spec,
         sequence_policy=sequence_policy,
         title=title,

--- a/test/test_sequence_visualizer.py
+++ b/test/test_sequence_visualizer.py
@@ -207,3 +207,63 @@ def test_sequence_recorder_policy_can_be_overridden_at_diagram(tmp_path, monkeyp
     result = seq.diagram(sequence_policy="change_emphasis")
     html = Path(result).read_text(encoding="utf-8")
     assert "const sequencePolicyName = `change_emphasis`" in html
+
+
+def test_sequence_recorder_accepts_label_and_embeds_in_html(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    seq = sequence(method="file", auto_open=False)
+    seq.record({"value": 1}, label="rotate left at node 5")
+    seq.record({"value": 2}, label="recolor uncle")
+    html = Path(seq.diagram()).read_text(encoding="utf-8")
+    assert "rotate left at node 5" in html
+    assert "recolor uncle" in html
+    assert "const frameLabels = " in html
+
+
+def test_sequence_recorder_accepts_note_and_embeds_in_html(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    seq = sequence(method="file", auto_open=False)
+    seq.record({"v": 1}, note="This step rebalances the left subtree.")
+    html = Path(seq.diagram()).read_text(encoding="utf-8")
+    assert "rebalances the left subtree" in html
+    assert "const frameNotes = " in html
+
+
+def test_sequence_recorder_label_and_note_are_independent(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    seq = sequence(method="file", auto_open=False)
+    seq.record({"v": 1}, label="step one")
+    seq.record({"v": 2}, note="just a note")
+    seq.record({"v": 3})
+    html = Path(seq.diagram()).read_text(encoding="utf-8")
+    assert "step one" in html
+    assert "just a note" in html
+    assert seq._frame_labels == ["step one", None, None]
+    assert seq._frame_notes == [None, "just a note", None]
+
+
+def test_sequence_recorder_label_too_long_is_truncated():
+    seq = sequence(method="file", auto_open=False)
+    long = "x" * 500
+    seq.record({"v": 1}, label=long)
+    assert seq._frame_labels[0] is not None
+    assert len(seq._frame_labels[0]) == 200
+
+
+def test_sequence_recorder_empty_label_normalized_to_none():
+    seq = sequence(method="file", auto_open=False)
+    seq.record({"v": 1}, label="   ")
+    seq.record({"v": 2}, note="\n\t  ")
+    assert seq._frame_labels[0] is None
+    assert seq._frame_notes[1] is None
+
+
+def test_sequence_recorder_label_special_chars_safely_escaped(tmp_path, monkeypatch):
+    """Labels go through json.dumps so backticks, quotes, and </script> can't
+    break out of the embedded JS array."""
+    monkeypatch.chdir(tmp_path)
+    seq = sequence(method="file", auto_open=False)
+    seq.record({"v": 1}, label='backtick `inj` "quote" </script>')
+    html = Path(seq.diagram()).read_text(encoding="utf-8")
+    label_block = html.split("const frameLabels = ")[1].split(";")[0]
+    assert "</script>" not in label_block


### PR DESCRIPTION
## Summary
- `SequenceRecorder.record()` now accepts optional `label` (short, header-bar) and `note` (longer, collapsible panel) kwargs. Both are optional; `record(obj)` keeps working unchanged, falling back to today's anonymous `Step X / Y` display.
- Status bar reads `Step 3 / 24 — <label>` when a label is present, plus a native scrubber tooltip; a `<details>` note panel appears only on frames with notes.
- `demos/balancing.ipynb` already passed a label string into a `_snap()` wrapper that silently discarded it. The wrapper now plumbs it through, so re-running the notebook shows real CLRS step descriptions on every frame.
- Bumps patch version to `1.2.2` and updates [`docs/usage/sequences.md`](docs/usage/sequences.md) with a "Labelling steps" section.

### Robustness fix bundled in
Labels/notes are embedded via a JSON encoder that escapes `</` to `<\/` so a label containing `</script>` cannot break out of the embedded `<script>` block. Caught by a new XSS-shaped test (`test_sequence_recorder_label_special_chars_safely_escaped`).

### What's deferred
Other improvements considered (play/pause, jump-to-step, diagnostic banner for duplicate atom IDs, diff visualization) were intentionally left for follow-up PRs to keep this one focused.

## Test plan
- [x] `pytest test/test_sequence_visualizer.py -v` — 23/23 pass (6 new tests)
- [x] `pytest -q` — full suite, 100 passed, 1 pre-existing skip
- [ ] Run `demos/balancing.ipynb` end-to-end and confirm RB-tree step labels (`Insert fixup Case 1: recolor (uncle RED)`, etc.) appear in the rendered viewer
- [ ] Manual smoke: `spytial.sequence()` viewer shows `Step X / Y — <label>`, scrubber tooltip, and note panel; frames without label/note fall back cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)