### PR TITLE
Detect JupyterLite/Pyodide kernel in is_notebook() (1.3.0)

### DIFF
--- a/spytial/_version.py
+++ b/spytial/_version.py
@@ -1,3 +1,3 @@
 """Package version source of truth."""
 
-__version__ = "1.2.7"
+__version__ = "1.3.0"

--- a/spytial/utils.py
+++ b/spytial/utils.py
@@ -26,8 +26,14 @@ def is_notebook() -> bool:
         ipython = get_ipython()
         if ipython is None:
             return False
-        # Check if we're in a notebook (IPython kernel has 'IPKernelApp')
-        return "IPKernelApp" in ipython.config
+        # Standard Jupyter (ipykernel) exposes an IPKernelApp config section.
+        if "IPKernelApp" in ipython.config:
+            return True
+        # JupyterLite / Pyodide runs a plain InteractiveShell subclass
+        # ("Interpreter") that has no IPKernelApp; Google Colab uses its own
+        # shell too. Treat any interactive shell that isn't the plain terminal
+        # REPL as a notebook so diagram() defaults to inline rendering there.
+        return type(ipython).__name__ != "TerminalInteractiveShell"
     except Exception:
         return False
 


### PR DESCRIPTION
## Detect the JupyterLite / Pyodide kernel in `is_notebook()`

`is_notebook()` returned `True` only when `"IPKernelApp"` was present in the IPython config. JupyterLite's Pyodide kernel is built on `InteractiveShellApp` (not ipykernel's `IPKernelApp`), so `is_notebook()` returned `False` there, and `default_method()` fell back to `"browser"`.

In the Pyodide **web-worker** kernel that means `diagram(x)` → `webbrowser.open()` → `from js import window` → `ImportError: cannot import name 'window' from 'js'` — so diagrams never rendered in JupyterLite.

### Fix
Keep the `IPKernelApp` fast-path, and additionally treat any interactive shell that isn't the plain terminal REPL (`TerminalInteractiveShell`) as a notebook. This covers JupyterLite's `Interpreter` shell (and Google Colab) while still returning `False` for the terminal and plain scripts.

### Verified (logic exercised against each shell type)
| environment | `is_notebook()` | `default_method()` |
|---|---|---|
| Jupyter / JupyterLab (ipykernel, `IPKernelApp`) | `True` | `inline` |
| JupyterLite / Pyodide (`Interpreter`) | `True` ✅ (was `False`) | `inline` |
| IPython terminal (`TerminalInteractiveShell`) | `False` | `browser` |
| plain `python script.py` (no IPython) | `False` | `browser` |

Bumps version `1.2.7` → `1.3.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
