### PR TITLE
Reshape docs landing & getting-started; reframe spytial-clrs and spytial-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,77 +1,62 @@
 # sPyTial: Lightweight Diagrams for Structured Python Data
 
-```
+[![PyPI version](https://img.shields.io/pypi/v/spytial-diagramming.svg)](https://pypi.org/project/spytial-diagramming/)
+[![Python versions](https://img.shields.io/pypi/pyversions/spytial-diagramming.svg)](https://pypi.org/project/spytial-diagramming/)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![CI](https://github.com/sidprasad/spytial/actions/workflows/ci.yml/badge.svg)](https://github.com/sidprasad/spytial/actions/workflows/ci.yml)
+[![Docs](https://img.shields.io/badge/docs-mkdocs--material-blue.svg)](https://sidprasad.github.io/spytial/)
+
+```bash
 pip install spytial-diagramming
 ```
 
+**Docs:** https://sidprasad.github.io/spytial/ — start with [Getting Started](https://sidprasad.github.io/spytial/getting-started/) for install, badges, and your first diagram.
+
+---
 
 Sometimes you just want to see your data.
 
-You’re working with a tree, a graph, a recursive object -- maybe an AST, a neural network, or a symbolic term. You don’t need an interactive dashboard or a production-grade visualization system. You just need a diagram, something that lays it out clearly so you can understand what’s going on.
+You're working with a tree, a graph, a recursive object — maybe an AST, a neural network, or a symbolic term. You don't need an interactive dashboard or a production-grade visualization system. You just need a diagram that lays it out clearly so you can understand what's going on.
 
-That’s what `sPyTial` is for. It’s designed for developers, educators, and researchers who work with structured data and need to make that structure visible — to themselves or to others — with minimal effort. 
+That's what `sPyTial` is for. It is designed for developers, educators, and researchers who work with structured data and need to make that structure visible — to themselves or to others — with minimal effort.
 
-## Why Spatial Representation Matters
+## Why spatial layout
 
-There’s strong evidence — from cognitive science, human-computer interaction, and decades of programming tool design — that **spatial representations help people understand structure**. When elements are placed meaningfully in space — grouped, aligned, oriented — we can spot patterns, detect errors, and reason more effectively. This idea shows up in research from Barbara Tversky, Larkin & Simon, and in the design of tools like Alloy and Scratch. 
+Spatial arrangement helps people understand structure: when elements are grouped, aligned, and oriented meaningfully, patterns and errors become easier to see. `sPyTial` gives you that layout **by default** — the diagram reflects how the parts are connected, not how they happen to be stored.
 
-`sPyTial` gives you that kind of spatial layout **by default**. When you visualize a Python object, the diagram reflects how the parts are connected, not just how they're stored. You get:
-- A **box-and-arrow diagram** that shows the shape of your data
-- A layout that follows cognitive and structural conventions
-- A tool that knows when something doesn't make sense
+You get:
+- a **box-and-arrow diagram** that shows the shape of your data
+- a layout driven by declarative constraints (`orientation`, `align`, `cyclic`, `group`)
+- a tool that flags when a constraint can't be satisfied
 
-## Quick Start
+## Quick start
 
 ```python
 import spytial
 
-# Visualize any Python object
 data = {
-    'name': 'root',
-    'children': [
-        {'value': 1},
-        {'value': 2},
-        {'value': 3}
-    ]
+    "name": "root",
+    "children": [
+        {"value": 1},
+        {"value": 2},
+        {"value": 3},
+    ],
 }
 
-# Opens in browser or inline if in a jupyter notebook.
+# Opens in a browser tab, or inline in a Jupyter notebook.
 spytial.diagram(data)
 
