### PR TITLE
Add property-based tests for reify() (Hypothesis)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ headless = [
 ]
 dev = [
     "pytest>=7.0.0",
+    "hypothesis>=6.0.0",
     "flake8>=6.0.0",
     "black>=23.0.0",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ ipython>=8.0.0 # For Jupyter notebook integration
 
 # Development and testing dependencies
 pytest>=7.0.0  # For testing
+hypothesis>=6.0.0  # For property-based testing
 flake8>=6.0.0  # For linting
 black>=23.0.0  # For code formatting
 

--- a/test/test_reify_pbt.py
+++ b/test/test_reify_pbt.py
@@ -1,0 +1,187 @@
+"""Property-based tests for ``reify`` — the inverse of ``build_instance``.
+
+The falsifiable property is whether, for a chosen set of values, the datum
+Spytial receives can reproduce the language's textual inspection string. We
+compare two paths and assert they end at the same string::
+
+    value ── repr ─────────────────────────────────────────► string
+    value ── build_instance ─► datum ─► reify ─► repr ──────► string
+
+i.e. ``repr(reify(build_instance(v))) == repr(v)``.
+
+``repr`` (not ``==``) is the oracle on purpose: it sidesteps ``float('nan')``,
+which is never equal to itself, while still pinning down the reconstructed
+value's textual form — exactly the inspection string a REPL would print.
+
+Scope of the generated values (what the round-trip is *designed* to recover):
+
+* Leaves: ``None``, ``bool``, ``int``, ``float`` (incl. ``nan``/``inf``), ``str``.
+* Order-stable containers: ``list``, ``tuple``, and ``dict`` (insertion-ordered).
+* ``dict`` keys are restricted to primitives + ``None``: ``DictRelationalizer``
+  walks those structurally, whereas a *complex* key (tuple/frozenset/object)
+  gets a synthetic, un-walked key atom and reifies to an empty shell — a
+  build-side limitation pinned by ``test_complex_dict_key_is_known_limitation``.
+* ``set`` is covered separately: a set's ``repr`` order is not a function of its
+  elements (the hash-table layout depends on insertion/resize history), so for
+  sets we assert element recovery rather than ``repr``-string equality.
+* ``bytes``/``frozenset`` and the documented long tail (enums, ``int``/``str``
+  subclasses, numpy) are out of scope — they fall back to the attribute-bag
+  proxy and are intentionally not generated here.
+"""
+
+from collections import Counter
+
+import pytest
+from hypothesis import given, settings, strategies as st
+
+from spytial.provider_system import CnDDataInstanceBuilder
+
+
+def _roundtrip(value):
+    """value ─► build_instance ─► datum ─► reify ─► reconstructed object."""
+    builder = CnDDataInstanceBuilder()
+    return builder.reify(builder.build_instance(value))
+
+
+# ---------------------------------------------------------------------------
+# Strategies
+# ---------------------------------------------------------------------------
+
+# Leaves whose repr is a pure function of the value. nan/inf are kept: their
+# repr ('nan'/'inf') round-trips even though `==` would not.
+atoms = st.one_of(
+    st.none(),
+    st.booleans(),
+    st.integers(),
+    st.floats(allow_nan=True, allow_infinity=True),
+    st.text(),
+)
+
+# Hashable leaves usable as dict keys and set elements: the primitives the
+# DictRelationalizer records structurally (str/int/float/bool) plus None (which
+# reify reconstructs from the atom type alone). nan is excluded on purpose — as
+# a key it is unlookupable, and because the datum memoizes equal atoms a dict or
+# set holding several *distinct* nan objects cannot round-trip its entry count
+# (two `nan` keys ── repr ── '{nan, nan}' collapse to one shared atom). inf is
+# kept: inf == inf, so it behaves like any ordinary key.
+hashable_atoms = st.one_of(
+    st.none(),
+    st.booleans(),
+    st.integers(),
+    st.floats(allow_nan=False, allow_infinity=True),
+    st.text(),
+)
+
+# Recursive structures whose repr is order-stable: lists, tuples (as values),
+# and insertion-ordered dicts. Sets are deliberately excluded here.
+repr_stable = st.recursive(
+    atoms,
+    lambda children: st.one_of(
+        st.lists(children),
+        st.lists(children).map(tuple),
+        st.dictionaries(keys=hashable_atoms, values=children),
+    ),
+    max_leaves=25,
+)
+
+
+# ---------------------------------------------------------------------------
+# The core property: the two paths land on the same inspection string
+# ---------------------------------------------------------------------------
+
+
+@settings(max_examples=300, deadline=None)
+@given(repr_stable)
+def test_repr_roundtrip(value):
+    assert repr(_roundtrip(value)) == repr(value)
+
+
+@settings(max_examples=200, deadline=None)
+@given(repr_stable)
+def test_replit_equals_repr(value):
+    # replit(datum) is defined as repr(reify(datum)) — the REPL-equivalent
+    # string — so it must reproduce repr(value) over the same domain.
+    builder = CnDDataInstanceBuilder()
+    datum = builder.build_instance(value)
+    assert builder.replit(datum) == repr(value)
+
+
+# ---------------------------------------------------------------------------
+# Sets: element recovery, since repr order isn't element-determined
+# ---------------------------------------------------------------------------
+
+
+@settings(max_examples=200, deadline=None)
+@given(st.sets(hashable_atoms))
+def test_set_elements_roundtrip(value):
+    out = _roundtrip(value)
+    assert isinstance(out, set)
+    # A set reprs in hash-table order, which depends on insertion history, so
+    # two sets with identical elements can repr differently. Compare the
+    # multiset of element reprs instead — order-independent, nan-safe.
+    assert Counter(map(repr, out)) == Counter(map(repr, value))
+
+
+# ---------------------------------------------------------------------------
+# Real objects: reify rebuilds the genuine class, so the custom __repr__ runs
+# ---------------------------------------------------------------------------
+
+
+class Vec2:
+    """Plain class with a non-structural custom __repr__."""
+
+    def __init__(self, x, y):
+        self.x = x
+        self.y = y
+
+    def __repr__(self):
+        return f"Vec2(x={self.x!r}, y={self.y!r})"
+
+
+class Pair:
+    """Holds arbitrary objects — including other reified instances."""
+
+    def __init__(self, first, second):
+        self.first = first
+        self.second = second
+
+    def __repr__(self):
+        return f"Pair({self.first!r}, {self.second!r})"
+
+
+@settings(max_examples=200, deadline=None)
+@given(repr_stable, repr_stable)
+def test_custom_object_repr_roundtrip(a, b):
+    obj = Vec2(a, b)
+    # The atom carries Vec2's module + qualname, so reify rebuilds the real
+    # class and its custom __repr__ runs — an attribute-bag proxy could not.
+    out = _roundtrip(obj)
+    assert type(out) is Vec2
+    assert repr(out) == repr(obj)
+
+
+@settings(max_examples=150, deadline=None)
+@given(repr_stable, repr_stable, repr_stable)
+def test_nested_custom_object_repr_roundtrip(a, b, c):
+    # Object-in-object: exercises register-before-recurse so the inner instance
+    # is rebuilt and reprs correctly inside the outer one's __repr__.
+    obj = Pair(Vec2(a, b), c)
+    out = _roundtrip(obj)
+    assert type(out) is Pair
+    assert repr(out) == repr(obj)
+
+
+# ---------------------------------------------------------------------------
+# Known limitation (tracked): complex dict keys aren't walked on the build side
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="DictRelationalizer emits a synthetic, un-walked key atom for "
+    "non-primitive dict keys (tuple/frozenset/object), so they reify to empty "
+    "shells. Build-side limitation; flip this test green when it's fixed.",
+)
+def test_complex_dict_key_is_known_limitation():
+    value = {("a", "b"): 1}
+    assert repr(_roundtrip(value)) == repr(value)


