### PR TITLE
Update spytial-core to 2.6.0 (v1.2.7)

### DIFF
--- a/spytial/_version.py
+++ b/spytial/_version.py
@@ -1,3 +1,3 @@
 """Package version source of truth."""
 
-__version__ = "1.2.6"
+__version__ = "1.2.7"

--- a/spytial/core_assets.py
+++ b/spytial/core_assets.py
@@ -1,6 +1,6 @@
 """Shared spytial-core browser asset definitions for HTML templates."""
 
-SPYTIAL_CORE_VERSION = "2.5.3-beta.1"
+SPYTIAL_CORE_VERSION = "2.6.0"
 
 _CDN_BASE = f"https://cdn.jsdelivr.net/npm/spytial-core@{SPYTIAL_CORE_VERSION}"
 

--- a/test/test_data_instance_format.py
+++ b/test/test_data_instance_format.py
@@ -1,5 +1,5 @@
 """
-Tests that build_instance() output matches the spytial-core v2.5.3-beta.1 IJsonDataInstance format.
+Tests that build_instance() output matches the spytial-core v2.6.0 IJsonDataInstance format.
 
 See spytial-core/docs/JSON_DATA_INSTANCE.md for the canonical spec.
 """


### PR DESCRIPTION
## Summary
- Bump bundled spytial-core from 2.5.3-beta.1 to 2.6.0
- Patch uptick spytial-py to 1.2.7

## Test plan
- [ ] CI passes