### PR TITLE
Walk complex dict keys so reify() recovers them

### DIFF
--- a/spytial/domain_relationalizers/dict_relationalizer.py
+++ b/spytial/domain_relationalizers/dict_relationalizer.py
@@ -21,17 +21,15 @@ class DictRelationalizer(RelationalizerBase):
         atoms = [Atom(id=obj_id, type=typ, label=label)]
         relations = []
         for k, v in obj.items():
-            # For primitive keys (str, int, float, bool), walk them properly
-            # so they get proper primitive IDs instead of synthetic key IDs
-            if isinstance(k, (str, int, float, bool)):
-                # Walk the key as a primitive - this will give it a proper ID
-                key_id = walker_func._walk(k)
-            else:
-                # For complex keys, create a synthetic key atom
-                key_id = f"{obj_id}_key_{len(relations)}"
-                key_str = f"key_{len(relations)}"
-                key_atom = Atom(id=key_id, type=type(k).__name__, label=key_str)
-                atoms.append(key_atom)
+            # Walk every key through the normal pipeline — primitives *and*
+            # complex keys (tuples, objects, …). _walk records the key's own
+            # atom plus, for containers/objects, its nested structure and class
+            # identity, which reify needs to rebuild the real key. A previous
+            # shortcut emitted a synthetic, un-walked atom for non-primitive
+            # keys, so they reified to empty shells (e.g. {('a','b'): 1} came
+            # back as {(): 1}). Memoization also means a key object that appears
+            # elsewhere now shares one atom instead of being duplicated.
+            key_id = walker_func._walk(k)
 
             # Get the value ID
             vid = walker_func._walk(v)

--- a/test/test_reify.py
+++ b/test/test_reify.py
@@ -12,8 +12,6 @@ These cover the regression reported as sidprasad/spytial#90:
 from dataclasses import dataclass, field
 from typing import List, Optional
 
-import pytest
-
 from spytial.provider_system import CnDDataInstanceBuilder
 from spytial.dataclass_builder import _make_dataclass_reifier
 
@@ -107,6 +105,44 @@ def test_reify_dict_self_loop():
     assert isinstance(out, dict)
     assert out["a"] == 1
     assert out["self"] is out
+
+
+# ---------------------------------------------------------------------------
+# Complex (non-primitive) dict keys are walked, so they keep their contents
+# ---------------------------------------------------------------------------
+
+
+def test_reify_tuple_dict_key():
+    # Regression: a tuple key used to get a synthetic, un-walked key atom and
+    # reified to an empty tuple ({('a', 'b'): 1} -> {(): 1}).
+    d = {("a", "b"): 1, ("c",): 2}
+    di = CnDDataInstanceBuilder().build_instance(d)
+    out = CnDDataInstanceBuilder().reify(di)
+
+    assert isinstance(out, dict)
+    assert out[("a", "b")] == 1
+    assert out[("c",)] == 2
+    assert repr(out) == repr(d)
+
+
+def test_reify_nested_tuple_dict_key():
+    d = {("a",): {("b",): [1, 2]}}
+    out = CnDDataInstanceBuilder().reify(CnDDataInstanceBuilder().build_instance(d))
+    assert out[("a",)][("b",)] == [1, 2]
+    assert repr(out) == repr(d)
+
+
+def test_reify_object_dict_key():
+    # A custom, importable object as a dict key rebuilds the real class (Vec
+    # hashes by identity, so look the value up via the reconstructed key).
+    d = {Vec(1, 2): "here"}
+    out = CnDDataInstanceBuilder().reify(CnDDataInstanceBuilder().build_instance(d))
+
+    assert isinstance(out, dict) and len(out) == 1
+    out_key = next(iter(out))
+    assert type(out_key) is Vec
+    assert repr(out_key) == "Vec<1,2>"
+    assert out[out_key] == "here"
 
 
 # ---------------------------------------------------------------------------

--- a/test/test_reify.py
+++ b/test/test_reify.py
@@ -145,6 +145,24 @@ def test_reify_object_dict_key():
     assert out[out_key] == "here"
 
 
+def test_reify_frozenset_dict_key_preserves_elements():
+    # The fix walks a frozenset key like any value, so its elements survive the
+    # round-trip instead of collapsing to the empty shell the bug produced for
+    # complex keys. A frozenset still reifies to an attribute-bag proxy rather
+    # than a real frozenset — a separate, documented reify limitation — so
+    # recover the elements in a way that holds for either form.
+    fs = frozenset({"a", "b"})
+    out = CnDDataInstanceBuilder().reify(
+        CnDDataInstanceBuilder().build_instance({fs: 1})
+    )
+
+    assert isinstance(out, dict) and len(out) == 1
+    key = next(iter(out))
+    elements = set(key) if isinstance(key, frozenset) else set(key.contains)
+    assert elements == {"a", "b"}  # contents preserved, not an empty shell
+    assert out[key] == 1
+
+
 # ---------------------------------------------------------------------------
 # Multi-node cycles
 # ---------------------------------------------------------------------------

--- a/test/test_reify_pbt.py
+++ b/test/test_reify_pbt.py
@@ -17,21 +17,20 @@ Scope of the generated values (what the round-trip is *designed* to recover):
 
 * Leaves: ``None``, ``bool``, ``int``, ``float`` (incl. ``nan``/``inf``), ``str``.
 * Order-stable containers: ``list``, ``tuple``, and ``dict`` (insertion-ordered).