-# Or save to file
-spytial.diagram(data, method='file')
-
-# Step through a sequence of states
-states = [
-    {'value': 0, 'next': 1},
-    {'value': 1, 'next': 2},
-]
-spytial.diagramSequence(states, sequence_policy='stability')
-
-# If each step rebuilds fresh objects, provide an identity hook
-class Node:
-    def __init__(self, node_id, value):
-        self.id = node_id
-        self.value = value
-
-states = [Node("A", 1), Node("A", 2)]
-spytial.diagramSequence(
-    states,
-    sequence_policy='stability',
-    identity=lambda obj: obj.id if hasattr(obj, "id") else None,
-)
+# Or save to a file:
+spytial.diagram(data, method="file")
 ```
 
-## Documentation
+For stepping through sequences of states, custom relationalizers, and annotation-driven layouts, see the [docs](https://sidprasad.github.io/spytial/).
 
-Documentation is published at https://sidprasad.github.io/spytial/ and is generated from this repository with MkDocs.
+## Related projects
 
-The docs focus on user-facing material:
-
-- installation and first steps
-- diagramming, evaluation, annotations, and relationalizers
-- data-structure examples drawn from the `spytial-clrs` companion repo
-
+- **[`spytial-clrs`](https://github.com/sidprasad/spytial-clrs)** — a Jupyter notebook collection that implements the data structures from the CLRS algorithms textbook (Cormen, Leiserson, Rivest, Stein) using sPyTial: heaps, linked lists, hash tables, BST / red-black / B / van Emde Boas trees, disjoint-set forests, graphs with MST and SCC views, and more. The best place to see sPyTial on realistic structures.
+- **[`spytial-core`](https://github.com/sidprasad/spytial-core)** — the browser-side rendering engine sPyTial uses under the hood. Shared across all sPyTial language hosts (Python, Rust, Pyret, Lean). See [How It Works](https://sidprasad.github.io/spytial/how-it-works/).
 
 ## License
-This project is licensed under the MIT License. See the LICENSE file for details.
+
+MIT — see [LICENSE](LICENSE).

--- a/docs/examples/spytial-clrs.md
+++ b/docs/examples/spytial-clrs.md
@@ -1,16 +1,47 @@
-# `spytial-clrs` Examples
+# CLRS Notebook Examples
 
-[`spytial-clrs`](https://github.com/sidprasad/spytial-clrs) is the companion examples repository for `spytial-py`. It contains notebooks based on CLRS data structures and is the best source of realistic diagrams for docs, demos, and screenshots.
+[`spytial-clrs`](https://github.com/sidprasad/spytial-clrs) is a Jupyter notebook collection that implements the data structures from the **CLRS algorithms textbook** (Cormen, Leiserson, Rivest, Stein) using sPyTial. Each notebook is organized by CLRS chapter and walks through one or more textbook structures, declaring the spatial constraints that make their structure legible.
 
-## Why it is useful
+## What's in it
 
-If you want to see what sPyTial looks like on larger structures, `spytial-clrs` is the best place to start:
+| Chapter | Structures | Notebook |
+| --- | --- | --- |
+| 6, 19 | Max heap, Fibonacci heap | `heaps.ipynb` |
+| 10 | Stacks, queues | `stacksqueues.ipynb` |
+| 10.2 | Singly, doubly, circular linked lists | `linked-lists.ipynb` |
+| 11 | Direct-address and chained hash tables | `hash-tables.ipynb` |
+| 12, 13, 14, 14.3, 18, 20 | BST, red-black, order statistic, interval, B-tree, van Emde Boas | `trees.ipynb` |
+| 15.2 | Matrix-chain memoization tables | `memoization.ipynb` |
+| 16.3 | Huffman codes | `huffman.ipynb` |
+| 21.3 | Disjoint-set forests (forest and set views) | `disjoint-sets.ipynb` |
+| 22, 22.4, 22.5, 23 | Graphs, topological sort, strongly connected components, MST | `graphs.ipynb` |
 
-- it provides realistic examples that go beyond toy `dict` and `list` inputs
-- it shows how different layout operations help explain specific data structures
-- it gives you a gallery of end-to-end examples you can adapt for your own work
+Bonus: BDDs in `simple-bdd.ipynb`.
 
-## Example guide
+## Run the notebooks
+
+There are three ways to use the collection without installing anything locally beyond the notebooks themselves.
+
+**Docker** (zero local setup):
+
+```bash
+docker pull sidprasad/spytial-clrs:latest
+docker run -p 8888:8888 sidprasad/spytial-clrs
+# open http://localhost:8888
+```
+
+**JupyterLite** (in-browser, no install): see the [`spytial-clrs` README](https://github.com/sidprasad/spytial-clrs) for the deployed link.
+
+**Local clone**:
+
+```bash
+git clone https://github.com/sidprasad/spytial-clrs
+cd spytial-clrs
+pip install -r requirements.txt
+jupyter notebook src/
+```
+
+## Reading guide
 
 Use the notebooks as a guide depending on what you want to visualize:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,10 +1,45 @@
 # Getting Started
 
+[![PyPI version](https://img.shields.io/pypi/v/spytial-diagramming.svg)](https://pypi.org/project/spytial-diagramming/)
+[![Python versions](https://img.shields.io/pypi/pyversions/spytial-diagramming.svg)](https://pypi.org/project/spytial-diagramming/)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/sidprasad/spytial/blob/main/LICENSE)
+[![CI](https://github.com/sidprasad/spytial/actions/workflows/ci.yml/badge.svg)](https://github.com/sidprasad/spytial/actions/workflows/ci.yml)
+[![Docs](https://img.shields.io/badge/docs-mkdocs--material-blue.svg)](https://sidprasad.github.io/spytial/)
+
 ## Install
 
 ```bash
 pip install spytial-diagramming
 ```
+
+- **PyPI:** [pypi.org/project/spytial-diagramming](https://pypi.org/project/spytial-diagramming/)
+- **Source:** [github.com/sidprasad/spytial](https://github.com/sidprasad/spytial)
+- **Supported Python:** 3.8 – 3.12
+
+## Optional extras
+
+Most users do not need these. Install them only if you hit one of the listed cases.
+
+```bash
+pip install "spytial-diagramming[widget]"     # anywidget-based Jupyter widget mode
+pip install "spytial-diagramming[headless]"   # Selenium-driven headless rendering for benchmarking
+pip install "spytial-diagramming[dev]"        # pytest, flake8, black (contributors)
+pip install "spytial-diagramming[docs]"       # mkdocs + plugins (contributors)
+```
+
+- `[headless]` also requires a Chrome / Chromedriver installation on `PATH`. See [Diagramming → Headless benchmarking](usage/diagramming.md#headless-benchmarking).
+
+## Environment
+
+`sPyTial` works in three places without configuration:
+
+| Where you run it | Default output |
+| --- | --- |
+| Jupyter / IPython notebook | Inline HTML |
+| Script / REPL | Opens a new browser tab |
+| Anywhere, on demand | Writes an HTML file |
+
+Rendering itself is done in the browser by [`spytial-core`](how-it-works.md), which is loaded from a CDN the first time you render. There is nothing extra to install; the bundle is cached by the browser after first load. See [How It Works](how-it-works.md) for the pipeline and for offline / pinning guidance.
 
 ## First diagram
 
@@ -22,8 +57,6 @@ example = {
 spytial.diagram(example)
 ```
 
