### PR TITLE
Fix id()-reuse leak in object annotation / id registries

### DIFF
--- a/spytial/annotations.py
+++ b/spytial/annotations.py
@@ -6,6 +6,7 @@
 import yaml
 import re
 import json
+import weakref
 
 
 class NoAliasDumper(yaml.Dumper):
@@ -57,11 +58,95 @@ OBJECT_ANNOTATIONS_ATTR = "__spytial_object_annotations__"
 # Object ID storage attribute name (for self-reference)
 OBJECT_ID_ATTR = "__spytial_object_id__"
 
+_MISSING = object()
+
+
+class _IdentityKeyedRegistry:
+    """A process-global map keyed by object identity, safe against id reuse.
+
+    Some built-in values (``list``, ``dict``, ``tuple``) can store neither a
+    marker attribute nor a weak reference, so any per-object state for them must
+    live in a module-global map. Keying that map by raw ``id(obj)`` is unsafe:
+    once the object is garbage-collected its id can be reused by a brand-new
+    object, which would then silently inherit the dead object's entry.
+
+    Each entry therefore retains a *reference* to the object it belongs to:
+
+    * weak-referenceable objects (``set``, custom instances) get a ``weakref``
+      whose finalizer evicts the entry the instant the object dies — so its id
+      is never simultaneously freed and still mapped;
+    * objects that support neither attribute storage nor weakref (``list``,
+      ``dict``, ``tuple``) get a *strong* reference, which pins the id for as
+      long as the entry lives, so the id cannot be reused while it is mapped.
+
+    Lookups additionally verify object identity, so even under a reused id no
+    object can ever read another object's value. Keys are ``id(obj)`` ints, so
+    unhashable objects (lists, dicts) are fine.
+    """
+
+    def __init__(self):
+        # id(obj) -> (holder, is_weak, value); holder is a weakref or the obj.
+        self._entries = {}
+
+    def _live_object(self, entry):
+        holder, is_weak, _value = entry
+        return holder() if is_weak else holder
+
+    def _make_evictor(self, oid):
+        def _evict(dead_ref):
+            entry = self._entries.get(oid)
+            # Only drop the entry if it still belongs to the object that died,
+            # never a newer entry that reused the id.
+            if entry is not None and entry[0] is dead_ref:
+                del self._entries[oid]
+
+        return _evict
+
+    def _store(self, obj, value):
+        oid = id(obj)
+        try:
+            holder = weakref.ref(obj, self._make_evictor(oid))
+            is_weak = True
+        except TypeError:
+            # Cannot weak-reference this type (list/dict/tuple/...). Hold a
+            # strong reference: it pins the id so reuse is impossible.
+            holder = obj
+            is_weak = False
+        self._entries[oid] = (holder, is_weak, value)
+
+    def get(self, obj, default=None):
+        entry = self._entries.get(id(obj))
+        if entry is None:
+            return default
+        if self._live_object(entry) is obj:
+            return entry[2]
+        # Stale: a reused id (or a dead weakref not yet finalized). Evict.
+        self._entries.pop(id(obj), None)
+        return default
+
+    def __contains__(self, obj):
+        return self.get(obj, _MISSING) is not _MISSING
+
+    def get_or_create(self, obj, factory):
+        existing = self.get(obj, _MISSING)
+        if existing is not _MISSING:
+            return existing
+        value = factory()
+        self._store(obj, value)
+        return value
+
+    def set(self, obj, value):
+        self._store(obj, value)
+
+    def clear(self):
+        self._entries.clear()
+
+
 # Global registry for objects that can't store annotations directly
-_OBJECT_ANNOTATION_REGISTRY = {}
+_OBJECT_ANNOTATION_REGISTRY = _IdentityKeyedRegistry()
 
 # Global registry for object IDs (for objects that can't store attributes)
-_OBJECT_ID_REGISTRY = {}
+_OBJECT_ID_REGISTRY = _IdentityKeyedRegistry()
 
 # Counter for generating unique object IDs
 _OBJECT_ID_COUNTER = 0
@@ -616,19 +701,24 @@ def list_type_alias_annotations():
 
 def reset_object_ids():
     """
-    Reset the global object ID state. Useful for testing or when you need
+    Reset the global object-level state. Useful for testing or when you need
     deterministic object ID generation across multiple runs.
 
-    Warning: This will clear all existing object ID mappings, so existing
-    selectors that depend on previous object IDs may no longer work.
+    Clears both global registries — object IDs and object annotations — for the
+    built-in values that can't store that state on themselves.
+
+    Warning: This will clear all existing object ID mappings and any
+    annotations recorded for un-attributable objects, so existing selectors
+    that depend on previous object IDs may no longer work.
     """
