### PR TITLE
docs: open Playground links in a new tab

### DIFF
--- a/docs/javascripts/playground-newtab.js
+++ b/docs/javascripts/playground-newtab.js
@@ -1,0 +1,19 @@
+// Open any link to the in-browser Playground in a new tab/window, so readers
+// don't lose their place in the docs (and don't reload Pyodide on back-nav).
+(function () {
+  function mark() {
+    document.querySelectorAll("a[href]").forEach(function (a) {
+      var href = a.getAttribute("href") || "";
+      if (/(^|\/)playground\/(index\.html)?($|[?#])/.test(href)) {
+        a.target = "_blank";
+        a.rel = "noopener";
+      }
+    });
+  }
+  // Material exposes `document$`; fall back to a plain load listener.
+  if (typeof window.document$ !== "undefined" && window.document$.subscribe) {
+    window.document$.subscribe(mark);
+  } else {
+    document.addEventListener("DOMContentLoaded", mark);
+  }
+})();

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,9 @@ markdown_extensions:
 extra_css:
   - stylesheets/extra.css
 
+extra_javascript:
+  - javascripts/playground-newtab.js
+
 watch:
   - spytial
   - docs


### PR DESCRIPTION
Opening the in-browser Playground now happens in a **new tab/window**, so readers don't lose their place in the docs (and don't reload Pyodide on back-navigation).

A small script (`docs/javascripts/playground-newtab.js`) marks every link whose href points to `/playground/` with `target="_blank" rel="noopener"`. This covers the **nav tab** and all in-content links uniformly, with no hardcoded URLs — it works locally and on the deployed site.

Verified: build clean, script copied + referenced, and the matched hrefs are `playground/` (home) and `../playground/` (sub-pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)