-By default, sPyTial renders inline in notebooks and opens a browser tab everywhere else.
-
 ## Inspect before you diagram
 
 If you want to confirm how an object is being serialized, use the evaluator first:
@@ -38,12 +71,7 @@ This is useful when you are debugging a custom class, an annotation, or a relati
 
 ## Display methods
 
-`sPyTial` chooses a display method based on environment:
-
-- **Notebook:** renders inline.
-- **Anywhere else:** opens a browser tab.
-
-You can override this explicitly:
+`sPyTial` chooses a display method based on environment. You can override it explicitly:
 
 ```python
 spytial.diagram(example, method="browser")   # open a new tab
@@ -63,4 +91,5 @@ spytial.diagram(example, method="inline")    # force inline output
 
 - Read [Diagramming](usage/diagramming.md) for the main rendering workflow.
 - Read [Operations](operations.md) to control layout and drawing.
-- Browse [CLRS Examples](examples/spytial-clrs.md) for richer data-structure examples.
+- Read [How It Works](how-it-works.md) to understand the Python → browser pipeline.
+- Browse [CLRS Notebook Examples](examples/spytial-clrs.md) for worked examples on classic data structures (heaps, trees, graphs, hash tables, disjoint-set forests, and more).

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -1,0 +1,51 @@
+# How It Works
+
+`sPyTial` is a thin Python layer over a shared browser-side rendering engine. Understanding the split helps when you want to pin a version, work offline, or build your own host.
+
+## The pipeline
+
+```
+Python object
+  → relationalizer (turns the object into atoms + relations)
+  → JSON data instance (the IJsonDataInstance format)
+  → HTML page (loads spytial-core from a CDN)
+  → spytial-core in the browser
+      → evaluates constraints + directives
+      → lays out a box-and-arrow diagram
+```
+
+The Python package handles steps 1–3: it walks your object, hands it to the matching relationalizer (see [Custom Relationalizers](relationalizers.md)), and emits a JSON payload plus a YAML spec of layout constraints. The HTML page it produces loads [`spytial-core`](https://github.com/sidprasad/spytial-core) from a CDN, which then does the actual rendering.
+
+## What `spytial-core` is
+
+[`spytial-core`](https://github.com/sidprasad/spytial-core) is the host-agnostic browser engine (TypeScript) that all sPyTial language bindings share:
+
+- [`spytial-py`](https://github.com/sidprasad/spytial) — Python (this package)
+- [`caraspace`](https://github.com/sidprasad/caraspace) — Rust
+- [`spyret`](https://github.com/sidprasad/spyret-lang) — Pyret
+- [`spytial-lean`](https://github.com/sidprasad/spytial-lean) — Lean
+
+Each host serializes its own values into the same JSON data instance format, so the layout engine, constraint solver, and renderer are shared across languages.
+
+## Version pinning
+
+This release pins a specific `spytial-core` version. The pinned version is defined once in [`spytial/core_assets.py`](https://github.com/sidprasad/spytial/blob/main/spytial/core_assets.py), and the CDN URL it builds looks like:
+
+```
+https://cdn.jsdelivr.net/npm/spytial-core@<version>/dist/browser/spytial-core-complete.global.js
+```
+
+To read the version at runtime:
+
+```python
+from spytial.core_assets import get_spytial_core_version
+print(get_spytial_core_version())
+```
+
+When `spytial-core` is upgraded, that constant is bumped and a new sPyTial release is cut.
+
+## What this means for you
+
+- **No extra install.** You only `pip install spytial-diagramming`. The browser bundle is fetched from the CDN the first time a diagram is rendered, then cached by the browser.
+- **First render needs network access.** Once the bundle is cached, rendering works offline. For air-gapped or reproducibility-sensitive workflows, fetch the pinned CDN URL once and serve it locally.
+- **The JSON format is `spytial-core`'s `IJsonDataInstance`.** If you want to drive the engine from a non-Python host, or write tests that bypass Python entirely, the data format is documented in [`spytial-core`](https://github.com/sidprasad/spytial-core)'s docs.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,14 +1,14 @@
 # sPyTial
 
-sPyTial turns Python objects into box-and-arrow diagrams backed by Spytial's layout engine. It is aimed at cases where the structure matters more than the UI: debugging recursive objects, teaching data structures, inspecting serialized state, or building small visual tools around Python models.
+**Spatial diagrams of Python objects.** sPyTial turns structured Python data into box-and-arrow diagrams whose layout is driven by declarative spatial constraints. It is aimed at cases where the structure matters more than the UI: debugging recursive objects, teaching data structures, inspecting serialized state, or building small visual tools around Python models.
 
-## Install
+## What you can do with it
 
-```bash
-pip install spytial-diagramming
-```
+- Render any Python object — `dict`, `list`, dataclass, custom class, graph — as a box-and-arrow diagram.
+- Control layout declaratively with constraints (`orientation`, `align`, `cyclic`, `group`) and directives (`atomColor`, `attribute`, `tag`, `inferredEdge`, …).
+- Step through sequences of states to visualize how a data structure evolves.
 
-## Quick start
+## Hello, sPyTial
 
 ```python
 import spytial