-    global _OBJECT_ID_COUNTER, _OBJECT_ID_REGISTRY
+    global _OBJECT_ID_COUNTER
     _OBJECT_ID_COUNTER = 0
     _OBJECT_ID_REGISTRY.clear()
+    _OBJECT_ANNOTATION_REGISTRY.clear()
 
-    # Also clear object ID attributes from any objects that have them
-    # Note: We can't easily find all objects that have the attribute,
-    # so this is a best-effort cleanup of the global registry only.
+    # Note: object ID / annotation *attributes* stored on attributable objects
+    # are left intact; we can't enumerate them, so this clears the global
+    # registries only.
 
 
 def _get_or_create_object_id(obj):
@@ -647,9 +737,9 @@ def _get_or_create_object_id(obj):
         pass
 
     # Check global registry for objects that can't store attributes
-    obj_python_id = id(obj)
-    if obj_python_id in _OBJECT_ID_REGISTRY:
-        return _OBJECT_ID_REGISTRY[obj_python_id]
+    existing = _OBJECT_ID_REGISTRY.get(obj)
+    if existing is not None:
+        return existing
 
     # Create new unique ID
     _OBJECT_ID_COUNTER += 1
@@ -660,7 +750,7 @@ def _get_or_create_object_id(obj):
         setattr(obj, OBJECT_ID_ATTR, unique_id)
     except (AttributeError, TypeError):
         # Object doesn't support attribute assignment, use global registry
-        _OBJECT_ID_REGISTRY[obj_python_id] = unique_id
+        _OBJECT_ID_REGISTRY.set(obj, unique_id)
 
     return unique_id
 
@@ -843,11 +933,10 @@ def _ensure_object_registry(obj):
         return getattr(obj, OBJECT_ANNOTATIONS_ATTR)
     except (AttributeError, TypeError):
         # Object doesn't support attribute assignment (e.g., built-in types)
-        # Use global registry instead
-        obj_id = id(obj)
-        if obj_id not in _OBJECT_ANNOTATION_REGISTRY:
-            _OBJECT_ANNOTATION_REGISTRY[obj_id] = {"constraints": [], "directives": []}
-        return _OBJECT_ANNOTATION_REGISTRY[obj_id]
+        # Use the identity-keyed global registry instead.
+        return _OBJECT_ANNOTATION_REGISTRY.get_or_create(
+            obj, lambda: {"constraints": [], "directives": []}
+        )
 
 
 def _annotate_object(obj, annotation_type, **kwargs):
@@ -1076,9 +1165,8 @@ def collect_decorators(obj, type_hint=None):
         combined_registry["directives"].extend(object_registry["directives"])
 
     # Then check global registry for objects that can't store attributes
-    obj_id = id(obj)
-    if obj_id in _OBJECT_ANNOTATION_REGISTRY:
-        object_registry = _OBJECT_ANNOTATION_REGISTRY[obj_id]
+    object_registry = _OBJECT_ANNOTATION_REGISTRY.get(obj)
+    if object_registry is not None:
         combined_registry["constraints"].extend(object_registry["constraints"])
         combined_registry["directives"].extend(object_registry["directives"])
 

--- a/spytial/provider_system.py
+++ b/spytial/provider_system.py
@@ -380,11 +380,12 @@ class CnDDataInstanceBuilder:
                     spytial_id = getattr(obj, OBJECT_ID_ATTR)
                     self._seen[oid] = spytial_id
                     return spytial_id
-                # Then check global registry
-                elif oid in _OBJECT_ID_REGISTRY:
-                    spytial_id = _OBJECT_ID_REGISTRY[oid]
-                    self._seen[oid] = spytial_id
-                    return spytial_id
+                # Then check the identity-keyed global registry
+                else:
+                    spytial_id = _OBJECT_ID_REGISTRY.get(obj)
+                    if spytial_id is not None:
+                        self._seen[oid] = spytial_id
+                        return spytial_id
             except ImportError:
                 pass
 

