### PR TITLE
Optional LLM shape enrichment for spytial.suggest (orientation / cyclic / group)

### DIFF
--- a/docs/suggest.md
+++ b/docs/suggest.md
@@ -1,9 +1,10 @@
 # Suggesting specs
 
 `spytial.suggest` reads a class and proposes a starting set of layout
-directives — a lightweight scaffold you then edit, not a finished spec. It is
-pure static analysis: no LLM, no network, no extra dependencies. The whole point
-is to get you past the blank page.
+directives — a lightweight scaffold you then edit, not a finished spec. By
+default it is pure static analysis: no LLM, no network, no extra dependencies
+(an optional model-backed enrichment layer is described [below](#optional-llm-enrichment)).
+The whole point is to get you past the blank page.
 
 It lives in its own subpackage and is **not** imported by `spytial` itself, so
 you opt in:
@@ -113,11 +114,52 @@ def color_by_status(field, cls_info):
 - Pass `suggest(cls, registry=my_registry)` to run an isolated rule set, or use
   `DEFAULT_REGISTRY.copy()` to start from the built-ins and add to them.
 
+## Optional: LLM enrichment
+
+The deterministic core gets the *structure* right but punts on taste — enum
+colors come from an arbitrary built-in palette. The optional enrichment layer
+fills those in semantically, behind the `[suggest-llm]` extra:
+
+```bash
+pip install "spytial_diagramming[suggest-llm]"
+llm install llm-anthropic        # or llm-gemini, llm-openai, llm-ollama, …
+llm keys set anthropic           # llm owns key management; spytial doesn't
+```
+
+```python
+draft = suggest(RBNode, enrich=True)              # uses your default llm model
+draft = suggest(RBNode, enrich=True, enrich_model="claude-sonnet-4-6")
+```
+
+It depends on [`llm`](https://llm.datasette.io/) (Simon Willison's) rather than a
+single provider SDK, so you choose the model — Claude, GPT, Gemini, a local model
+via Ollama — and `llm` handles the keys.
+
+The design is deliberately conservative, in one sentence: **the model never
+writes a selector.** Spytial selectors are Alloy/Forge relational expressions; a
+model gets them subtly wrong and there is no in-Python validator to catch it (the
+engine runs in the browser). So enrichment only substitutes *values* into the
+selectors the deterministic rules already generated and render-verified — today,
+one color per enum member. Consequences:
+
+- **Type-level first.** Enum members are read statically, so `enrich=True` needs
+  no instance.
+- **You pick.** Enriched rows are tagged `source="llm"` (a `model` chip in the
+  notebook panel) and stay **off by default** — they are candidates, never
+  applied behind your back.
+- **It can't break `suggest()`.** No `llm` installed, no model configured, or a
+  malformed response each degrade to the static draft with a note in
+  `draft.notes` — never an exception.
+
+Unfamiliar domain naming and freeform structural selectors (the heap) are *not*
+done here — that needs the datum schema, an instance, and render-verification,
+and is left for a later, hard-gated tier.
+
 ## Limits
 
 `suggest` infers structure from fields and references. It cannot recover
 structure that lives in *computation* — an array-backed heap whose tree is
 implied by index arithmetic, for example — and it will say so in `draft.notes`
-rather than invent edges. Semantic color palettes and unfamiliar domain naming
-are deliberately left to you (or a future enrichment layer); the deterministic
-core aims to get the structure right and the rest close enough to edit.
+rather than invent edges. Unfamiliar domain naming is still left to you (or the
+enrichment tier above); the deterministic core aims to get the structure right
+and the rest close enough to edit.

--- a/docs/suggest.md
+++ b/docs/suggest.md
@@ -116,9 +116,11 @@ def color_by_status(field, cls_info):
 
 ## Optional: LLM enrichment
 
-The deterministic core gets the *structure* right but punts on taste — enum
-colors come from an arbitrary built-in palette. The optional enrichment layer
-fills those in semantically, behind the `[suggest-llm]` extra:
+The deterministic rules key off a fixed name vocabulary — `left`/`right`,
+`next`/`prev`, `parent`/`children` — and fall back to a flat `below` for any
+self-reference they don't recognize. The optional enrichment layer asks a model
+to suggest the *spatial shape* of those fields instead, behind the
+`[suggest-llm]` extra:
 
 ```bash
 pip install "spytial_diagramming[suggest-llm]"
@@ -127,39 +129,42 @@ llm keys set anthropic           # llm owns key management; spytial doesn't
 ```
 
 ```python
-draft = suggest(RBNode, enrich=True)              # uses your default llm model
-draft = suggest(RBNode, enrich=True, enrich_model="claude-sonnet-4-6")
+draft = suggest(Ticket, enrich=True)              # uses your default llm model
+draft = suggest(Ticket, enrich=True, enrich_model="claude-sonnet-4-6")
 ```
 
 It depends on [`llm`](https://llm.datasette.io/) (Simon Willison's) rather than a
 single provider SDK, so you choose the model — Claude, GPT, Gemini, a local model
 via Ollama — and `llm` handles the keys.
 
-The design is deliberately conservative, in one sentence: **the model never
-writes a selector.** Spytial selectors are Alloy/Forge relational expressions; a
-model gets them subtly wrong and there is no in-Python validator to catch it (the
-engine runs in the browser). So enrichment only substitutes *values* into the
-selectors the deterministic rules already generated and render-verified — today,
-one color per enum member. Consequences:
+It suggests **shape**: an `orientation` direction per structural field, `cyclic`
+for ring-like links, and `group` for collections. So a field named `escalation`
+— which the rules can only lay out `below` — gets a model-proposed `above`,
+because the model reads the name. The key line: **the model picks the shape, not
+the selector.** It chooses a direction from a fixed vocabulary; spytial builds the
+selector from the field, reusing the same render-verified forms the deterministic
+rules emit. That's what keeps it schema-level and safe:
 
-- **Type-level first.** Enum members are read statically, so `enrich=True` needs
+- **Type-level first.** It reasons over the class's fields, so `enrich=True` needs
   no instance.
 - **You pick.** Enriched rows are tagged `source="llm"` (a `model` chip in the
-  notebook panel) and stay **off by default** — they are candidates, never
-  applied behind your back.
+  notebook panel) and stay **off by default** — candidates beside the
+  deterministic ones, never applied behind your back.
 - **It can't break `suggest()`.** No `llm` installed, no model configured, or a
   malformed response each degrade to the static draft with a note in
-  `draft.notes` — never an exception.
+  `draft.notes` — never an exception. Choices that name an unknown field or an
+  out-of-vocabulary direction are dropped.
 
-Unfamiliar domain naming and freeform structural selectors (the heap) are *not*
-done here — that needs the datum schema, an instance, and render-verification,
-and is left for a later, hard-gated tier.
+Letting the model write actual selectors is a separate, future extension: a
+selector can only be *validated* by evaluating it over a data instance (the
+engine has no schema-only mode), so that tier belongs with a **set of example
+instances** to check against — not here, where there may be no instance at all.
 
 ## Limits
 
 `suggest` infers structure from fields and references. It cannot recover
 structure that lives in *computation* — an array-backed heap whose tree is
 implied by index arithmetic, for example — and it will say so in `draft.notes`
-rather than invent edges. Unfamiliar domain naming is still left to you (or the
-enrichment tier above); the deterministic core aims to get the structure right
-and the rest close enough to edit.
+rather than invent edges. The deterministic core aims to get the structure right
+and the rest close enough to edit; the [enrichment tier](#optional-llm-enrichment)
+above helps with the spatial shape of unfamiliar fields.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,12 +52,15 @@ dev = [
 e2e = [
     "playwright>=1.40",
 ]
-# Future home for the optional LLM enrichment layer of spytial.suggest
-# (semantic palettes, unfamiliar domain naming). The static analyzer needs none
-# of this — it is stdlib-only. Uncomment and pin a provider when that lands:
-# suggest-llm = [
-#     "anthropic>=0.40",
-# ]
+# Optional LLM enrichment layer for spytial.suggest (semantic enum palettes today).
+# The static analyzer needs none of this — it is stdlib-only and the default path.
+# We depend on `llm` (Simon Willison's) rather than a single provider SDK: it is
+# provider-agnostic (Claude, GPT, Gemini, local Ollama via plugins) and owns key
+# management, so spytial stays unopinionated. Install a provider plugin separately,
+# e.g. `llm install llm-anthropic`. (`llm` itself requires Python >=3.10.)
+suggest-llm = [
+    "llm>=0.23",
+]
 docs = [
     "mkdocs>=1.5.0",
     "mkdocs-material>=9.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,8 +52,9 @@ dev = [
 e2e = [
     "playwright>=1.40",
 ]
-# Optional LLM enrichment layer for spytial.suggest (semantic enum palettes today).
-# The static analyzer needs none of this — it is stdlib-only and the default path.
+# Optional LLM enrichment layer for spytial.suggest (spatial-shape suggestions:
+# orientation / cyclic / group over structural fields). The static analyzer needs
+# none of this — it is stdlib-only and the default path.
 # We depend on `llm` (Simon Willison's) rather than a single provider SDK: it is
 # provider-agnostic (Claude, GPT, Gemini, local Ollama via plugins) and owns key
 # management, so spytial stays unopinionated. Install a provider plugin separately,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,9 @@ e2e = [
 # management, so spytial stays unopinionated. Install a provider plugin separately,
 # e.g. `llm install llm-anthropic`. (`llm` itself requires Python >=3.10.)
 suggest-llm = [
-    "llm>=0.23",
+    # `llm` requires Python >=3.10; the marker keeps the extra installable (just
+    # inert) on the project's 3.8/3.9 floor rather than erroring at resolution.
+    "llm>=0.23; python_version >= '3.10'",
 ]
 docs = [
     "mkdocs>=1.5.0",

--- a/spytial/suggest/__init__.py
+++ b/spytial/suggest/__init__.py
@@ -57,11 +57,14 @@ def suggest(
         registry: an alternate :class:`HeuristicRegistry`; defaults to the global
             one populated with the built-in rules.
         enrich: opt into the optional LLM enrichment layer (the ``[suggest-llm]``
-            extra). It only *fills values* into selectors the deterministic rules
-            already generated — today, semantic colors for enum members in place of
-            the arbitrary built-in palette. The model never writes a selector;
-            enriched rows are tagged ``source="llm"`` and stay off by default, so
-            they are candidates you pick. Degrades to the static draft (with a note)
+            extra). It suggests the *spatial shape* of the structure — orientation
+            directions per structural field, ``cyclic`` for ring-like links, and
+            ``group`` for collections — filling the gap where the deterministic rules
+            fall back to a flat ``below`` for fields outside their name vocabulary.
+            The model only chooses the shape; spytial supplies the (render-verified)
+            selector from the field, so this stays schema-level and needs no
+            instance. Enriched rows are tagged ``source="llm"`` and stay off by
+            default — candidates you pick. Degrades to the static draft (with a note)
             if ``llm`` isn't installed or no model is configured — never raises.
         enrich_model: an ``llm`` model id (e.g. ``"claude-sonnet-4-6"``); defaults
             to your configured ``llm`` default model. Ignored unless ``enrich``.

--- a/spytial/suggest/__init__.py
+++ b/spytial/suggest/__init__.py
@@ -45,6 +45,7 @@ def suggest(
     instance: Any = None,
     registry: Optional[HeuristicRegistry] = None,
     enrich: bool = False,
+    enrich_model: Optional[str] = None,
 ) -> SpecDraft:
     """Analyze a class and return a :class:`SpecDraft` of proposed directives.
 
@@ -55,15 +56,16 @@ def suggest(
             can't recover.
         registry: an alternate :class:`HeuristicRegistry`; defaults to the global
             one populated with the built-in rules.
-        enrich: reserved for the optional LLM enrichment layer (semantic palettes,
-            unfamiliar domain naming). Not yet implemented.
+        enrich: opt into the optional LLM enrichment layer (the ``[suggest-llm]``
+            extra). It only *fills values* into selectors the deterministic rules
+            already generated — today, semantic colors for enum members in place of
+            the arbitrary built-in palette. The model never writes a selector;
+            enriched rows are tagged ``source="llm"`` and stay off by default, so
+            they are candidates you pick. Degrades to the static draft (with a note)
+            if ``llm`` isn't installed or no model is configured — never raises.
+        enrich_model: an ``llm`` model id (e.g. ``"claude-sonnet-4-6"``); defaults
+            to your configured ``llm`` default model. Ignored unless ``enrich``.
     """
-    if enrich:
-        raise NotImplementedError(
-            "LLM enrichment is not implemented yet. The static analyzer needs no "
-            "extra dependencies; when enrichment lands it will live behind the "
-            "'spytial_diagramming[suggest-llm]' extra."
-        )
     if isinstance(target, type):
         cls = target
     else:
@@ -73,4 +75,9 @@ def suggest(
 
     reg = registry if registry is not None else DEFAULT_REGISTRY
     class_info = build_class_info(cls, instance=instance)
-    return build_draft(class_info, reg)
+    draft = build_draft(class_info, reg)
+    if enrich:
+        from ._enrich import enrich_draft
+
+        draft = enrich_draft(draft, class_info, model=enrich_model)
+    return draft

--- a/spytial/suggest/_enrich.py
+++ b/spytial/suggest/_enrich.py
@@ -1,32 +1,45 @@
-"""Optional LLM *enrichment* for ``spytial.suggest`` (the ``[suggest-llm]`` extra).
+"""Optional LLM *shape* enrichment for ``spytial.suggest`` (the ``[suggest-llm]``
+extra).
 
-Dormant unless you call ``suggest(..., enrich=True)``. The deterministic analyzer
-needs none of this.
+Dormant unless you call ``suggest(..., enrich=True)``. This tier is **schema-level**:
+it reasons over the class's structural fields, not a data instance, so it needs no
+datum — only the model call.
 
-The cardinal rule here: **the model never writes a relational selector.** Spytial
-selectors are Alloy/Forge relational expressions (``{ p : T, c : T | c in p.left }``,
-``left - (univ -> NoneType)``, ``@:(x.color.name) = RED``) — easy for a model to get
-subtly wrong, and there is no in-Python validator to catch it (spytial-core runs in
-the browser). So enrichment only fills *values* into directives whose selectors the
-deterministic rules already generated and render-verified. Today that is one thing:
-semantic colors for enum members, replacing the arbitrary built-in palette. The
-worst a bad model response can do is propose an ugly color — never an illegal
-selector.
+What it does: suggest the *spatial shape* of a structure — how each structural
+field orients in space (``orientation`` directions), whether a self-reference forms
+a ring (``cyclic``), and whether a collection's elements should be boxed together
+(``group``). This is exactly where the deterministic rules are weakest: they key off
+a fixed name vocabulary (left/right/next/prev/parent/children) and fall back to a
+flat ``below`` for anything else. A model reads ``escalation`` / ``downstream`` /
+``reportsTo`` and proposes a direction that matches the meaning.
 
-Everything degrades to the static draft. No ``llm`` installed, no model/key
-configured, or a malformed response each append a note and return the draft
-unchanged — enrichment can never crash ``suggest()``. And because enriched rows are
-tagged ``source="llm"`` and stay off by default, they are *candidates you pick*, not
-directives applied behind your back.
+What it deliberately does **not** do: write a selector. Spytial selectors are
+Alloy/Forge relational expressions, and validating one requires a datum the schema
+doesn't have — the evaluator only runs over a data instance. (Letting the model
+author selectors, checked against real instances, is a separate, instance-set-based
+extension.) So here the model only chooses the *shape*; spytial supplies the
+selector from the field, reusing the same render-verified forms the deterministic
+rules emit. That keeps the tier safe by construction at the type level.
+
+Enriched rows are tagged ``source="llm"``, stay off by default (you pick), and every
+failure path — no ``llm`` installed, no model configured, malformed output — degrades
+to the static draft with a note. Enrichment can never crash ``suggest()``.
 """
 
 from __future__ import annotations
 
 import json
-from typing import Dict, List, Optional
+from typing import List, Optional
 
 from ._model import ClassInfo, SpecDraft, Suggestion
-from .rules import enum_member_selector
+from .rules import _children_selector, _edge_selector
+
+# Render-verified spatial vocabularies the model picks from. Validated in Python
+# (not just declared in the schema) so a provider that ignores nested enums can't
+# slip an unknown token into a directive.
+_ORIENT_DIRS = ("below", "above", "left", "right", "directlyRight", "directlyLeft")
+_CYCLIC_DIRS = ("clockwise", "counterclockwise")
+_CONTAINERS = ("list", "tuple", "set", "dict")
 
 _INSTALL_HINT = (
     "enrich=True needs the optional 'llm' library. Install it with "
@@ -35,47 +48,57 @@ _INSTALL_HINT = (
     "llm provider plugin). Returning the static draft unchanged."
 )
 
-# A fixed-shape schema (a flat list, not an open-ended map) so it round-trips
-# across llm provider plugins whose structured-output support rejects
-# ``additionalProperties``.
-_PALETTE_SCHEMA = {
+_SHAPE_SCHEMA = {
     "type": "object",
     "properties": {
-        "assignments": {
+        "shapes": {
             "type": "array",
             "items": {
                 "type": "object",
                 "properties": {
                     "field": {"type": "string"},
-                    "member": {"type": "string"},
-                    "color": {
+                    "constraint": {
                         "type": "string",
-                        "description": (
-                            "A CSS color name or #hex. Empty string if no "
-                            "conventional color fits."
-                        ),
+                        "enum": ["orientation", "cyclic", "group", "none"],
                     },
+                    "directions": {
+                        "type": "array",
+                        "items": {"type": "string", "enum": list(_ORIENT_DIRS)},
+                    },
+                    "direction": {"type": "string", "enum": list(_CYCLIC_DIRS)},
+                    "why": {"type": "string"},
                 },
-                "required": ["field", "member", "color"],
+                "required": ["field", "constraint", "why"],
             },
         }
     },
-    "required": ["assignments"],
+    "required": ["shapes"],
 }
 
-_PALETTE_PROMPT = """\
-You choose display colors for enum members in a structure diagram. You ONLY choose \
-colors — never write code, selectors, or any other text. Prefer conventional \
-associations: RED->red, BLACK->#222, GREEN->seagreen, BLUE->steelblue, \
-ACTIVE/OK/SUCCESS->seagreen, ERROR/FAIL->crimson, WARNING/PENDING->goldenrod, \
-INACTIVE/DISABLED->#999. If a member has no conventional color, return an empty \
-string for it and it will keep the default palette.
+_SHAPE_PROMPT = """\
+You suggest the spatial SHAPE of a data structure for a diagram — how each
+structural field lays out. You do NOT write selectors or code; you only pick a shape
+per field from a fixed vocabulary, and spytial draws the selector itself.
+
+For each structural field choose exactly one constraint:
+- orientation: the field is a directional edge. Give 1-2 directions from
+  [below, above, left, right, directlyRight, directlyLeft]. A tree child -> below;
+  a forward/"next" link -> right; a parent/back link -> above.
+- cyclic: the field forms a ring or cycle (circular list, ring buffer). Give a
+  direction (clockwise / counterclockwise). Only for single-pointer fields.
+- group: the field is a collection whose elements should be boxed together. Only
+  for container fields (list/tuple/set/dict).
+- none: no clear spatial meaning. This is the preferred answer when unsure.
+
+Read the field NAME for meaning: reportsTo/manager/escalation -> above;
+downstream/child -> below or right; sibling/peer -> right. When in doubt, choose
+none — suggest less, not more.
 
 Class: {cls}
-Enum fields and their members:
+Structural fields:
 {fields}
 
-Return exactly one assignment per (field, member) pair listed above."""
+Return one entry per field listed above."""
 
 
 def _import_llm():
@@ -88,14 +111,18 @@ def _import_llm():
         return None
 
 
+def _structural_fields(ci: ClassInfo) -> List:
+    """Non-private self-referential fields — the structural edges shape applies to."""
+    return [f for f in ci.fields if f.is_self_ref and not f.is_private]
+
+
 def enrich_draft(
     draft: SpecDraft, class_info: ClassInfo, *, model: Optional[str] = None
 ) -> SpecDraft:
-    """Augment a :class:`SpecDraft` with model-chosen values; returns the draft.
+    """Augment a :class:`SpecDraft` with model-suggested spatial shape.
 
-    Any failure — missing dependency, no configured model, malformed output —
-    leaves the deterministic suggestions untouched and records a note in
-    ``draft.notes``. The draft is mutated in place and also returned.
+    Returns the same draft, mutated in place. Any failure leaves the deterministic
+    suggestions untouched and records a note in ``draft.notes``.
     """
     llm = _import_llm()
     if llm is None:
@@ -111,77 +138,105 @@ def enrich_draft(
         return draft
 
     try:
-        _enrich_palette(draft, class_info, m)
+        _enrich_shape(draft, class_info, m)
     except Exception as exc:  # noqa: BLE001 — never crash suggest() on enrichment
-        draft.notes.append(f"enrich=True: color enrichment skipped ({exc}).")
+        draft.notes.append(f"enrich=True: shape enrichment skipped ({exc}).")
     return draft
 
 
-def _enrich_palette(draft: SpecDraft, ci: ClassInfo, model) -> None:
-    """Replace the built-in palette guesses for enum fields with semantic colors."""
-    enum_fields: Dict[str, List[str]] = {
-        f.name: list(f.enum_members)
-        for f in ci.fields
-        if f.enum_members and not f.is_private
-    }
-    if not enum_fields:
-        return  # nothing to color; don't spend a model call
+def _enrich_shape(draft: SpecDraft, ci: ClassInfo, model) -> None:
+    fields = _structural_fields(ci)
+    if not fields:
+        return  # nothing structural to shape; don't spend a model call
 
-    colors = _ask_palette(model, ci.cls.__name__, enum_fields)
-    if not colors:
-        return
-
-    type_name = ci.cls.__name__
-    draft.suggestions = [
-        s
-        for s in draft.suggestions
-        if not (s.directive == "atomColor" and s.source_field in enum_fields)
-    ]
-    for field_name, members in enum_fields.items():
-        chosen = colors.get(field_name, {})
-        for member in members:
-            color = chosen.get(member)
-            if not color:
-                continue  # no conventional color — keep the default (drop the row)
-            draft.suggestions.append(
-                Suggestion(
-                    "atomColor",
-                    {
-                        "selector": enum_member_selector(type_name, field_name, member),
-                        "value": color,
-                    },
-                    "medium",
-                    f"{field_name} = {member} -> {color} (semantic, model-chosen)",
-                    field_name,
-                    enabled_by_default=False,
-                    source="llm",
-                )
-            )
+    shapes = _ask_shapes(model, ci, fields)
+    _apply_shapes(draft, ci, fields, shapes)
 
 
-def _ask_palette(
-    model, cls_name: str, enum_fields: Dict[str, List[str]]
-) -> Dict[str, Dict[str, str]]:
-    """Prompt the model for one color per (field, member); validate the response.
-
-    Returns ``{field: {member: color}}``, keeping only non-empty colors for
-    (field, member) pairs we actually asked about — so a model can't smuggle in a
-    field/member (and therefore a selector) we never offered.
-    """
-    field_lines = "\n".join(
-        f"- {field}: {', '.join(members)}" for field, members in enum_fields.items()
-    )
-    prompt = _PALETTE_PROMPT.format(cls=cls_name, fields=field_lines)
-    response = model.prompt(prompt, schema=_PALETTE_SCHEMA)
+def _ask_shapes(model, ci: ClassInfo, fields: List) -> List[dict]:
+    """Prompt the model for a shape per structural field; return the raw list."""
+    lines = []
+    for f in fields:
+        kind = f.container if f.container else "single pointer"
+        nullable = "yes" if f.has_none_default else "no"
+        lines.append(
+            f"- {f.name}: type={f.type_repr or '?'}, kind={kind}, nullable={nullable}"
+        )
+    prompt = _SHAPE_PROMPT.format(cls=ci.cls.__name__, fields="\n".join(lines))
+    response = model.prompt(prompt, schema=_SHAPE_SCHEMA)
     data = json.loads(response.text())
+    shapes = data.get("shapes", [])
+    return [s for s in shapes if isinstance(s, dict)]
 
-    out: Dict[str, Dict[str, str]] = {}
-    for assignment in data.get("assignments", []):
-        if not isinstance(assignment, dict):
+
+def _apply_shapes(draft: SpecDraft, ci: ClassInfo, fields: List, shapes: List) -> None:
+    """Turn validated shape choices into off-by-default, model-tagged suggestions.
+
+    Every selector is built by spytial from the field (the render-verified form the
+    deterministic rules use), never by the model. Choices that name an unknown field,
+    an out-of-vocabulary direction, or a constraint that doesn't fit the field's kind
+    are dropped — schema-level validation, no datum required.
+    """
+    by_name = {f.name: f for f in fields}
+    cls = ci.cls.__name__
+    seen = {_key(s) for s in draft.suggestions}
+
+    for sh in shapes:
+        f = by_name.get(sh.get("field"))
+        if f is None:
+            continue  # model named a field we didn't analyze — drop it
+        sug = _shape_to_suggestion(ci, cls, f, sh)
+        if sug is None:
             continue
-        field = assignment.get("field")
-        member = assignment.get("member")
-        color = str(assignment.get("color") or "").strip()
-        if color and field in enum_fields and member in enum_fields[field]:
-            out.setdefault(field, {})[member] = color
-    return out
+        key = _key(sug)
+        if key in seen:
+            continue  # don't duplicate a directive the deterministic rules emitted
+        seen.add(key)
+        draft.suggestions.append(sug)
+
+
+def _shape_to_suggestion(ci: ClassInfo, cls: str, f, sh: dict) -> Optional[Suggestion]:
+    kind = sh.get("constraint")
+    why = (sh.get("why") or "").strip()
+    rationale = f"{f.name}: {why}" if why else f"{f.name}: model-suggested shape"
+
+    if kind == "orientation":
+        dirs = [d for d in (sh.get("directions") or []) if d in _ORIENT_DIRS][:2]
+        if not dirs:
+            return None
+        if f.container in _CONTAINERS:
+            selector = _children_selector(cls, f.name, f.container)
+        else:
+            selector = _edge_selector(ci, f.name)
+        kwargs = {"selector": selector, "directions": dirs}
+    elif kind == "cyclic":
+        if f.container is not None:
+            return None  # a ring is over a single pointer, not a collection
+        direction = sh.get("direction")
+        if direction not in _CYCLIC_DIRS:
+            return None
+        kwargs = {"selector": _edge_selector(ci, f.name), "direction": direction}
+    elif kind == "group":
+        if f.container not in _CONTAINERS:
+            return None  # group boxes the elements of a collection
+        kwargs = {"field": f.name, "groupOn": 0, "addToGroup": 1}
+    else:
+        return None  # 'none' or anything unrecognized — abstain
+
+    return Suggestion(
+        kind,
+        kwargs,
+        "low",
+        rationale,
+        f.name,
+        enabled_by_default=False,
+        source="llm",
+    )
+
+
+def _key(s: Suggestion):
+    return (
+        s.directive,
+        s.source_field,
+        json.dumps(s.kwargs, sort_keys=True, default=str),
+    )

--- a/spytial/suggest/_enrich.py
+++ b/spytial/suggest/_enrich.py
@@ -1,0 +1,187 @@
+"""Optional LLM *enrichment* for ``spytial.suggest`` (the ``[suggest-llm]`` extra).
+
+Dormant unless you call ``suggest(..., enrich=True)``. The deterministic analyzer
+needs none of this.
+
+The cardinal rule here: **the model never writes a relational selector.** Spytial
+selectors are Alloy/Forge relational expressions (``{ p : T, c : T | c in p.left }``,
+``left - (univ -> NoneType)``, ``@:(x.color.name) = RED``) — easy for a model to get
+subtly wrong, and there is no in-Python validator to catch it (spytial-core runs in
+the browser). So enrichment only fills *values* into directives whose selectors the
+deterministic rules already generated and render-verified. Today that is one thing:
+semantic colors for enum members, replacing the arbitrary built-in palette. The
+worst a bad model response can do is propose an ugly color — never an illegal
+selector.
+
+Everything degrades to the static draft. No ``llm`` installed, no model/key
+configured, or a malformed response each append a note and return the draft
+unchanged — enrichment can never crash ``suggest()``. And because enriched rows are
+tagged ``source="llm"`` and stay off by default, they are *candidates you pick*, not
+directives applied behind your back.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Dict, List, Optional
+
+from ._model import ClassInfo, SpecDraft, Suggestion
+from .rules import enum_member_selector
+
+_INSTALL_HINT = (
+    "enrich=True needs the optional 'llm' library. Install it with "
+    'pip install "spytial_diagramming[suggest-llm]" and configure a model '
+    "(e.g. `llm install llm-anthropic && llm keys set anthropic`, or any other "
+    "llm provider plugin). Returning the static draft unchanged."
+)
+
+# A fixed-shape schema (a flat list, not an open-ended map) so it round-trips
+# across llm provider plugins whose structured-output support rejects
+# ``additionalProperties``.
+_PALETTE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "assignments": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "field": {"type": "string"},
+                    "member": {"type": "string"},
+                    "color": {
+                        "type": "string",
+                        "description": (
+                            "A CSS color name or #hex. Empty string if no "
+                            "conventional color fits."
+                        ),
+                    },
+                },
+                "required": ["field", "member", "color"],
+            },
+        }
+    },
+    "required": ["assignments"],
+}
+
+_PALETTE_PROMPT = """\
+You choose display colors for enum members in a structure diagram. You ONLY choose \
+colors — never write code, selectors, or any other text. Prefer conventional \
+associations: RED->red, BLACK->#222, GREEN->seagreen, BLUE->steelblue, \
+ACTIVE/OK/SUCCESS->seagreen, ERROR/FAIL->crimson, WARNING/PENDING->goldenrod, \
+INACTIVE/DISABLED->#999. If a member has no conventional color, return an empty \
+string for it and it will keep the default palette.
+
+Class: {cls}
+Enum fields and their members:
+{fields}
+
+Return exactly one assignment per (field, member) pair listed above."""
+
+
+def _import_llm():
+    """Return the ``llm`` module, or ``None`` if the extra isn't installed."""
+    try:
+        import llm  # type: ignore
+
+        return llm
+    except ImportError:
+        return None
+
+
+def enrich_draft(
+    draft: SpecDraft, class_info: ClassInfo, *, model: Optional[str] = None
+) -> SpecDraft:
+    """Augment a :class:`SpecDraft` with model-chosen values; returns the draft.
+
+    Any failure — missing dependency, no configured model, malformed output —
+    leaves the deterministic suggestions untouched and records a note in
+    ``draft.notes``. The draft is mutated in place and also returned.
+    """
+    llm = _import_llm()
+    if llm is None:
+        draft.notes.append(_INSTALL_HINT)
+        return draft
+
+    try:
+        m = llm.get_model(model) if model else llm.get_model()
+    except Exception as exc:  # noqa: BLE001 — any provider/config error degrades
+        draft.notes.append(
+            f"enrich=True: no usable llm model ({exc}); returning the static draft."
+        )
+        return draft
+
+    try:
+        _enrich_palette(draft, class_info, m)
+    except Exception as exc:  # noqa: BLE001 — never crash suggest() on enrichment
+        draft.notes.append(f"enrich=True: color enrichment skipped ({exc}).")
+    return draft
+
+
+def _enrich_palette(draft: SpecDraft, ci: ClassInfo, model) -> None:
+    """Replace the built-in palette guesses for enum fields with semantic colors."""
+    enum_fields: Dict[str, List[str]] = {
+        f.name: list(f.enum_members)
+        for f in ci.fields
+        if f.enum_members and not f.is_private
+    }
+    if not enum_fields:
+        return  # nothing to color; don't spend a model call
+
+    colors = _ask_palette(model, ci.cls.__name__, enum_fields)
+    if not colors:
+        return
+
+    type_name = ci.cls.__name__
+    draft.suggestions = [
+        s
+        for s in draft.suggestions
+        if not (s.directive == "atomColor" and s.source_field in enum_fields)
+    ]
+    for field_name, members in enum_fields.items():
+        chosen = colors.get(field_name, {})
+        for member in members:
+            color = chosen.get(member)
+            if not color:
+                continue  # no conventional color — keep the default (drop the row)
+            draft.suggestions.append(
+                Suggestion(
+                    "atomColor",
+                    {
+                        "selector": enum_member_selector(type_name, field_name, member),
+                        "value": color,
+                    },
+                    "medium",
+                    f"{field_name} = {member} -> {color} (semantic, model-chosen)",
+                    field_name,
+                    enabled_by_default=False,
+                    source="llm",
+                )
+            )
+
+
+def _ask_palette(
+    model, cls_name: str, enum_fields: Dict[str, List[str]]
+) -> Dict[str, Dict[str, str]]:
+    """Prompt the model for one color per (field, member); validate the response.
+
+    Returns ``{field: {member: color}}``, keeping only non-empty colors for
+    (field, member) pairs we actually asked about — so a model can't smuggle in a
+    field/member (and therefore a selector) we never offered.
+    """
+    field_lines = "\n".join(
+        f"- {field}: {', '.join(members)}" for field, members in enum_fields.items()
+    )
+    prompt = _PALETTE_PROMPT.format(cls=cls_name, fields=field_lines)
+    response = model.prompt(prompt, schema=_PALETTE_SCHEMA)
+    data = json.loads(response.text())
+
+    out: Dict[str, Dict[str, str]] = {}
+    for assignment in data.get("assignments", []):
+        if not isinstance(assignment, dict):
+            continue
+        field = assignment.get("field")
+        member = assignment.get("member")
+        color = str(assignment.get("color") or "").strip()
+        if color and field in enum_fields and member in enum_fields[field]:
+            out.setdefault(field, {})[member] = color
+    return out

--- a/spytial/suggest/_enrich.py
+++ b/spytial/suggest/_enrich.py
@@ -199,6 +199,11 @@ def _shape_to_suggestion(ci: ClassInfo, cls: str, f, sh: dict) -> Optional[Sugge
     kind = sh.get("constraint")
     why = (sh.get("why") or "").strip()
     rationale = f"{f.name}: {why}" if why else f"{f.name}: model-suggested shape"
+    # Directives over the original field relation carry source_field=f.name; a
+    # derived (parent, child) edge over a container carries None, matching
+    # rules.child_container — so identical suggestions de-dup and same-field
+    # exclusivity grouping stays correct.
+    source_field = f.name
 
     if kind == "orientation":
         dirs = [d for d in (sh.get("directions") or []) if d in _ORIENT_DIRS][:2]
@@ -206,6 +211,7 @@ def _shape_to_suggestion(ci: ClassInfo, cls: str, f, sh: dict) -> Optional[Sugge
             return None
         if f.container in _CONTAINERS:
             selector = _children_selector(cls, f.name, f.container)
+            source_field = None  # derived edge, not the container relation itself
         else:
             selector = _edge_selector(ci, f.name)
         kwargs = {"selector": selector, "directions": dirs}
@@ -228,7 +234,7 @@ def _shape_to_suggestion(ci: ClassInfo, cls: str, f, sh: dict) -> Optional[Sugge
         kwargs,
         "low",
         rationale,
-        f.name,
+        source_field,
         enabled_by_default=False,
         source="llm",
     )

--- a/spytial/suggest/_html.py
+++ b/spytial/suggest/_html.py
@@ -24,6 +24,12 @@ def _row(suggestion, dim: bool = False) -> str:
     badge_fg = "#0c447c" if state == "on" else "#888780"
     badge_border = "none" if state == "on" else "0.5px solid #b4b2a9"
     kwargs = ", ".join(f"{k}={v!r}" for k, v in suggestion.kwargs.items())
+    model_tag = (
+        '<span style="font-size:10px;color:#6b4fbb;background:#f1ecfa;'
+        'padding:1px 6px;border-radius:5px;flex:none;">model</span>'
+        if getattr(suggestion, "source", "rule") == "llm"
+        else ""
+    )
     return (
         f'<div style="display:flex;align-items:center;gap:10px;padding:8px 10px;'
         f'border:0.5px solid #e3e1d9;border-radius:8px;opacity:{opacity};margin-bottom:6px;">'
@@ -32,6 +38,7 @@ def _row(suggestion, dim: bool = False) -> str:
         f"<div>@spytial.{_esc(suggestion.directive)}({_esc(kwargs)})</div>"
         f'<div style="font-family:inherit;font-size:11px;color:#5f5e5a;font-style:italic;">'
         f"{_esc(suggestion.rationale)}</div></div>"
+        f"{model_tag}"
         f'<span style="font-size:11px;color:{badge_fg};background:{badge_bg};'
         f'border:{badge_border};padding:2px 8px;border-radius:6px;flex:none;">{state}</span>'
         f"</div>"
@@ -42,6 +49,8 @@ def render_html(draft: SpecDraft) -> str:
     cls_name = _esc(draft.cls.__name__)
     enabled = draft.enabled()
     speculative = [s for s in draft.suggestions if not s.enabled_by_default]
+    has_llm = any(getattr(s, "source", "rule") == "llm" for s in draft.suggestions)
+    provenance = "analysis + model" if has_llm else "analysis only · no model"
 
     parts = [
         '<div style="max-width:680px;border:0.5px solid #d3d1c7;border-radius:12px;'
@@ -49,7 +58,7 @@ def render_html(draft: SpecDraft) -> str:
         f'<div style="display:flex;justify-content:space-between;align-items:baseline;margin-bottom:2px;">'
         f'<span style="font-family:ui-monospace,Menlo,monospace;font-size:14px;color:#2c2c2a;">'
         f"spytial.suggest({cls_name})</span>"
-        f'<span style="font-size:11px;color:#888780;">analysis only · no model</span></div>',
+        f'<span style="font-size:11px;color:#888780;">{provenance}</span></div>',
         f'<div style="font-size:12px;color:#5f5e5a;margin-bottom:14px;">'
         f"{len(draft.suggestions)} proposed · "
         f"{len(enabled)} on by default · edit, then copy or .apply()</div>",

--- a/spytial/suggest/_model.py
+++ b/spytial/suggest/_model.py
@@ -61,6 +61,7 @@ class Suggestion:
     rationale: str = ""  # human-readable "why" — teaches the directive language
     source_field: Optional[str] = None
     enabled_by_default: Optional[bool] = None
+    source: str = "rule"  # 'rule' (deterministic) | 'llm' (model-enriched value)
 
     def __post_init__(self) -> None:
         if self.enabled_by_default is None:

--- a/spytial/suggest/rules.py
+++ b/spytial/suggest/rules.py
@@ -52,6 +52,20 @@ _PALETTE = [
 ]
 
 
+def enum_member_selector(type_name: str, field_name: str, member: str) -> str:
+    """Selector matching atoms whose enum ``field`` equals ``member``.
+
+    An Enum member relationalizes to an atom whose display label is not the member
+    name, so ``@:(x.field)`` won't match it — join through the member's ``name``
+    relation: ``@:(x.field.name)`` reads the ``'RED'``/``'BLACK'`` string atom.
+
+    Public because the optional LLM enrichment layer reuses this exact (render-
+    verified) selector and only substitutes the color *value*; the model never
+    authors relational syntax itself.
+    """
+    return "{ x : %s | @:(x.%s.name) = %s }" % (type_name, field_name, member)
+
+
 def _self_ref_names(ci: ClassInfo) -> set:
     # Private fields are skipped by the relationalizers, so their edges never
     # render — exclude them so no structural rule targets a missing relation.
@@ -334,10 +348,7 @@ def enum_color(field: FieldInfo, ci: ClassInfo) -> List[Suggestion]:
     out: List[Suggestion] = []
     for i, member in enumerate(field.enum_members):
         color = _PALETTE[i % len(_PALETTE)]
-        # An Enum member relationalizes to an atom whose display label is not the
-        # member name, so @:(x.field) won't match it — join through the member's
-        # `name` relation: @:(x.field.name) reads the 'RED'/'BLACK' string atom.
-        selector = "{ x : %s | @:(x.%s.name) = %s }" % (type_name, field.name, member)
+        selector = enum_member_selector(type_name, field.name, member)
         out.append(
             Suggestion(
                 "atomColor",

--- a/spytial/suggest/rules.py
+++ b/spytial/suggest/rules.py
@@ -59,9 +59,9 @@ def enum_member_selector(type_name: str, field_name: str, member: str) -> str:
     name, so ``@:(x.field)`` won't match it — join through the member's ``name``
     relation: ``@:(x.field.name)`` reads the ``'RED'``/``'BLACK'`` string atom.
 
-    Public because the optional LLM enrichment layer reuses this exact (render-
-    verified) selector and only substitutes the color *value*; the model never
-    authors relational syntax itself.
+    Factored out (rather than inlined in :func:`enum_color`) so this exact, render-
+    verified form lives in one place — reusable by custom heuristics or tooling that
+    needs to match an enum member.
     """
     return "{ x : %s | @:(x.%s.name) = %s }" % (type_name, field_name, member)
 

--- a/test/test_suggest.py
+++ b/test/test_suggest.py
@@ -682,11 +682,22 @@ def test_enrich_orientation_over_container_uses_children_selector(monkeypatch):
     payload = {"shapes": [_shape("related", "orientation", directions=["right"])]}
     monkeypatch.setattr(_enrich_mod, "_import_llm", lambda: _fake_llm(payload))
     draft = suggest(Ticket, enrich=True)
+    # The derived (parent, child) edge carries source_field=None — matching
+    # rules.child_container — so it de-dups and groups like the deterministic one.
     assert any(
         s.kwargs
         == {"selector": _child_edge("Ticket", "related"), "directions": ["right"]}
+        and s.source_field is None
         for s in _of(draft, "orientation")
     )
+
+
+def test_enrich_container_orientation_dedups_against_deterministic(monkeypatch):
+    # The rules already orient `related` children below (derived edge, source_field
+    # None); an identical model suggestion must collapse, not slip past _key().
+    payload = {"shapes": [_shape("related", "orientation", directions=["below"])]}
+    monkeypatch.setattr(_enrich_mod, "_import_llm", lambda: _fake_llm(payload))
+    assert not _of(suggest(Ticket, enrich=True), "orientation")
 
 
 def test_enrich_cyclic_over_single_pointer(monkeypatch):

--- a/test/test_suggest.py
+++ b/test/test_suggest.py
@@ -9,18 +9,20 @@ path the introspector has to handle.
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import List, Optional
 
 import spytial
+import spytial.suggest._enrich as _enrich_mod
 from spytial.suggest import (
     HeuristicRegistry,
     Suggestion,
     build_class_info,
     suggest,
 )
-from spytial.suggest.rules import _LIST_HIDE
+from spytial.suggest.rules import _LIST_HIDE, enum_member_selector
 
 
 # --------------------------------------------------------------------------- #
@@ -594,3 +596,146 @@ def test_custom_registry_is_isolated_from_default():
     # nothing registered -> nothing suggested, proving the default registry
     # didn't leak in.
     assert draft.suggestions == []
+
+
+# --------------------------------------------------------------------------- #
+# 7. Optional LLM enrichment (mocked — never touches a network or the llm dep)
+# --------------------------------------------------------------------------- #
+
+
+class _FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def text(self):
+        return json.dumps(self._payload)
+
+
+class _FakeModel:
+    def __init__(self, payload, calls=None):
+        self._payload = payload
+        self._calls = calls
+
+    def prompt(self, prompt, schema=None):
+        if self._calls is not None:
+            self._calls.append({"prompt": prompt, "schema": schema})
+        return _FakeResponse(self._payload)
+
+
+def _fake_llm(payload, calls=None, seen_model=None):
+    class _LLM:
+        @staticmethod
+        def get_model(name=None):
+            if seen_model is not None:
+                seen_model.append(name)
+            return _FakeModel(payload, calls)
+
+    return _LLM
+
+
+def _atomcolors(draft):
+    return [s for s in draft.suggestions if s.directive == "atomColor"]
+
+
+def test_enrich_missing_llm_degrades_with_note(monkeypatch):
+    # `llm` not installed is the real default; assert a clean no-op + a note that
+    # points at the extra, rather than a crash.
+    monkeypatch.setattr(_enrich_mod, "_import_llm", lambda: None)
+    base = _atomcolors(suggest(RBNode, instance=_rb_instance()))
+    draft = suggest(RBNode, instance=_rb_instance(), enrich=True)
+    assert [s.kwargs["value"] for s in _atomcolors(draft)] == [
+        s.kwargs["value"] for s in base
+    ]
+    assert all(s.source == "rule" for s in _atomcolors(draft))
+    assert any("suggest-llm" in n for n in draft.notes)
+
+
+def test_enrich_palette_swaps_in_semantic_colors(monkeypatch):
+    payload = {
+        "assignments": [
+            {"field": "color", "member": "RED", "color": "red"},
+            {"field": "color", "member": "BLACK", "color": "#222"},
+        ]
+    }
+    monkeypatch.setattr(_enrich_mod, "_import_llm", lambda: _fake_llm(payload))
+    draft = suggest(RBNode, instance=_rb_instance(), enrich=True)
+    by_sel = {s.kwargs["selector"]: s.kwargs["value"] for s in _atomcolors(draft)}
+    assert by_sel[enum_member_selector("RBNode", "color", "RED")] == "red"
+    assert by_sel[enum_member_selector("RBNode", "color", "BLACK")] == "#222"
+    # model-sourced, still off by default (you pick), and the selectors are exactly
+    # the verified ones the deterministic rule generated — the model only colors.
+    assert _atomcolors(draft) and all(s.source == "llm" for s in _atomcolors(draft))
+    assert all(not s.enabled_by_default for s in _atomcolors(draft))
+    base = _atomcolors(suggest(RBNode, instance=_rb_instance()))
+    assert {s.kwargs["selector"] for s in base} == set(by_sel)
+
+
+def test_enrich_works_at_type_level_without_instance(monkeypatch):
+    # The headline property: enrichment needs no instance — enum members are read
+    # statically, so suggest(cls, enrich=True) enriches a bare class.
+    payload = {"assignments": [{"field": "color", "member": "RED", "color": "red"}]}
+    monkeypatch.setattr(_enrich_mod, "_import_llm", lambda: _fake_llm(payload))
+    draft = suggest(RBNode, enrich=True)
+    reds = [s for s in _atomcolors(draft) if s.kwargs["value"] == "red"]
+    assert reds and reds[0].source == "llm"
+
+
+def test_enrich_no_enum_fields_never_calls_model(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        _enrich_mod, "_import_llm", lambda: _fake_llm({"assignments": []}, calls)
+    )
+    draft = suggest(BTreeNode, enrich=True)  # no enum field anywhere
+    assert calls == []  # abstain — don't spend a model call when there's nothing
+    assert not _atomcolors(draft)
+
+
+def test_enrich_ignores_unrequested_field_member(monkeypatch):
+    # A model that names a field/member we never offered must not inject a row
+    # (and therefore can't smuggle in a selector for something we didn't analyze).
+    payload = {
+        "assignments": [
+            {"field": "color", "member": "RED", "color": "red"},
+            {"field": "bogus", "member": "X", "color": "lime"},
+            {"field": "color", "member": "NOTAMEMBER", "color": "lime"},
+        ]
+    }
+    monkeypatch.setattr(_enrich_mod, "_import_llm", lambda: _fake_llm(payload))
+    draft = suggest(RBNode, instance=_rb_instance(), enrich=True)
+    values = {s.kwargs["value"] for s in _atomcolors(draft)}
+    assert "red" in values and "lime" not in values
+
+
+def test_enrich_bad_response_degrades(monkeypatch):
+    class _BadModel:
+        def prompt(self, prompt, schema=None):
+            class _R:
+                def text(self):
+                    return "not json {"
+
+            return _R()
+
+    class _LLM:
+        @staticmethod
+        def get_model(name=None):
+            return _BadModel()
+
+    monkeypatch.setattr(_enrich_mod, "_import_llm", lambda: _LLM)
+    base = _atomcolors(suggest(RBNode, instance=_rb_instance()))
+    draft = suggest(RBNode, instance=_rb_instance(), enrich=True)
+    # falls back to the built-in palette, records a note, and never raises
+    assert [s.kwargs["value"] for s in _atomcolors(draft)] == [
+        s.kwargs["value"] for s in base
+    ]
+    assert any("enrichment skipped" in n for n in draft.notes)
+
+
+def test_enrich_passes_through_model_id(monkeypatch):
+    seen = []
+    monkeypatch.setattr(
+        _enrich_mod,
+        "_import_llm",
+        lambda: _fake_llm({"assignments": []}, seen_model=seen),
+    )
+    suggest(RBNode, instance=_rb_instance(), enrich=True, enrich_model="claude-x")
+    assert seen == ["claude-x"]

--- a/test/test_suggest.py
+++ b/test/test_suggest.py
@@ -22,7 +22,7 @@ from spytial.suggest import (
     build_class_info,
     suggest,
 )
-from spytial.suggest.rules import _LIST_HIDE, enum_member_selector
+from spytial.suggest.rules import _LIST_HIDE
 
 
 # --------------------------------------------------------------------------- #
@@ -633,77 +633,123 @@ def _fake_llm(payload, calls=None, seen_model=None):
     return _LLM
 
 
-def _atomcolors(draft):
-    return [s for s in draft.suggestions if s.directive == "atomColor"]
+def _llm_rows(draft):
+    return [s for s in draft.suggestions if s.source == "llm"]
+
+
+def _of(draft, directive):
+    return [
+        s for s in draft.suggestions if s.directive == directive and s.source == "llm"
+    ]
+
+
+# An unfamiliar-named structure: `escalation` is a single self-ref pointer whose
+# name is outside the built-in vocabulary (the rules only manage a flat 'below'),
+# and `related` is a self-ref collection. Both are read statically — no instance.
+@dataclass
+class Ticket:
+    id: int = 0
+    escalation: Optional["Ticket"] = None
+    related: List["Ticket"] = field(default_factory=list)
+
+
+def _shape(field, constraint, **extra):
+    return {"field": field, "constraint": constraint, "why": "test", **extra}
 
 
 def test_enrich_missing_llm_degrades_with_note(monkeypatch):
-    # `llm` not installed is the real default; assert a clean no-op + a note that
-    # points at the extra, rather than a crash.
+    # `llm` not installed is the real default; assert a clean no-op + a note.
     monkeypatch.setattr(_enrich_mod, "_import_llm", lambda: None)
-    base = _atomcolors(suggest(RBNode, instance=_rb_instance()))
-    draft = suggest(RBNode, instance=_rb_instance(), enrich=True)
-    assert [s.kwargs["value"] for s in _atomcolors(draft)] == [
-        s.kwargs["value"] for s in base
-    ]
-    assert all(s.source == "rule" for s in _atomcolors(draft))
+    draft = suggest(Ticket, enrich=True)
+    assert not _llm_rows(draft)
     assert any("suggest-llm" in n for n in draft.notes)
 
 
-def test_enrich_palette_swaps_in_semantic_colors(monkeypatch):
+def test_enrich_orientation_for_unfamiliar_field(monkeypatch):
+    # The model picks a direction (above); spytial supplies the field-form selector.
+    payload = {"shapes": [_shape("escalation", "orientation", directions=["above"])]}
+    monkeypatch.setattr(_enrich_mod, "_import_llm", lambda: _fake_llm(payload))
+    draft = suggest(Ticket, enrich=True)
+    assert any(
+        s.kwargs == {"selector": _edge("escalation"), "directions": ["above"]}
+        and s.source == "llm"
+        and not s.enabled_by_default
+        for s in _of(draft, "orientation")
+    )
+
+
+def test_enrich_orientation_over_container_uses_children_selector(monkeypatch):
+    payload = {"shapes": [_shape("related", "orientation", directions=["right"])]}
+    monkeypatch.setattr(_enrich_mod, "_import_llm", lambda: _fake_llm(payload))
+    draft = suggest(Ticket, enrich=True)
+    assert any(
+        s.kwargs
+        == {"selector": _child_edge("Ticket", "related"), "directions": ["right"]}
+        for s in _of(draft, "orientation")
+    )
+
+
+def test_enrich_cyclic_over_single_pointer(monkeypatch):
+    payload = {"shapes": [_shape("nxt", "cyclic", direction="clockwise")]}
+    monkeypatch.setattr(_enrich_mod, "_import_llm", lambda: _fake_llm(payload))
+    draft = suggest(LinkedNode, enrich=True)
+    assert any(
+        s.kwargs == {"selector": _edge("nxt"), "direction": "clockwise"}
+        for s in _of(draft, "cyclic")
+    )
+
+
+def test_enrich_group_only_for_containers(monkeypatch):
+    # group on a scalar pointer is dropped; on a collection it emits the
+    # field-based group form.
+    payload = {"shapes": [_shape("escalation", "group"), _shape("related", "group")]}
+    monkeypatch.setattr(_enrich_mod, "_import_llm", lambda: _fake_llm(payload))
+    draft = suggest(Ticket, enrich=True)
+    assert [s.kwargs for s in _of(draft, "group")] == [
+        {"field": "related", "groupOn": 0, "addToGroup": 1}
+    ]
+
+
+def test_enrich_rejects_unknown_field(monkeypatch):
+    # A field we never analyzed can't be targeted — so the model can't drive a
+    # selector for something off-schema.
+    payload = {"shapes": [_shape("nope", "orientation", directions=["below"])]}
+    monkeypatch.setattr(_enrich_mod, "_import_llm", lambda: _fake_llm(payload))
+    assert not _llm_rows(suggest(Ticket, enrich=True))
+
+
+def test_enrich_filters_out_of_vocab_directions(monkeypatch):
     payload = {
-        "assignments": [
-            {"field": "color", "member": "RED", "color": "red"},
-            {"field": "color", "member": "BLACK", "color": "#222"},
+        "shapes": [
+            _shape("escalation", "orientation", directions=["sideways", "above"])
         ]
     }
     monkeypatch.setattr(_enrich_mod, "_import_llm", lambda: _fake_llm(payload))
-    draft = suggest(RBNode, instance=_rb_instance(), enrich=True)
-    by_sel = {s.kwargs["selector"]: s.kwargs["value"] for s in _atomcolors(draft)}
-    assert by_sel[enum_member_selector("RBNode", "color", "RED")] == "red"
-    assert by_sel[enum_member_selector("RBNode", "color", "BLACK")] == "#222"
-    # model-sourced, still off by default (you pick), and the selectors are exactly
-    # the verified ones the deterministic rule generated — the model only colors.
-    assert _atomcolors(draft) and all(s.source == "llm" for s in _atomcolors(draft))
-    assert all(not s.enabled_by_default for s in _atomcolors(draft))
-    base = _atomcolors(suggest(RBNode, instance=_rb_instance()))
-    assert {s.kwargs["selector"] for s in base} == set(by_sel)
+    draft = suggest(Ticket, enrich=True)
+    assert any(s.kwargs["directions"] == ["above"] for s in _of(draft, "orientation"))
+
+
+def test_enrich_dedups_against_deterministic(monkeypatch):
+    # The rules already orient `escalation` below; an identical model suggestion is
+    # not added a second time.
+    payload = {"shapes": [_shape("escalation", "orientation", directions=["below"])]}
+    monkeypatch.setattr(_enrich_mod, "_import_llm", lambda: _fake_llm(payload))
+    assert not _of(suggest(Ticket, enrich=True), "orientation")
 
 
 def test_enrich_works_at_type_level_without_instance(monkeypatch):
-    # The headline property: enrichment needs no instance — enum members are read
-    # statically, so suggest(cls, enrich=True) enriches a bare class.
-    payload = {"assignments": [{"field": "color", "member": "RED", "color": "red"}]}
+    payload = {"shapes": [_shape("escalation", "orientation", directions=["above"])]}
     monkeypatch.setattr(_enrich_mod, "_import_llm", lambda: _fake_llm(payload))
-    draft = suggest(RBNode, enrich=True)
-    reds = [s for s in _atomcolors(draft) if s.kwargs["value"] == "red"]
-    assert reds and reds[0].source == "llm"
+    assert _of(suggest(Ticket, enrich=True), "orientation")  # no instance= needed
 
 
-def test_enrich_no_enum_fields_never_calls_model(monkeypatch):
+def test_enrich_no_structural_fields_never_calls_model(monkeypatch):
     calls = []
     monkeypatch.setattr(
-        _enrich_mod, "_import_llm", lambda: _fake_llm({"assignments": []}, calls)
+        _enrich_mod, "_import_llm", lambda: _fake_llm({"shapes": []}, calls)
     )
-    draft = suggest(BTreeNode, enrich=True)  # no enum field anywhere
-    assert calls == []  # abstain — don't spend a model call when there's nothing
-    assert not _atomcolors(draft)
-
-
-def test_enrich_ignores_unrequested_field_member(monkeypatch):
-    # A model that names a field/member we never offered must not inject a row
-    # (and therefore can't smuggle in a selector for something we didn't analyze).
-    payload = {
-        "assignments": [
-            {"field": "color", "member": "RED", "color": "red"},
-            {"field": "bogus", "member": "X", "color": "lime"},
-            {"field": "color", "member": "NOTAMEMBER", "color": "lime"},
-        ]
-    }
-    monkeypatch.setattr(_enrich_mod, "_import_llm", lambda: _fake_llm(payload))
-    draft = suggest(RBNode, instance=_rb_instance(), enrich=True)
-    values = {s.kwargs["value"] for s in _atomcolors(draft)}
-    assert "red" in values and "lime" not in values
+    suggest(Point, enrich=True)  # only scalars — nothing structural to shape
+    assert calls == []
 
 
 def test_enrich_bad_response_degrades(monkeypatch):
@@ -721,21 +767,15 @@ def test_enrich_bad_response_degrades(monkeypatch):
             return _BadModel()
 
     monkeypatch.setattr(_enrich_mod, "_import_llm", lambda: _LLM)
-    base = _atomcolors(suggest(RBNode, instance=_rb_instance()))
-    draft = suggest(RBNode, instance=_rb_instance(), enrich=True)
-    # falls back to the built-in palette, records a note, and never raises
-    assert [s.kwargs["value"] for s in _atomcolors(draft)] == [
-        s.kwargs["value"] for s in base
-    ]
-    assert any("enrichment skipped" in n for n in draft.notes)
+    draft = suggest(Ticket, enrich=True)
+    assert not _llm_rows(draft)  # never raises; degrades to the static draft
+    assert any("shape enrichment skipped" in n for n in draft.notes)
 
 
 def test_enrich_passes_through_model_id(monkeypatch):
     seen = []
     monkeypatch.setattr(
-        _enrich_mod,
-        "_import_llm",
-        lambda: _fake_llm({"assignments": []}, seen_model=seen),
+        _enrich_mod, "_import_llm", lambda: _fake_llm({"shapes": []}, seen_model=seen)
     )
-    suggest(RBNode, instance=_rb_instance(), enrich=True, enrich_model="claude-x")
+    suggest(Ticket, enrich=True, enrich_model="claude-x")
     assert seen == ["claude-x"]


### PR DESCRIPTION
Wires the reserved `enrich=` seam in `spytial.suggest` to an **opt-in** layer that asks a model to suggest the **spatial shape** of a structure, behind a `[suggest-llm]` extra.

## The idea
The deterministic rules only know a fixed name vocabulary — `left`/`right`, `next`/`prev`, `parent`/`children` — and fall back to a flat `below` for any self-reference they don't recognize. A model reads `escalation` / `downstream` / `reportsTo` and proposes a direction that matches the meaning. So `enrich=True` suggests, per structural field:

- **orientation** — a direction from a fixed vocab (`below/above/left/right/directlyRight/directlyLeft`)
- **cyclic** — `clockwise`/`counterclockwise` for ring-like single pointers
- **group** — the field-based form for collections

```python
draft = suggest(Ticket, enrich=True)                            # default llm model
draft = suggest(Ticket, enrich=True, enrich_model="claude-sonnet-4-6")
```

## The invariant: the model picks the shape, spytial builds the selector
The model chooses a *direction*; spytial emits the render-verified field-form selector (`_edge_selector` / `_children_selector`) the deterministic rules already use. Example output for a `Ticket{ escalation, related }`:

```
@spytial.orientation({'selector': 'escalation - (univ -> NoneType)', 'directions': ['above']})   # spytial wrote the selector; model only said "above"
@spytial.group({'field': 'related', 'groupOn': 0, 'addToGroup': 1})
```

This keeps it **schema-level** (no instance needed) and safe by construction:
- **Type-level first** — reasons over `ClassInfo`; `enrich=True` needs no instance.
- **You pick** — rows are `source="llm"` (a `model` chip in the panel), **off by default**, candidates beside the deterministic ones.
- **Can't break `suggest()`** — no `llm` / no model / malformed output each degrade to the static draft with a note. Choices naming an unknown field, an out-of-vocab direction, or a constraint that doesn't fit the field's kind are dropped (validated against `ClassInfo` — no datum).

## Why the model doesn't author selectors here
A selector can only be *validated* by evaluating it over a data instance — `SGraphQueryEvaluator` (the `IEvaluator`, wrapping `simple-graph-query`) has no schema-only mode. At the type level there's no datum to check against. Letting the model write + validate selectors therefore belongs in a **separate extension keyed to a set of example instances**, not in schema-level `suggest()`. (Findings: the evaluator logic is DOM-free but the published browser bundle needs `window`, so headless use needs a small node build in spytial-core; and a schema-level check would need a synthesized *witness* datum.)

## Dependency
[`llm`](https://llm.datasette.io/) (Simon Willison's), not a single-provider SDK — provider-agnostic (Claude/GPT/Gemini/Ollama) and it owns key management. `suggest-llm = ["llm>=0.23"]`.

## Tests
Rewritten around shape, all **mocked — no network, no `llm` in CI**: orientation for an unfamiliar field, container→children-selector, cyclic over a single pointer, group-only-for-containers, unknown-field rejection, direction filtering, dedup against deterministic, type-level/no-instance, abstain-when-no-structural-fields, malformed-response degradation, model-id passthrough.

```
234 passed, 4 skipped     # full suite; black + flake8 clean on authored files
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)