-* ``dict`` keys are restricted to primitives + ``None``: ``DictRelationalizer``
-  walks those structurally, whereas a *complex* key (tuple/frozenset/object)
-  gets a synthetic, un-walked key atom and reifies to an empty shell — a
-  build-side limitation pinned by ``test_complex_dict_key_is_known_limitation``.
+* ``dict`` keys: primitives, ``None``, and **tuples of those** all round-trip —
+  ``DictRelationalizer`` walks every key structurally, so a complex key keeps
+  its contents (``{('a', 'b'): 1}`` reifies back to ``{('a', 'b'): 1}``).
 * ``set`` is covered separately: a set's ``repr`` order is not a function of its
   elements (the hash-table layout depends on insertion/resize history), so for
   sets we assert element recovery rather than ``repr``-string equality.
 * ``bytes``/``frozenset`` and the documented long tail (enums, ``int``/``str``
   subclasses, numpy) are out of scope — they fall back to the attribute-bag
-  proxy and are intentionally not generated here.
+  proxy and are intentionally not generated here. (A ``frozenset`` *key* is
+  therefore still out of scope, like a ``frozenset`` value.)
 """
 
 from collections import Counter
 
-import pytest
 from hypothesis import given, settings, strategies as st
 
 from spytial.provider_system import CnDDataInstanceBuilder
@@ -57,19 +56,23 @@ atoms = st.one_of(
     st.text(),
 )
 
-# Hashable leaves usable as dict keys and set elements: the primitives the
-# DictRelationalizer records structurally (str/int/float/bool) plus None (which
-# reify reconstructs from the atom type alone). nan is excluded on purpose — as
-# a key it is unlookupable, and because the datum memoizes equal atoms a dict or
-# set holding several *distinct* nan objects cannot round-trip its entry count
-# (two `nan` keys ── repr ── '{nan, nan}' collapse to one shared atom). inf is
-# kept: inf == inf, so it behaves like any ordinary key.
-hashable_atoms = st.one_of(
-    st.none(),
-    st.booleans(),
-    st.integers(),
-    st.floats(allow_nan=False, allow_infinity=True),
-    st.text(),
+# Hashable values usable as dict keys and set elements: primitives, None, and
+# tuples nested arbitrarily over those — DictRelationalizer walks every key, so
+# tuple keys keep their contents. nan is excluded on purpose: as a key it is
+# unlookupable, and because the datum memoizes equal atoms a dict or set holding
+# several *distinct* nan objects cannot round-trip its entry count (two `nan`
+# keys ── repr ── '{nan, nan}' collapse to one shared atom). inf is kept:
+# inf == inf, so it behaves like any ordinary key.
+hashable_atoms = st.recursive(
+    st.one_of(
+        st.none(),
+        st.booleans(),
+        st.integers(),
+        st.floats(allow_nan=False, allow_infinity=True),
+        st.text(),
+    ),
+    lambda children: st.lists(children).map(tuple),
+    max_leaves=8,
 )
 
 # Recursive structures whose repr is order-stable: lists, tuples (as values),
@@ -172,16 +175,13 @@ def test_nested_custom_object_repr_roundtrip(a, b, c):
 
 
 # ---------------------------------------------------------------------------
-# Known limitation (tracked): complex dict keys aren't walked on the build side
+# Complex dict keys: now walked structurally, so they keep their contents
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="DictRelationalizer emits a synthetic, un-walked key atom for "
-    "non-primitive dict keys (tuple/frozenset/object), so they reify to empty "
-    "shells. Build-side limitation; flip this test green when it's fixed.",
-)
-def test_complex_dict_key_is_known_limitation():
-    value = {("a", "b"): 1}
+def test_complex_dict_key_roundtrip():
+    # Regression for the build-side bug where a non-primitive dict key got a
+    # synthetic, un-walked key atom and reified to an empty shell ({('a','b'): 1}
+    # came back as {(): 1}). DictRelationalizer now walks every key.
+    value = {("a", "b"): 1, ("c",): 2}
     assert repr(_roundtrip(value)) == repr(value)


### PR DESCRIPTION
## What

`reify(build_instance(d))` lost the contents of any **non-primitive dict key**. A tuple/frozenset/object used as a key reified to an empty shell:

```python
reify(build_instance({('a', 'b'): 1}))   # -> {(): 1}   (was)
                                          # -> {('a', 'b'): 1}   (now)
```

Tuples as dict *values*, in lists, and in sets always round-tripped — the loss was specific to **keys**.

## Why

[`DictRelationalizer`](https://github.com/sidprasad/spytial/blob/main/spytial/domain_relationalizers/dict_relationalizer.py) special-cased keys: primitives were walked, but anything else got a **synthetic, un-walked key atom** (`type=type(k).__name__`, `label="key_N"`). That atom carried none of the key's structure — no tuple `t0`/`t1` relations, no object `__module__`/`__qualname__` — so reify had nothing to rebuild from and produced an empty value.

## Fix

Walk *every* key through the normal pipeline (`walker_func._walk(k)`), exactly as values are walked. Primitives still resolve to their primitive atoms; complex keys now record their nested structure and class identity, which reify already knows how to reconstruct. As a bonus, a key object that also appears elsewhere now shares a single atom (memoization) instead of being duplicated.

No visualization/format test changed — full suite stayed green.

## Found by the property-based tests

This was surfaced (and pinned with a strict-`xfail`) by the PBT suite in #102. This PR turns that `xfail` into a passing regression test and **broadens the dict-key / set-element strategy to include tuples of hashable atoms**, so the property now actively exercises complex keys (stress: 5k examples, clean). Plus focused example tests in `test/test_reify.py` (tuple key, nested tuple key, importable-object key).

## Scope / still out of scope

`frozenset` keys still reify to the attribute-bag proxy — but only because `frozenset` *itself* isn't reconstructed to a real `frozenset` (same as a `frozenset` value); that's the documented long tail, not this bug.

## Testing

Full suite: **126 passed, 1 skipped**. flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)