--- a/test/test_annotation_registry_isolation.py
+++ b/test/test_annotation_registry_isolation.py
@@ -1,0 +1,169 @@
+"""Object-annotation / object-id registries must not leak across `id()` reuse.
+
+Built-in values that can't store attributes (list, dict, tuple, set) keep their
+annotations and self-reference ids in process-global maps. Those maps used to be
+keyed by raw ``id(obj)``, so once an annotated object was garbage-collected a new
+object could reuse its id and silently inherit the dead object's annotations.
+
+The fix keys those maps through ``_IdentityKeyedRegistry``, which retains a
+reference to each object (a weakref with an evicting finalizer where possible, a
+strong reference that pins the id otherwise) and verifies identity on read.
+"""
+
+import gc
+
+import pytest
+
+import spytial.annotations as ann
+from spytial.annotations import (
+    _IdentityKeyedRegistry,
+    annotate_orientation,
+    annotate_group,
+    collect_decorators,
+    reset_object_ids,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_registries():
+    reset_object_ids()
+    yield
+    reset_object_ids()
+
+
+# ---------------------------------------------------------------------------
+# Unit tests on the registry helper
+# ---------------------------------------------------------------------------
+
+
+def test_weakreffable_entry_is_evicted_on_gc():
+    reg = _IdentityKeyedRegistry()
+
+    class Obj:  # weak-referenceable
+        pass
+
+    o = Obj()
+    reg.set(o, "v")
+    assert reg.get(o) == "v"
+    assert len(reg._entries) == 1
+
+    del o
+    gc.collect()
+    # The weakref finalizer drops the entry the moment the object dies, so its
+    # id can never be both freed and still mapped.
+    assert len(reg._entries) == 0
+
+
+def test_unweakreffable_entry_is_pinned_by_strong_ref():
+    reg = _IdentityKeyedRegistry()
+    lst = [1, 2, 3]  # lists support neither setattr nor weakref
+    reg.set(lst, "v")
+    assert reg.get(lst) == "v"
+
+    del lst
+    gc.collect()
+    # A list can't be weak-referenced, so the registry holds it strongly: the
+    # entry (and the object's id) is pinned, which is what prevents reuse.
+    assert len(reg._entries) == 1
+
+    reg.clear()
+    assert len(reg._entries) == 0
+
+
+def test_identity_guard_rejects_foreign_object():
+    reg = _IdentityKeyedRegistry()
+    a = [1]
+    reg.set(a, "A")
+    assert a in reg
+    # A different object never reads A's value.
+    assert reg.get([1]) is None
+    assert ([1] in reg) is False
+
+
+def test_reused_id_does_not_leak():
+    # Deterministically emulate id reuse: move an entry so an id slot maps to a
+    # value whose stored object is *not* the one we look up under that id.
+    reg = _IdentityKeyedRegistry()
+
+    class Box:
+        pass
+
+    keeper = Box()
+    reg.set(keeper, "keeper-value")
+    other = Box()
+    reg._entries[id(other)] = reg._entries.pop(id(keeper))
+
+    # id(other) now maps to an entry whose live object is `keeper`, not `other`.
+    assert reg.get(other) is None             # identity guard rejects it
+    assert id(other) not in reg._entries       # and evicts the stale slot
+
+
+# ---------------------------------------------------------------------------
+# End-to-end through the public annotate_* / collect_decorators API
+# ---------------------------------------------------------------------------
+
+
+def test_fresh_builtins_never_inherit_phantom_annotations():
+    a = {"x": 1}
+    annotate_orientation(a, selector="k", directions=["horizontal"])
+    assert len(collect_decorators(a)["constraints"]) == 1
+
+    # Many fresh, never-annotated builtins must all come back clean — even if
+    # one reuses the id of a value created earlier in this loop.
+    for _ in range(200):
+        assert collect_decorators({"y": 2})["constraints"] == []
+        assert collect_decorators([0, 0])["constraints"] == []
+        assert collect_decorators((9, 9))["constraints"] == []
+
+
+def test_set_annotation_evicted_after_gc():
+    s = {1, 2, 3}  # set: weak-referenceable, not attribute-storable
+    annotate_group(s, field="elements", groupOn=0, addToGroup=1)
+    assert len(collect_decorators(s)["constraints"]) == 1
+
+    before = len(ann._OBJECT_ANNOTATION_REGISTRY._entries)
+    assert before == 1
+    del s
+    gc.collect()
+    assert len(ann._OBJECT_ANNOTATION_REGISTRY._entries) == before - 1
+
+
+def test_distinct_builtins_keep_independent_annotations():
+    a = [1, 2, 3]
+    b = [1, 2, 3]  # equal but distinct object
+    annotate_orientation(a, selector="a", directions=["horizontal"])
+    annotate_orientation(b, selector="b", directions=["vertical"])
+
+    a_sel = collect_decorators(a)["constraints"][0]["orientation"]["selector"]
+    b_sel = collect_decorators(b)["constraints"][0]["orientation"]["selector"]
+    assert a_sel == "a"
+    assert b_sel == "b"
+    assert len(collect_decorators(a)["constraints"]) == 1
+    assert len(collect_decorators(b)["constraints"]) == 1
+
+
+def test_reset_object_ids_clears_annotation_registry():
+    a = [1, 2]
+    annotate_orientation(a, selector="items", directions=["horizontal"])
+    assert collect_decorators(a)["constraints"]
+
+    reset_object_ids()
+    # reset now clears the annotation registry too, not just the id registry.
+    assert collect_decorators(a)["constraints"] == []
+
+
+def test_self_reference_id_resolves_via_global_id_registry():
+    # A set can't store the id attribute, so its self-reference id lives in the
+    # global id registry — exercising the provider_system get_id path that reads
+    # _OBJECT_ID_REGISTRY (previously uncovered).
+    from spytial.annotations import orientation
+    from spytial.provider_system import CnDDataInstanceBuilder
+
+    s = orientation(selector="self", directions=["below"])({1, 2, 3})
+    sel = collect_decorators(s)["constraints"][0]["orientation"]["selector"]
+    assert "obj_" in sel  # an id was assigned and stored in the global registry
+
+    # Walking the set resolves its id through _OBJECT_ID_REGISTRY.get(obj)
+    # without raising (regression guard for the helper migration).
+    di = CnDDataInstanceBuilder().build_instance({"s": s})
+    assert di["atoms"]

--- a/test/test_object_annotations.py
+++ b/test/test_object_annotations.py
@@ -24,7 +24,6 @@ def test_object_annotations_basic():
     assert decorators['constraints'][0]['orientation']['selector'] == 'items'
     print("✓ Basic object annotation works")
 
-@pytest.mark.skip(reason="Global registry for built-in types can leak across objects; skipping until registry isolation is fixed.")
 def test_object_annotations_builtin_types():
     """Test object annotations with built-in types that can't store attributes."""
     print("=== Testing Built-in Types (set, tuple, etc.) ===")


### PR DESCRIPTION
## The bug
Built-in values that can't store attributes (`list`, `dict`, `tuple`, `set`) keep their object-level annotations and self-reference ids in two process-global maps (`_OBJECT_ANNOTATION_REGISTRY`, `_OBJECT_ID_REGISTRY` in `spytial/annotations.py`). Both were keyed by **raw `id(obj)`**. Once an annotated object is garbage-collected, a new object can reuse its `id()` and **silently inherit the dead object's annotations**.

This was latent/test-only (hence the `@pytest.mark.skip` on `test_object_annotations_builtin_types`), but it becomes a real correctness risk alongside the generalized input path in #114: `spytial.edit(...)` / `_generate_cnd_spec` run `collect_decorators` on arbitrary builtins, so a user could annotate one list, let it be collected, then `edit()` a new list that reuses the id and picks up stale constraints.

## The fix
Route **both** registries through a new `_IdentityKeyedRegistry` that retains a reference to each object and verifies identity on read, so an id can never be simultaneously freed and still mapped:

- **weak-referenceable objects** (`set`, custom instances) → a `weakref` whose finalizer evicts the entry the instant the object dies. Annotation lifetime tracks object lifetime, as requested.
- **objects that support neither `setattr` nor `weakref`** (`list`, `dict`, `tuple`) → a **strong reference**, which pins the id so it can't be reused.

> ⚠️ **The obvious `weakref`-key approach does not work here.** The task suggested keying by `weakref.ref(obj)` "since lists and dicts can be weak-referenced" — empirically they **cannot**: `list`, `dict`, `tuple`, `int`, `str` support neither `setattr` nor `weakref` (only `set`, custom classes, and subclasses do). So `WeakKeyDictionary`/weakref-keying is impossible for the exact types that need the global registry; the strong-ref-pins-the-id fallback is the correct treatment for them.

A read-time **identity guard** (`stored_obj is obj`) backs both paths, so even a reused id returns the default, never another object's value.

## Trade-off (deliberate)
Annotating an un-weak-referenceable builtin (`list`/`dict`/`tuple`) now **pins it** until `reset_object_ids()`. Bounded by the number of explicitly-annotated such objects, and `reset_object_ids()` now clears the annotation registry too (it previously cleared only ids), giving a public release valve. Correctness over a small, bounded memory cost — the alternative is the leak.

## Also in this PR
- **`provider_system.py` get_id** read the id registry via `oid in ... / [oid]` (an already-computed id int). Migrated to `_OBJECT_ID_REGISTRY.get(obj)` — this would otherwise have broken against the new registry, and the path (`set`/`list` self-reference ids) was previously **uncovered by tests**.
- **Un-skip `test_object_annotations_builtin_types`** — it tested exactly this leak; it now passes. The root-cause fix also makes the suite order-independent (weak-referenceable annotations auto-evict on GC; un-weak-referenceable ones are identity-guarded), so no test-level isolation fixture is needed.
- **New `test/test_annotation_registry_isolation.py`** (9 tests): weakref eviction on GC, strong-ref pinning, identity guard, deterministic reused-id rejection, fresh-builtin isolation across 200 allocations, `reset_object_ids` clearing annotations, and the self-reference-via-global-registry `build_instance` path.

## Verification
Full suite: **139 passed** (Python 3.9, CPython).

## Relationship to other work
Independent of #114 and based on `main` — this is a `main` bug regardless of the input generalization. #114 is what makes it user-reachable. (Spawned from the follow-up flagged on #114.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
