### PR TITLE
Rebuild real objects in reify(); add replit()

### DIFF
--- a/spytial/provider_system.py
+++ b/spytial/provider_system.py
@@ -911,9 +911,15 @@ class CnDDataInstanceBuilder:
                     value = [reify_atom(tid) for tid in target_ids]
                 try:
                     object.__setattr__(obj, rel_name, value)
-                except (AttributeError, TypeError):
-                    # e.g. __slots__ without this name, or read-only — skip,
-                    # best-effort like the rest of generic reconstruction.
+                except Exception:
+                    # Skip on any setattr failure and keep the real instance.
+                    # The relationalizer records public @property values, so
+                    # writing them back here routes through the descriptor's
+                    # setter; besides __slots__ gaps and read-only attributes
+                    # (AttributeError/TypeError), a validated setter may reject
+                    # the restored value with ValueError or similar. Best-effort,
+                    # like the rest of generic reconstruction: a single rejected
+                    # field must not abort rebuilding the object.
                     pass
             return obj
 

--- a/spytial/provider_system.py
+++ b/spytial/provider_system.py
@@ -5,6 +5,7 @@ This module provides a pluggable system for converting Python objects
 into CnD-compatible atom/relation representations using relationalizers.
 """
 
+import importlib
 import inspect
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type
 
@@ -41,6 +42,30 @@ def _invoke_custom_reifier(fn, atom, relations, reify_atom, register):
     if len(positional) >= 4:
         return fn(atom, relations, reify_atom, register)
     return fn(atom, relations, reify_atom)
+
+
+def _resolve_class(module_name: Optional[str], qualname: Optional[str]) -> Optional[type]:
+    """Resolve a class object from its module + qualified name.
+
+    Returns ``None`` when the class can't be located — defined in a closure or
+    comprehension (``<locals>`` in the qualname), module not importable, or the
+    dotted path doesn't resolve to a class. Callers fall back to a structural
+    proxy in that case. In the same-process / round-trip-to-host setting the
+    class is always importable (including ``__main__`` for REPL/script code).
+    """
+    if not module_name or not qualname or "<locals>" in qualname:
+        return None
+    try:
+        module = importlib.import_module(module_name)
+    except Exception:
+        return None
+    obj: Any = module
+    for part in qualname.split("."):
+        try:
+            obj = getattr(obj, part)
+        except AttributeError:
+            return None
+    return obj if isinstance(obj, type) else None
 
 
 def relationalizer(cls: Type = None, *, priority: int = 0):
@@ -462,6 +487,16 @@ class CnDDataInstanceBuilder:
                 else:
                     # Even if relationalizer provided a different type, add the hierarchy
                     atom["type_hierarchy"] = [atom["type"]] + type_hierarchy
+                # Record the class's importable identity so reify() can rebuild
+                # the REAL object (object.__new__ + setattr) rather than a
+                # structural proxy. Only for non-builtins — primitives and
+                # containers have dedicated reify paths. Survives build_instance
+                # (only type_hierarchy is stripped); spytial-core ignores the
+                # extra keys for visualization.
+                obj_cls = type(obj)
+                if obj_cls.__module__ != "builtins":
+                    atom["__module__"] = obj_cls.__module__
+                    atom["__qualname__"] = obj_cls.__qualname__
                 primary_atom_id = atom["id"]
             else:
                 # Secondary atoms (e.g., list elements) - keep their relationalizer-provided type
@@ -663,6 +698,18 @@ class CnDDataInstanceBuilder:
         root_atom_id = self._resolve_root_id(data_instance, atoms, relations, root_id)
         return reify_atom(root_atom_id)
 
+    def replit(self, data_instance: Dict, root_id: Optional[str] = None) -> str:
+        """Reproduce the host REPL's output for a data instance.
+
+        Equivalent to ``repr(self.reify(data_instance, root_id))`` — rebuild the
+        object, then let Python's own ``repr`` render it. Matches ``repr(v)``
+        exactly for any importable, ordinarily-constructed value (custom
+        ``__repr__`` and cycle handling included, since it delegates to Python);
+        values that fall back to a structural proxy render as
+        ``TypeName(field=value)``.
+        """
+        return repr(self.reify(data_instance, root_id))
+
     def _resolve_root_id(
         self,
         data_instance: Dict,
@@ -835,17 +882,53 @@ class CnDDataInstanceBuilder:
     def _reify_generic_object(
         self, atom: Dict, relations: Dict, reify_atom, register
     ) -> Any:
-        """Reconstruct a generic object from its atom and relations.
+        """Reconstruct an object from its atom and relations.
 
-        Allocates the attribute-bag instance and registers it *before*
-        recursing into relations so self-loops and back-pointers resolve to
-        the same instance.
+        Prefers rebuilding the **real** instance: when the atom carries the
+        class's importable identity (``__module__`` + ``__qualname__``, recorded
+        by _walk for non-builtins) and that class resolves, allocate it with
+        ``object.__new__`` and populate fields directly — pickle's discipline.
+        This yields a genuine ``cls`` instance, so ``repr`` runs the real
+        ``__repr__`` and ``isinstance`` holds; registering the empty instance
+        *before* recursing keeps self-loops and back-pointers intact.
+
+        Falls back to a structural attribute-bag proxy when the class can't be
+        resolved (closure/dynamic class, module not importable) or can't be
+        allocated this way (custom ``__new__`` / C-level state — enums, numpy,
+        ``int``/``str`` subclasses). The proxy preserves attributes and cycles
+        but reprs as ``TypeName(field=value)``.
         """
         atom_type = atom["type"]
 
         if atom_type in {"dict", "list", "tuple", "set"}:
             raise ValueError(f"Type {atom_type} should be handled by specific method")
 
