### PR TITLE
Update spytial-core to 2.9.0; bump 1.4.1 -> 1.5.0

### DIFF
--- a/spytial/_version.py
+++ b/spytial/_version.py
@@ -1,3 +1,3 @@
 """Package version source of truth."""
 
-__version__ = "1.4.1"
+__version__ = "1.5.0"

--- a/spytial/core_assets.py
+++ b/spytial/core_assets.py
@@ -1,6 +1,6 @@
 """Shared spytial-core browser asset definitions for HTML templates."""
 
-SPYTIAL_CORE_VERSION = "2.7.1"
+SPYTIAL_CORE_VERSION = "2.9.0"
 
 _CDN_BASE = f"https://cdn.jsdelivr.net/npm/spytial-core@{SPYTIAL_CORE_VERSION}"
 

--- a/test/test_data_instance_format.py
+++ b/test/test_data_instance_format.py
@@ -1,5 +1,5 @@
 """
-Tests that build_instance() output matches the spytial-core v2.7.1 IJsonDataInstance format.
+Tests that build_instance() output matches the spytial-core v2.9.0 IJsonDataInstance format.
 
 See spytial-core/docs/JSON_DATA_INSTANCE.md for the canonical spec.
 """


### PR DESCRIPTION
## Summary
- Bump bundled `spytial-core` from `2.7.1` → `2.9.0` (latest npm release) via `update-spytial-core.sh`, updating `spytial/core_assets.py` and the test docstring.
- Bump package minor version `1.4.1` → `1.5.0` in `spytial/_version.py`.

Merging this to `main` updates `spytial/_version.py`, which triggers the automated PyPI publish workflow (see [PUBLISHING.md](PUBLISHING.md)).

## Test plan
- `python -m pytest` → 130 passed, 1 skipped locally.
- CI must pass before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)