### PR TITLE
Update spytial-core to 2.5.0 + add bump script (v1.2.4)

### DIFF
--- a/spytial/_version.py
+++ b/spytial/_version.py
@@ -1,3 +1,3 @@
 """Package version source of truth."""
 
-__version__ = "1.2.3"
+__version__ = "1.2.4"

--- a/spytial/core_assets.py
+++ b/spytial/core_assets.py
@@ -1,6 +1,6 @@
 """Shared spytial-core browser asset definitions for HTML templates."""
 
-SPYTIAL_CORE_VERSION = "2.3.0"
+SPYTIAL_CORE_VERSION = "2.5.0"
 
 _CDN_BASE = f"https://cdn.jsdelivr.net/npm/spytial-core@{SPYTIAL_CORE_VERSION}"
 

--- a/test/test_data_instance_format.py
+++ b/test/test_data_instance_format.py
@@ -1,5 +1,5 @@
 """
-Tests that build_instance() output matches the spytial-core v2.3.0 IJsonDataInstance format.
+Tests that build_instance() output matches the spytial-core v2.5.0 IJsonDataInstance format.
 
 See spytial-core/docs/JSON_DATA_INSTANCE.md for the canonical spec.
 """

--- a/update-spytial-core.sh
+++ b/update-spytial-core.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Bump the bundled spytial-core version to the latest npm release.
+#
+# Reads the latest version from the npm registry, compares it against the
+# pinned version in spytial/core_assets.py, and rewrites the version in
+# both core_assets.py and the test docstring that references it.
+#
+# Usage:  ./update-spytial-core.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CORE_ASSETS="$REPO_ROOT/spytial/core_assets.py"
+TEST_DOCSTRING="$REPO_ROOT/test/test_data_instance_format.py"
+
+for f in "$CORE_ASSETS" "$TEST_DOCSTRING"; do
+    [[ -f "$f" ]] || { echo "missing: $f" >&2; exit 1; }
+done
+
+CURRENT="$(python3 -c "import re; print(re.search(r'SPYTIAL_CORE_VERSION = \"([^\"]+)\"', open('$CORE_ASSETS').read()).group(1))")"
+LATEST="$(curl -fsSL https://registry.npmjs.org/spytial-core/latest \
+    | python3 -c 'import json,sys; print(json.load(sys.stdin)["version"])')"
+
+echo "current: $CURRENT"
+echo "latest:  $LATEST"
+
+if [[ "$CURRENT" == "$LATEST" ]]; then
+    echo "Already up to date."
+    exit 0
+fi
+
+python3 - "$CORE_ASSETS" "$TEST_DOCSTRING" "$CURRENT" "$LATEST" <<'PY'
+import pathlib, sys
+core, test, cur, new = sys.argv[1:5]
+core_p = pathlib.Path(core)
+core_p.write_text(core_p.read_text().replace(
+    f'SPYTIAL_CORE_VERSION = "{cur}"',
+    f'SPYTIAL_CORE_VERSION = "{new}"',
+))
+test_p = pathlib.Path(test)
+test_p.write_text(test_p.read_text().replace(
+    f"spytial-core v{cur} IJsonDataInstance",
+    f"spytial-core v{new} IJsonDataInstance",
+))
+PY
+
+echo "Bumped spytial-core $CURRENT -> $LATEST"
+echo "Run 'pytest' to verify."


### PR DESCRIPTION
## Summary
- Bump bundled spytial-core CDN version from `2.3.0` → `2.5.0` (latest npm release). The IJsonDataInstance schema and bundle entry points are unchanged; the diff is rendering polish (palette, typography, edge routing, label placement, auto-sized nodes) plus the new `SpytialExplorer` overlay.
- Add `update-spytial-core.sh` at the repo root: queries `https://registry.npmjs.org/spytial-core/latest` and rewrites the version constant in `spytial/core_assets.py` and the matching docstring in `test/test_data_instance_format.py`. Idempotent — exits early when already up to date.
- Bump package patch version `1.2.3` → `1.2.4` in `spytial/_version.py`.

## Test plan
- [x] `pytest` — 102 passed, 1 skipped
- [x] `python -c "import spytial; print(spytial.get_spytial_core_version())"` prints `2.5.0`
- [x] `./update-spytial-core.sh` runs cleanly and reports "Already up to date" against the just-updated version
- [ ] Smoke test: render a visualization in a notebook and confirm the 2.5.0 bundle loads from jsDelivr without console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)