### PR DESCRIPTION
## What

Property-based tests (Hypothesis) for `reify`, the inverse of `build_instance`. They assert the **falsifiable round-trip property** the datum is supposed to satisfy: for a chosen value, reproduce the language's textual inspection string via two paths and check they land on the same string.

```
value ── repr ─────────────────────────────────────────► string
value ── build_instance ─► datum ─► reify ─► repr ──────► string
```

i.e. `repr(reify(build_instance(v))) == repr(v)` over many generated values.

`repr` (not `==`) is the oracle on purpose: it sidesteps `float('nan')` (never equal to itself) while still pinning the reconstructed value's textual form — exactly the string a REPL prints. This is also what `replit(datum)` returns, so it's tested directly too.

## Coverage — `test/test_reify_pbt.py`

| Property | Domain | Oracle |
|---|---|---|
| `test_repr_roundtrip` | None/bool/int/float (incl. nan/inf)/str, nested lists, tuples, insertion-ordered dicts | `repr` equality |
| `test_replit_equals_repr` | same | `replit(datum) == repr(value)` |
| `test_set_elements_roundtrip` | sets of hashable leaves | multiset of element `repr`s |
| `test_custom_object_repr_roundtrip` | `Vec2` with arbitrary fields | real class + custom `__repr__` |
| `test_nested_custom_object_repr_roundtrip` | `Pair(Vec2(...), ...)` | object-in-object rebuild |

Stress-tested at 4000 examples/property (20k total) — clean.

## Scoping reflects two genuine limitations the tests surfaced

- **Complex dict keys.** A tuple/frozenset/object used as a *dict key* gets a synthetic, un-walked key atom from `DictRelationalizer` ([dict_relationalizer.py:29-34](https://github.com/sidprasad/spytial/blob/main/spytial/domain_relationalizers/dict_relationalizer.py#L29-L34)) and reifies to an **empty shell** (`{('a','b'): 1}` → `{(): 1}`). Tuples as *values*, in lists, and in sets all round-trip fine — it's specific to keys. Pinned by `test_complex_dict_key_is_known_limitation` (strict `xfail`) so a future build-side fix flips it green. Likely worth a follow-up.
- **Distinct-nan keys/elements.** Because equal atoms are memoized (needed for sharing/cycles) and `nan != nan`, a dict/set holding several *distinct* nan objects can't round-trip its entry count (`{nan: 1, nan: 2}` → `{nan: ...}`). Such a container is degenerate (keys are unlookupable), so nan is excluded from generated keys/elements; **nan as a value round-trips fine** and stays in the domain.
- Out of scope (documented long tail — fall back to the attribute-bag proxy): `bytes`/`frozenset`, enums, `int`/`str` subclasses, numpy.

## Deps

Adds `hypothesis>=6.0.0` to the `dev` extra and `requirements.txt` so CI (which installs `.[dev]`) picks it up.

## Testing

Full suite: **122 passed, 1 skipped, 1 xfailed**. flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)