### PR TITLE
Add runtime policy selector to the sequence viewer

### DIFF
--- a/docs/usage/sequences.md
+++ b/docs/usage/sequences.md
@@ -68,6 +68,8 @@ The `sequence_policy` controls how the frontend positions atoms across frames:
 | `ignore_history` | Each frame is laid out independently |
 | `random_positioning` | Random placement each frame |
 
+The `sequence_policy=` argument sets the **initial** policy, but viewers can switch on the fly using a dropdown in the header — useful for comparing how each policy presents the same algorithm. Switching mid-sequence re-applies the previous → current transition with the new policy; on step 0 (which has no transition) the change takes effect on the next navigation.
+
 ## In-place mutation (most common)
 
 When the **same Python objects** are mutated between frames, atom IDs are stable automatically — no configuration needed. The recorder uses a single shared builder whose persistent ID table survives across `.record()` calls.

--- a/spytial/_version.py
+++ b/spytial/_version.py
@@ -1,3 +1,3 @@
 """Package version source of truth."""
 
-__version__ = "1.2.2"
+__version__ = "1.2.3"

--- a/spytial/sequence_visualizer_template.html
+++ b/spytial/sequence_visualizer_template.html
@@ -57,6 +57,21 @@
             color: #4b5563;
         }
 
+        .sequence-policy-select {
+            border: 1px solid #cbd5e1;
+            border-radius: 6px;
+            padding: 4px 6px;
+            font-size: 12px;
+            background: #ffffff;
+            color: #1f2937;
+            cursor: pointer;
+        }
+
+        .sequence-policy-select:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+        }
+
         .sequence-controls {
             display: flex;
             align-items: center;
@@ -233,7 +248,13 @@
         <div class="sequence-header">
             <div class="sequence-status">
                 <span class="sequence-title" id="step-status">Step 1 of 1</span>
-                <span class="sequence-policy" id="policy-status"></span>
+                <label class="sequence-policy" for="policy-select">Policy:</label>
+                <select id="policy-select" class="sequence-policy-select" aria-label="Sequence policy">
+                    <option value="stability">Stability</option>
+                    <option value="change_emphasis">Change emphasis</option>
+                    <option value="ignore_history">Ignore history</option>
+                    <option value="random_positioning">Random positioning</option>
+                </select>
             </div>
             <div class="sequence-controls">
                 <button type="button" class="sequence-button" id="prev-step" title="Previous (←)">◀</button>
@@ -265,7 +286,7 @@
         const sequenceData = {{ sequence_data | safe }};
         const frameLabels = {{ frame_labels | safe }};
         const frameNotes = {{ frame_notes | safe }};
-        const sequencePolicyName = `{{ sequence_policy }}`;
+        let sequencePolicyName = `{{ sequence_policy }}`;
 
         let graphElement = null;
         let currentIndex = null;
@@ -426,7 +447,27 @@
                 ? `${displayIndex + 1}/${totalSteps}: ${label}`
                 : `Step ${displayIndex + 1}`;
 
+            const policySelect = document.getElementById("policy-select");
+            if (policySelect) {
+                policySelect.disabled = isRendering;
+            }
+
             updateNotePanel(displayIndex);
+        }
+
+        async function onPolicyChange(newPolicy) {
+            if (newPolicy === sequencePolicyName) return;
+            sequencePolicyName = newPolicy;
+
+            // Step 0 has no transition to animate, so the policy has no
+            // visible effect until the user navigates.
+            if (currentIndex === null || currentIndex === 0 || isRendering) return;
+
+            // Re-apply the (N-1) → N transition with the new policy by
+            // rewinding currentIndex one step and re-rendering the same target.
+            const target = currentIndex;
+            currentIndex = target - 1;
+            await renderStep(target);
         }
 
         function resolveSequencePolicy(core) {
@@ -597,6 +638,13 @@
                 }
             });
 
