### PR TITLE
Fix publish workflow version regex

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Read version and check PyPI
         id: v
         run: |
-          version=$(python -c "import re; print(re.search(r'\"([^\"]+)\"', open('spytial/_version.py').read()).group(1))")
+          version=$(python -c "import re; print(re.search(r'__version__\s*=\s*\"([^\"]+)\"', open('spytial/_version.py').read()).group(1))")
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "Detected version: $version"
           status=$(curl -s -o /dev/null -w '%{http_code}' "https://pypi.org/pypi/spytial-diagramming/$version/json")


### PR DESCRIPTION
## Summary
The `detect` job in `.github/workflows/publish.yml` extracted the version with `re.search(r'"([^"]+)"', ...)`, which matched the **first** quoted run in `spytial/_version.py` — the module docstring `"""Package version source of truth."""`. The job then passed `Package version source of truth.` to curl as a URL path component, producing a malformed URL and exit code 3 from `bash -e`.

This anchors the regex to `__version__\s*=\s*"..."` so it always picks the version literal regardless of preceding docstrings or comments.

Surfaced by the publish run for v1.2.4: https://github.com/sidprasad/spytial/actions/runs/25131680522/job/73659291477

## Test plan
- [x] Run the fixed regex locally against `spytial/_version.py` → returns `1.2.4`
- [ ] After merge, re-run the failed workflow (`gh run rerun 25131680522 --repo sidprasad/spytial`) or push any no-op edit to `_version.py` on `main` to confirm it now reaches the build/publish jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)