@@ -24,21 +24,20 @@ tree = {
 spytial.diagram(tree)
 ```
 
-## What lives in this site
+**→ [Install and run your first diagram (Getting Started)](getting-started.md)**
 
-This site focuses on using sPyTial:
+## The sPyTial ecosystem
 
-- installation and first steps
-- diagramming and evaluation
-- operations and custom relationalizers
-- worked examples drawn from classic data structures
+sPyTial is part of a small family of projects. Most users only need the first.
 
-## Using `spytial-clrs` as the examples repo
+- **`spytial-py`** (this package) — the Python host. Install with `pip install spytial-diagramming`. Exposes `diagram()`, `evaluate()`, decorators and types for annotating layouts, and a relationalizer plug-in system.
+- **[`spytial-core`](https://github.com/sidprasad/spytial-core)** — the browser-side rendering engine (TypeScript). Loaded automatically from a CDN; you do not install it yourself. The same engine is used by every sPyTial language host (Python, Rust, Pyret, Lean). See [How It Works](how-it-works.md) for the pipeline.
+- **[`spytial-clrs`](https://github.com/sidprasad/spytial-clrs)** — a Jupyter notebook collection that implements the data structures from the **CLRS algorithms textbook** (Cormen, Leiserson, Rivest, Stein) using sPyTial: heaps, stacks, queues, linked lists, hash tables, BST / red-black / B / van Emde Boas / interval trees, Huffman codes, disjoint-set forests, graphs with MST and SCC views. It is the best place to see the package on realistic structures. Ships with a Docker image and a JupyterLite deployment for zero-install browsing.
 
-The sibling [`spytial-clrs`](https://github.com/sidprasad/spytial-clrs) repository is the best source of worked examples for this package. It contains CLRS-style notebooks for linked lists, heaps, trees, graphs, disjoint sets, and memoization tables.
+## Where to go next
 
-- It gives you larger, more realistic examples than small `dict` and `list` snippets.
-- It shows how sPyTial can be used to explain common data structures visually.
-- It is a good place to browse if you want inspiration for your own diagrams.
-
-Start with [Getting Started](getting-started.md), then move to [Diagramming](usage/diagramming.md) or [CLRS Examples](examples/spytial-clrs.md).
+- [Getting Started](getting-started.md) — install, badges, first diagram.
+- [Diagramming](usage/diagramming.md) — the main rendering workflow.
+- [Operations](operations.md) — constraints and directives.
+- [How It Works](how-it-works.md) — the Python → browser pipeline and `spytial-core`.
+- [CLRS Notebook Examples](examples/spytial-clrs.md) — worked examples on classic data structures.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -117,10 +117,12 @@ class TreeNode:
         self.value = value
 ```
 
-## Patterns used in `spytial-clrs`
+## Patterns used in the CLRS notebooks
 
-The CLRS notebooks are a good source of idiomatic operation usage:
+[`spytial-clrs`](https://github.com/sidprasad/spytial-clrs) — a notebook collection implementing CLRS-textbook data structures with sPyTial — is a good source of idiomatic operation usage:
 
 - linked lists use `attribute(...)` to turn fields into compact labels
 - heaps and matrix-style examples use `align(...)` to create readable rows or sibling levels
 - disjoint sets, hash tables, and SCC views use `group(...)` to expose higher-level regions
+
+See [CLRS Notebook Examples](examples/spytial-clrs.md) for the full guide.

--- a/docs/usage/diagramming.md
+++ b/docs/usage/diagramming.md
@@ -74,10 +74,12 @@ metrics = spytial.diagram(
 - `method="browser"` and `method="file"` return the HTML file path.
 - `headless=True` returns performance metrics when `perf_iterations` is set.
 
-## Patterns from `spytial-clrs`
+## Patterns from the CLRS notebooks
 
-If you want realistic examples instead of toy snippets, use the notebooks in [`spytial-clrs`](https://github.com/sidprasad/spytial-clrs):
+For realistic examples instead of toy snippets, use [`spytial-clrs`](https://github.com/sidprasad/spytial-clrs) — a notebook collection that implements CLRS-textbook data structures with sPyTial:
 
 - `linked-lists.ipynb` shows list-like structures and cyclic constraints.
 - `heaps.ipynb` and `trees.ipynb` show recursive structures with alignment and attributes.
 - `graphs.ipynb` and `disjoint-sets.ipynb` show grouping-heavy layouts.
+
+See [CLRS Notebook Examples](../examples/spytial-clrs.md) for the full guide.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,13 +9,14 @@ site_dir: site
 nav:
   - Home: index.md
   - Getting Started: getting-started.md
+  - How It Works: how-it-works.md
   - Diagramming: usage/diagramming.md
   - Sequences: usage/sequences.md
   - Evaluator: usage/evaluator.md
   - Operations: operations.md
   - Dataclass Builder: usage/dataclass-builder.md
   - Custom Relationalizers: relationalizers.md
-  - CLRS Examples: examples/spytial-clrs.md
+  - CLRS Notebook Examples: examples/spytial-clrs.md
   - API Reference: reference/api.md
 
 theme:


### PR DESCRIPTION
## Summary

- Turns `docs/getting-started.md` into the canonical "send this link" install page: PyPI/Python/license/CI/docs badges, PyPI link, supported Python versions, the previously-undocumented optional extras (`[widget]`, `[headless]`, `[dev]`, `[docs]`), environment table, plus the existing first-diagram and display-method content.
- Rewrites `docs/index.md` as a real landing page (drops the duplicated install snippet) and adds a "sPyTial ecosystem" section that describes `spytial-py`, `spytial-core`, and `spytial-clrs` concretely. No more "sister/sibling/companion repo" wording.
- Adds `docs/how-it-works.md` to explain the Python → JSON → browser pipeline and what `spytial-core` actually is — the host-agnostic rendering engine shared across spytial-py, caraspace, spyret, and spytial-lean. References `get_spytial_core_version()` so the version isn't duplicated in prose.
- Reframes `spytial-clrs` everywhere it appears as what it concretely is — a Jupyter notebook collection implementing the **CLRS algorithms textbook** data structures (Cormen, Leiserson, Rivest, Stein) with sPyTial. Adds chapter coverage, Docker, and JupyterLite to its page.
- Trims `README.md` for consumer focus: adds the same badge row, drops the advanced `diagramSequence` + identity-hook example (already covered in `docs/usage/sequences.md`), shortens the academic "Why Spatial Representation Matters" passage, and adds a Related projects section.
- `mkdocs.yml`: adds `How It Works` between `Getting Started` and `Diagramming`; renames `CLRS Examples` → `CLRS Notebook Examples`.

## Test plan

- [x] `mkdocs build --strict` succeeds; new page renders at `/how-it-works/`
- [x] Nav order is Home → Getting Started → How It Works → Diagramming → … → CLRS Notebook Examples → API Reference
- [x] `grep -rni "sister\|companion" docs/ README.md` returns no hits (remaining `sibling` matches are a `field="sibling"` parameter and a "sibling levels" description — both legitimate)
- [ ] Confirm badges render on the published docs site after the gh-pages workflow runs on merge
- [ ] Confirm badges render on the README on github.com after merge
- [ ] Spot-check the PyPI link resolves: https://pypi.org/project/spytial-diagramming/

🤖 Generated with [Claude Code](https://claude.com/claude-code)