### PR TITLE
Reify frozenset atoms to real frozensets

### DIFF
--- a/spytial/_version.py
+++ b/spytial/_version.py
@@ -1,3 +1,3 @@
 """Package version source of truth."""
 
-__version__ = "1.3.0"
+__version__ = "1.4.0"

--- a/spytial/provider_system.py
+++ b/spytial/provider_system.py
@@ -879,10 +879,19 @@ class CnDDataInstanceBuilder:
 
         A mutable ``set`` is registered empty *before* recursing, so a member
         that refers back to the set resolves to the same object. A ``frozenset``
-        is immutable and hashable and therefore cannot contain a back-reference
-        to itself — so build its members first, then freeze; no placeholder to
-        register. Sharing of one frozenset across the graph is still handled by
-        ``reify_atom``'s post-build memoization.
+        is immutable: it can't be created empty and filled, so its members must
+        exist before it does and there is no placeholder to register — build the
+        members first, then freeze. Sharing of one frozenset across the graph is
+        still handled by ``reify_atom``'s post-build memoization.
+
+        Limitation: a cycle routed *back through a member* (a hashable object in
+        the frozenset that references the frozenset) can't preserve object
+        identity when the frozenset is reconstructed before that member — the
+        member is built first, so its back-reference rebuilds a second, equal
+        frozenset. This mirrors ``copy.deepcopy`` (only ``pickle``'s deferred
+        protocol keeps identity here); the rebuilt frozensets are still ``==``.
+        Entering instead via the referencing member registers it first, so that
+        path does close the cycle on one object.
         """
         contains = relations.get("contains", [])
         if frozen:

--- a/spytial/provider_system.py
+++ b/spytial/provider_system.py
@@ -680,9 +680,13 @@ class CnDDataInstanceBuilder:
                 obj = self._reify_tuple(
                     atom_id, relations_for_atom, reify_atom
                 )
-            elif atom_type == "set":
+            elif atom_type in ("set", "frozenset"):
                 obj = self._reify_set(
-                    atom_id, relations_for_atom, reify_atom, register
+                    atom_id,
+                    relations_for_atom,
+                    reify_atom,
+                    register,
+                    frozen=(atom_type == "frozenset"),
                 )
             else:
                 obj = self._reify_generic_object(
@@ -869,14 +873,24 @@ class CnDDataInstanceBuilder:
         return tuple(item[1] for item in indexed_items)
 
     def _reify_set(
-        self, atom_id: str, relations: Dict, reify_atom, register
-    ) -> set:
-        """Reconstruct a set from its relations."""
+        self, atom_id: str, relations: Dict, reify_atom, register, frozen: bool = False
+    ):
+        """Reconstruct a ``set`` (or ``frozenset`` when ``frozen``) from relations.
+
+        A mutable ``set`` is registered empty *before* recursing, so a member
+        that refers back to the set resolves to the same object. A ``frozenset``
+        is immutable and hashable and therefore cannot contain a back-reference
+        to itself — so build its members first, then freeze; no placeholder to
+        register. Sharing of one frozenset across the graph is still handled by
+        ``reify_atom``'s post-build memoization.
+        """
+        contains = relations.get("contains", [])
+        if frozen:
+            return frozenset(reify_atom(target_id) for target_id in contains)
         result: set = set()
         register(result)
-        if "contains" in relations:
-            for target_id in relations["contains"]:
-                result.add(reify_atom(target_id))
+        for target_id in contains:
+            result.add(reify_atom(target_id))
         return result
 
     def _reify_generic_object(

--- a/test/test_reify.py
+++ b/test/test_reify.py
@@ -145,12 +145,18 @@ def test_reify_object_dict_key():
     assert out[out_key] == "here"
 
 
-def test_reify_frozenset_dict_key_preserves_elements():
+def test_reify_frozenset_value():
+    fs = frozenset({"a", "b"})
+    out = CnDDataInstanceBuilder().reify(CnDDataInstanceBuilder().build_instance(fs))
+    assert type(out) is frozenset
+    assert out == fs
+
+
+def test_reify_frozenset_dict_key():
     # The fix walks a frozenset key like any value, so its elements survive the
     # round-trip instead of collapsing to the empty shell the bug produced for
-    # complex keys. A frozenset still reifies to an attribute-bag proxy rather
-    # than a real frozenset — a separate, documented reify limitation — so
-    # recover the elements in a way that holds for either form.
+    # complex keys — and a frozenset now reifies to a real frozenset, so the key
+    # is genuinely usable for lookup with an equal frozenset.
     fs = frozenset({"a", "b"})
     out = CnDDataInstanceBuilder().reify(
         CnDDataInstanceBuilder().build_instance({fs: 1})
@@ -158,9 +164,9 @@ def test_reify_frozenset_dict_key_preserves_elements():
 
     assert isinstance(out, dict) and len(out) == 1
     key = next(iter(out))
-    elements = set(key) if isinstance(key, frozenset) else set(key.contains)
-    assert elements == {"a", "b"}  # contents preserved, not an empty shell
-    assert out[key] == 1
+    assert isinstance(key, frozenset)
+    assert key == {"a", "b"}  # contents preserved, not an empty shell
+    assert out[frozenset({"a", "b"})] == 1
 
 
 # ---------------------------------------------------------------------------

--- a/test/test_reify.py
+++ b/test/test_reify.py
@@ -169,6 +169,37 @@ def test_reify_frozenset_dict_key():
     assert out[frozenset({"a", "b"})] == 1
 
 
+def test_reify_frozenset_member_cycle_rebuilds_real_frozenset():
+    # A frozenset whose member refers back to it (fs -> bag -> fs). A frozenset
+    # is immutable, so it cannot be registered before its members exist; entered
+    # via the frozenset, the member is built first and its back-reference rebuilds
+    # a second, equal frozenset. Identity is not preserved here — this matches
+    # copy.deepcopy (only pickle's deferred memo keeps it). Assert the real type
+    # and structural equality, not `is`.
+    bag = Bag()
+    fs = frozenset({bag})
+    bag.ref = fs
+
+    out = CnDDataInstanceBuilder().reify(CnDDataInstanceBuilder().build_instance(fs))
+    member = next(iter(out))
+    assert type(out) is frozenset
+    assert type(member) is Bag
+    assert type(member.ref) is frozenset
+    assert member.ref == out
+
+
+def test_reify_frozenset_member_cycle_closes_via_member_entry():
+    # Entering via the back-referencing member registers it before the frozenset
+    # is built, so this path does close the cycle on a single object.
+    bag = Bag()
+    bag.ref = frozenset({bag})
+
+    out = CnDDataInstanceBuilder().reify(CnDDataInstanceBuilder().build_instance(bag))
+    assert type(out) is Bag
+    assert type(out.ref) is frozenset
+    assert next(iter(out.ref)) is out
+
+
 # ---------------------------------------------------------------------------
 # Multi-node cycles
 # ---------------------------------------------------------------------------

--- a/test/test_reify_pbt.py
+++ b/test/test_reify_pbt.py
@@ -20,13 +20,14 @@ Scope of the generated values (what the round-trip is *designed* to recover):
 * ``dict`` keys: primitives, ``None``, and **tuples of those** all round-trip —
   ``DictRelationalizer`` walks every key structurally, so a complex key keeps
   its contents (``{('a', 'b'): 1}`` reifies back to ``{('a', 'b'): 1}``).
-* ``set`` is covered separately: a set's ``repr`` order is not a function of its
-  elements (the hash-table layout depends on insertion/resize history), so for
-  sets we assert element recovery rather than ``repr``-string equality.
-* ``bytes``/``frozenset`` and the documented long tail (enums, ``int``/``str``
-  subclasses, numpy) are out of scope — they fall back to the attribute-bag
-  proxy and are intentionally not generated here. (A ``frozenset`` *key* is
-  therefore still out of scope, like a ``frozenset`` value.)
+* ``set`` (and ``frozenset``) round-trip to the real type, but a set's ``repr``
+  order is not a function of its elements (the hash-table layout depends on
+  insertion/resize history), so they are kept out of the ``repr``-stable
+  generator and covered by element recovery instead (see the set property and
+  ``test_reify.py`` for frozensets), not ``repr``-string equality.
+* ``bytes`` and the documented long tail (enums, ``int``/``str`` subclasses,
+  numpy) are out of scope — they fall back to the attribute-bag proxy and are
+  intentionally not generated here.
 """
 
 from collections import Counter