+        def _populate(obj: Any) -> Any:
+            for rel_name, target_ids in relations.items():
+                if len(target_ids) == 1:
+                    value = reify_atom(target_ids[0])
+                else:
+                    value = [reify_atom(tid) for tid in target_ids]
+                try:
+                    object.__setattr__(obj, rel_name, value)
+                except (AttributeError, TypeError):
+                    # e.g. __slots__ without this name, or read-only — skip,
+                    # best-effort like the rest of generic reconstruction.
+                    pass
+            return obj
+
+        # Preferred path: rebuild the genuine class instance.
+        cls = _resolve_class(atom.get("__module__"), atom.get("__qualname__"))
+        if cls is not None:
+            try:
+                obj = object.__new__(cls)
+            except TypeError:
+                obj = None  # custom/unsafe __new__ — fall back to the proxy
+            if obj is not None:
+                register(obj)
+                return _populate(obj)
+
+        # Fallback: structural attribute-bag proxy.
         class ReconstructedObject:
             def __init__(self):
                 pass
@@ -857,14 +940,7 @@ class CnDDataInstanceBuilder:
         obj = ReconstructedObject()
         obj.__class__.__name__ = atom_type
         register(obj)
-
-        for rel_name, target_ids in relations.items():
-            if len(target_ids) == 1:
-                setattr(obj, rel_name, reify_atom(target_ids[0]))
-            else:
-                setattr(obj, rel_name, [reify_atom(tid) for tid in target_ids])
-
-        return obj
+        return _populate(obj)
 
     def can_reify(self, data_instance: Dict) -> bool:
         """

--- a/test/test_reify.py
+++ b/test/test_reify.py
@@ -168,8 +168,10 @@ def test_reify_generic_object_self_loop():
     di = CnDDataInstanceBuilder().build_instance(b)
     out = CnDDataInstanceBuilder().reify(di)
 
-    # _reify_generic_object produces an attribute-bag, not the original class,
-    # but the self-reference should still resolve to the same object.
+    # The atom carries Bag's module + qualname, so reify rebuilds the REAL
+    # class (object.__new__ + setattr), not an attribute-bag proxy — and the
+    # self-reference still resolves to the same object.
+    assert type(out) is Bag
     assert getattr(out, "self_ref") is out
     assert getattr(out, "tag") == "hello"
 
@@ -281,3 +283,41 @@ def test_dataclass_reifier_backcompat_3arg_signature():
     di = CnDDataInstanceBuilder().build_instance(Simple(x=42))
     out = r.reify(di)
     assert out == Simple(x=42)
+
+
+# ---------------------------------------------------------------------------
+# Rebuilding the REAL object (object.__new__ via module/qualname) + replit
+# ---------------------------------------------------------------------------
+
+
+class Vec:
+    """Plain (non-dataclass) class with a non-structural custom __repr__."""
+
+    def __init__(self, x, y):
+        self.x = x
+        self.y = y
+
+    def __repr__(self):
+        return f"Vec<{self.x},{self.y}>"
+
+
+def test_reify_rebuilds_real_class_with_custom_repr():
+    v = Vec(1, 2)
+    di = CnDDataInstanceBuilder().build_instance(v)
+    out = CnDDataInstanceBuilder().reify(di)
+    # The genuine class — so the real (custom, non-structural) __repr__ runs,
+    # something an attribute-bag proxy could never reproduce.
+    assert type(out) is Vec
+    assert repr(out) == repr(v) == "Vec<1,2>"
+
+
+def test_replit_matches_repr_for_custom_class():
+    v = Vec(3, 4)
+    di = CnDDataInstanceBuilder().build_instance(v)
+    assert CnDDataInstanceBuilder().replit(di) == repr(v)
+
+
+def test_replit_matches_repr_for_nested_builtins():
+    value = {"nums": [1, 2, 3], "tag": "hi"}
+    di = CnDDataInstanceBuilder().build_instance(value)
+    assert CnDDataInstanceBuilder().replit(di) == repr(value)

--- a/test/test_reify.py
+++ b/test/test_reify.py
@@ -321,3 +321,46 @@ def test_replit_matches_repr_for_nested_builtins():
     value = {"nums": [1, 2, 3], "tag": "hi"}
     di = CnDDataInstanceBuilder().build_instance(value)
     assert CnDDataInstanceBuilder().replit(di) == repr(value)
+
+
+# ---------------------------------------------------------------------------
+# Property setters that reject the restored value (sidprasad/spytial#101 review)
+# ---------------------------------------------------------------------------
+
+
+class Account:
+    """A validated setter that can reject the value the getter would report.
+
+    The relationalizer records the public ``balance`` @property, so reify writes
+    it back *through the setter* — which here refuses negative balances even
+    though an overdrawn account reads one. Reconstruction must skip the rejected
+    field, not abort.
+    """
+
+    def __init__(self, balance):
+        self._balance = balance
+
+    @property
+    def balance(self):
+        return self._balance
+
+    @balance.setter
+    def balance(self, value):
+        if value < 0:
+            raise ValueError("cannot set a negative balance")
+        self._balance = value
+
+    def __repr__(self):
+        return f"Account({self._balance})"
+
+
+def test_reify_skips_property_setter_that_rejects_value():
+    a = Account(-50)  # overdrawn: balance reads -50, but the setter rejects -50
+    di = CnDDataInstanceBuilder().build_instance(a)
+    # 'balance' is recorded via the public @property, so reify routes it back
+    # through the validating setter, which raises ValueError on -50.
+    assert any(r["name"] == "balance" for r in di["relations"])
+    # The raising setter must be skipped — reify still returns the real class
+    # rather than aborting the whole reconstruction.
+    out = CnDDataInstanceBuilder().reify(di)
+    assert type(out) is Account


### PR DESCRIPTION
## What

`reify()` now rebuilds the **real** object instead of an attribute-bag proxy.

- `build_instance` records each non-builtin atom's class identity (`__module__` + `__qualname__`) at the single `_walk` chokepoint.
- `_reify_generic_object` resolves that class and allocates via `object.__new__` + `object.__setattr__` (pickle's discipline), registering the empty instance *before* recursing so cycles/sharing survive.
- Graceful fallback to the existing proxy when the class can't be resolved (closures/`<locals>`, dynamic classes) or allocated (custom `__new__` / C-level state — enums, numpy, `int`/`str` subclasses).
- New `CnDDataInstanceBuilder.replit(data_instance, root_id=None)` = `repr(reify(...))` — the REPL-equivalent string for a data instance.

## Why

A genuine instance means `repr` runs the type's real `__repr__` and `isinstance` holds, so

```
repr(reify(build_instance(v))) == repr(v)
```

now holds for any importable, ordinarily-constructed object — **custom `__repr__` included** — which an attribute-bag proxy could never do.

## Testing

- `test/test_reify.py`: 18/18 (3 new — real rebuild w/ custom repr, `replit` vs custom class, `replit` vs nested builtins; strengthened the generic-object test to assert the real class).
- Full suite: **116 passed, 1 skipped**.

## Follow-ups

- The pickle long tail (enums, `int`/`str` subclasses, numpy) still falls back to the proxy — `__reduce_ex__` / `__getnewargs__` / `__setstate__` would extend coverage.
- `__module__`/`__qualname__` are per-atom keys, ignored by spytial-core for rendering. Whether they survive a spytial-core/browser round-trip (as `rootId` doesn't) is unverified — the widget's registered-reifier path already covers that case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