+            const policySelect = document.getElementById("policy-select");
+            if (policySelect) {
+                policySelect.addEventListener("change", function () {
+                    onPolicyChange(this.value);
+                });
+            }
+
             window.addEventListener("keydown", function (event) {
                 if (event.key === "ArrowLeft") {
                     navigate(-1);
@@ -613,8 +661,10 @@
             }
 
             graphElement = document.getElementById("graph-container");
-            document.getElementById("policy-status").textContent =
-                `Policy: ${prettyPolicyName(sequencePolicyName)}`;
+            const policySelect = document.getElementById("policy-select");
+            if (policySelect && [...policySelect.options].some(o => o.value === sequencePolicyName)) {
+                policySelect.value = sequencePolicyName;
+            }
 
             // Mount the spytial-core error modal (displays constraint/layout warnings)
             if (window.mountErrorMessageModal) {

--- a/test/test_sequence_visualizer.py
+++ b/test/test_sequence_visualizer.py
@@ -148,7 +148,7 @@ def test_sequence_recorder_writes_navigation_html(tmp_path, monkeypatch):
     assert result.endswith("spytial_sequence_visualization.html")
     assert 'id="prev-step"' in html
     assert 'id="next-step"' in html
-    assert "const sequencePolicyName = `stability`;" in html
+    assert "let sequencePolicyName = `stability`;" in html
     assert "prevInstance" in html
     assert "currInstance" in html
 
@@ -184,7 +184,7 @@ def test_sequence_recorder_accepts_all_valid_policies(tmp_path, monkeypatch, pol
     seq.record({"v": 1})
     result = seq.diagram()
     html = Path(result).read_text(encoding="utf-8")
-    assert f"const sequencePolicyName = `{policy}`" in html
+    assert f"let sequencePolicyName = `{policy}`" in html
 
 
 def test_sequence_recorder_rejects_invalid_policy_at_construction():
@@ -206,7 +206,27 @@ def test_sequence_recorder_policy_can_be_overridden_at_diagram(tmp_path, monkeyp
     seq.record({"v": 1})
     result = seq.diagram(sequence_policy="change_emphasis")
     html = Path(result).read_text(encoding="utf-8")
-    assert "const sequencePolicyName = `change_emphasis`" in html
+    assert "let sequencePolicyName = `change_emphasis`" in html
+
+
+def test_sequence_recorder_renders_policy_select_in_html(tmp_path, monkeypatch):
+    """The viewer header includes a <select> dropdown listing all four policies."""
+    monkeypatch.chdir(tmp_path)
+    seq = sequence(method="file", auto_open=False)
+    seq.record({"v": 1})
+    html = Path(seq.diagram()).read_text(encoding="utf-8")
+    assert 'id="policy-select"' in html
+    for policy in SEQUENCE_POLICY_NAMES:
+        assert f'value="{policy}"' in html
+
+
+def test_sequence_recorder_initial_policy_matches_python_arg(tmp_path, monkeypatch):
+    """The Python-supplied sequence_policy is the initial value of the dropdown."""
+    monkeypatch.chdir(tmp_path)
+    seq = sequence(sequence_policy="change_emphasis", method="file", auto_open=False)
+    seq.record({"v": 1})
+    html = Path(seq.diagram()).read_text(encoding="utf-8")
+    assert "let sequencePolicyName = `change_emphasis`;" in html
 
 
 def test_sequence_recorder_accepts_label_and_embeds_in_html(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- The viewer header now includes a `<select id="policy-select">` dropdown listing all four sequence policies (Stability, Change emphasis, Ignore history, Random positioning).
- The Python `sequence_policy=` argument becomes the **initial** selection. Viewers can switch on the fly to compare how each policy presents the same algorithm.
- Switching mid-sequence rewinds `currentIndex` by one and re-renders the same target step, so the previous → current transition replays under the new policy. On step 0 (no transition to apply) the change takes effect on the next navigation.
- Bumps patch version to `1.2.3`.

### Why the step cache stays valid
`getStepData()` caches `{ dataInstance, layout, error }`. The `layout` is computed by `LayoutInstance.generateLayout(dataInstance)` *before* any policy is consulted — policy only enters via `resolveSequencePolicy(core)` in `renderStep`, which reads the global `sequencePolicyName` fresh on every call. Flipping policy + re-rendering produces correct results without flushing the cache.

### Out of scope (deferred)
- Locking / hiding the dropdown (e.g. `policy_locked=True` on `sequence()`)
- Persisting choice across reloads (localStorage)

## Test plan
- [x] `pytest test/test_sequence_visualizer.py -v` — 25/25 pass (2 new tests + 2 existing tests updated for `let` → `const` mutation change)
- [x] `pytest -q` — full suite, 102 passed, 1 pre-existing skip
- [ ] Manual: render a multi-step `spytial.sequence()` viewer; switch policy mid-sequence; confirm the current frame re-animates with the new policy and `currentIndex` is preserved
- [ ] Manual: confirm the dropdown disables briefly during render (matches prev/next/scrubber)

🤖 Generated with [Claude Code](https://claude.com/claude-code)