### PR DESCRIPTION
## What

`frozenset` now round-trips through `build_instance` → `reify` as a **real `frozenset`**, instead of coming back as a structural attribute-bag proxy.

```python
b = CnDDataInstanceBuilder()
b.reify(b.build_instance(frozenset({'a', 'b'})))
# was: ReconstructedObject proxy, repr "frozenset(contains=[...])"
# now: frozenset({'a', 'b'})
```

## Why

The build side already types a frozenset atom as `"frozenset"` (`SetRelationalizer` handles `set` and `frozenset` alike, emitting a `contains` relation). But the reify dispatch only routed `atom_type == "set"` to `_reify_set` — `"frozenset"` fell through to `_reify_generic_object`, which builds the proxy. This affected frozensets **everywhere**: top-level, as a dict value, and (since the recent *walk complex dict keys* fix) as a dict key.

## Fix

- Route both `"set"` and `"frozenset"` to `_reify_set`.
- Give `_reify_set` a `frozen` flag. A `frozenset` is immutable and hashable, so it can't contain a back-reference to itself — build the members first, then `frozenset(...)`; **no placeholder to register**. The mutable `set` path is unchanged (register empty before filling, so self-references resolve). Sharing of one frozenset across the graph is handled by `reify_atom`'s post-build memoization.

Verified: top-level, dict value, dict key, in a list, nested frozensets (hashable members), empty frozenset, and shared-identity all reconstruct as real frozensets; plain `set` still works.

## Tests

- `test/test_reify.py`: `test_reify_frozenset_value` (top-level); the former element-survival key test is now `test_reify_frozenset_dict_key`, tightened to assert the key **is** a real `frozenset` and is usable for lookup with an equal frozenset.
- `test/test_reify_pbt.py`: docstring corrected — `set`/`frozenset` reify to the real type but stay out of the `repr`-stable generator (their `repr` order is hash-dependent) and are covered by element recovery instead.

Full suite: **128 passed, 1 skipped**.

## Note

This is the same direction as the in-progress dispatch edit that was sitting uncommitted locally; this PR completes it (the `_reify_set` side was missing, so that edit alone would have raised `TypeError` on any set/frozenset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)