### PR TITLE
suggest: make enrich= a provider slot (callable), drop the ambient llm default

### DIFF
--- a/docs/suggest.md
+++ b/docs/suggest.md
@@ -129,13 +129,39 @@ llm keys set anthropic           # llm owns key management; spytial doesn't
 ```
 
 ```python
-draft = suggest(Ticket, enrich=True)              # uses your default llm model
-draft = suggest(Ticket, enrich=True, enrich_model="claude-sonnet-4-6")
+draft = suggest(Ticket, enrich="claude-sonnet-4-6")   # a named llm model
+draft = suggest(Ticket, enrich="llama3.2")            # a local model via llm-ollama
 ```
 
-It depends on [`llm`](https://llm.datasette.io/) (Simon Willison's) rather than a
-single provider SDK, so you choose the model — Claude, GPT, Gemini, a local model
-via Ollama — and `llm` handles the keys.
+You always say **what** to enrich with; there is no ambient default. A string is a
+model id resolved through [`llm`](https://llm.datasette.io/) (Simon Willison's), so
+you pick the model (Claude, GPT, Gemini, a local model via Ollama) and `llm` owns
+the keys.
+
+A **provider is just a callable** `(prompt, *, schema) -> dict`. So you can enrich
+from a **subscription** instead of a metered key — the built-in `ClaudeCode` and
+`Codex` providers run the respective CLI on your existing plan:
+
+```python
+from spytial.suggest import ClaudeCode, Codex
+
+draft = suggest(Ticket, enrich=ClaudeCode(model="sonnet"))   # your Claude Max/Pro sub
+draft = suggest(Ticket, enrich=Codex())                      # your ChatGPT plan (codex)
+```
+
+Or write your own in a few lines — anything callable with that signature works,
+including a bare function (use `instruct_json` / `extract_json` for a text-only
+backend):
+
+```python
+from spytial.suggest.providers import instruct_json, extract_json
+
+def my_provider(prompt, *, schema):
+    text = call_some_model(instruct_json(prompt, schema))
+    return extract_json(text)
+
+draft = suggest(Ticket, enrich=my_provider)
+```
 
 It suggests **shape**: an `orientation` direction per structural field, `cyclic`
 for ring-like links, and `group` for collections. So a field named `escalation`
@@ -145,20 +171,25 @@ the selector.** It chooses a direction from a fixed vocabulary; spytial builds t
 selector from the field, reusing the same render-verified forms the deterministic
 rules emit. That's what keeps it schema-level and safe:
 
-- **Type-level first.** It reasons over the class's fields, so `enrich=True` needs
-  no instance.
+- **Type-level first.** It reasons over the class's fields, so `enrich=` needs no
+  instance.
 - **You pick.** Enriched rows are tagged `source="llm"` (a `model` chip in the
   notebook panel) and stay **off by default** — candidates beside the
   deterministic ones, never applied behind your back.
-- **It can't break `suggest()`.** No `llm` installed, no model configured, or a
-  malformed response each degrade to the static draft with a note in
-  `draft.notes` — never an exception. Choices that name an unknown field or an
-  out-of-vocabulary direction are dropped.
+- **It can't break `suggest()`.** An unresolvable `enrich=` spec (no `llm`
+  installed, an unknown model id, a non-provider value) or a malformed response
+  each degrade to the static draft with a note in `draft.notes` — never an
+  exception. Choices that name an unknown field or an out-of-vocabulary direction
+  are dropped.
 
-Letting the model write actual selectors is a separate, future extension: a
-selector can only be *validated* by evaluating it over a data instance (the
-engine has no schema-only mode), so that tier belongs with a **set of example
-instances** to check against — not here, where there may be no instance at all.
+When you pass example instances (`suggest(obj, enrich=...)` or
+`suggest(Cls, examples=[a, b, ...], enrich=...)`), a second tier lets the model
+**author selector expressions** for relational cases the shape tier can't reach —
+each admitted only if it evaluates cleanly, at the right arity, on *every* example.
+A selector can only be validated by running it over data (the engine has no
+schema-only mode), which is why that tier needs the examples and the shape tier
+above does not. It runs headlessly on a vendored spytial-core evaluator, so it
+needs only a `node` runtime.
 
 ## Limits
 

--- a/spytial/suggest/__init__.py
+++ b/spytial/suggest/__init__.py
@@ -96,7 +96,7 @@ def suggest(
             ``(prompt, *, schema) -> dict`` — a function, or a built-in like
             :class:`~spytial.suggest.ClaudeCode` / :class:`~spytial.suggest.Codex` to
             enrich from a subscription instead of a metered key. ``None`` (default)
-            leaves the draft static. Enrichment suggests the
+            or ``False`` leaves the draft static. Enrichment suggests the
             *spatial shape* of the structure (orientation directions per field,
             ``cyclic`` for ring-like links, ``group`` for collections) where the
             deterministic rules fall back to a flat ``below``; the model only chooses
@@ -128,7 +128,11 @@ def suggest(
     reg = registry if registry is not None else DEFAULT_REGISTRY
     class_info = build_class_info(cls, instance=sample)
     draft = build_draft(class_info, reg)
-    if enrich:
+    # ``None``/``False`` mean "no enrichment"; everything else is a provider spec.
+    # Use identity checks, not truthiness — a callable provider whose ``__bool__``
+    # (or ``__len__``) is falsy must still resolve, since the contract accepts *any*
+    # callable.
+    if enrich is not None and enrich is not False:
         # Resolve the provider up front: a bad spec (no llm / unknown id / wrong
         # type) degrades to the static draft with a note rather than raising.
         try:

--- a/spytial/suggest/__init__.py
+++ b/spytial/suggest/__init__.py
@@ -24,6 +24,14 @@ from typing import Any, List, Optional
 from . import rules  # noqa: F401  (import for the side effect of registering built-ins)
 from ._model import ClassInfo, FieldInfo, SpecDraft, Suggestion
 from .introspect import build_class_info
+from .providers import (
+    ClaudeCode,
+    Codex,
+    EnrichError,
+    EnrichProvider,
+    LlmModel,
+    as_provider,
+)
 from .registry import DEFAULT_REGISTRY, HeuristicRegistry, build_draft, heuristic
 
 __all__ = [
@@ -36,6 +44,11 @@ __all__ = [
     "FieldInfo",
     "ClassInfo",
     "build_class_info",
+    "EnrichProvider",
+    "EnrichError",
+    "LlmModel",
+    "ClaudeCode",
+    "Codex",
 ]
 
 
@@ -44,7 +57,7 @@ def _coerce_examples(examples: Any, instance: Any) -> List[Any]:
 
     ``examples`` is a list/tuple of instances; a bare object counts as one example.
     When omitted, fall back to the single sampled ``instance`` so the common
-    ``suggest(obj, enrich=True)`` validates against ``obj``. ``None`` entries drop.
+    ``suggest(obj, enrich=...)`` validates against ``obj``. ``None`` entries drop.
     """
     if examples is None:
         return [instance] if instance is not None else []
@@ -59,8 +72,7 @@ def suggest(
     instance: Any = None,
     examples: Optional[List[Any]] = None,
     registry: Optional[HeuristicRegistry] = None,
-    enrich: bool = False,
-    enrich_model: Optional[str] = None,
+    enrich: Any = None,
 ) -> SpecDraft:
     """Analyze a class and return a :class:`SpecDraft` of proposed directives.
 
@@ -77,22 +89,24 @@ def suggest(
             ``target``); pass more for the instance-set form. Ignored unless ``enrich``.
         registry: an alternate :class:`HeuristicRegistry`; defaults to the global
             one populated with the built-in rules.
-        enrich: opt into the optional LLM enrichment layer (the ``[suggest-llm]``
-            extra). It suggests the *spatial shape* of the structure — orientation
-            directions per structural field, ``cyclic`` for ring-like links, and
-            ``group`` for collections — filling the gap where the deterministic rules
-            fall back to a flat ``below`` for fields outside their name vocabulary.
-            The model only chooses the shape; spytial supplies the (render-verified)
-            selector from the field, so this stays schema-level and needs no
-            instance. Enriched rows are tagged ``source="llm"`` and stay off by
-            default — candidates you pick. Degrades to the static draft (with a note)
-            if ``llm`` isn't installed or no model is configured — never raises.
-            When examples are available, enrichment additionally authors *selectors*
-            for relational cases the shape tier can't express, validating each by
-            evaluating it over every example (these too are off-by-default
-            ``source="llm"`` candidates).
-        enrich_model: an ``llm`` model id (e.g. ``"claude-sonnet-4-6"``); defaults
-            to your configured ``llm`` default model. Ignored unless ``enrich``.
+        enrich: turn on the optional LLM enrichment layer by saying *what* to enrich
+            with — there is no ambient default. Either a model-id **string** resolved
+            through the ``llm`` library (e.g. ``enrich="llama3.2"``, ``"gpt-4o"``; the
+            ``[suggest-llm]`` extra), or any **callable provider** with the signature
+            ``(prompt, *, schema) -> dict`` — a function, or a built-in like
+            :class:`~spytial.suggest.ClaudeCode` / :class:`~spytial.suggest.Codex` to
+            enrich from a subscription instead of a metered key. ``None`` (default)
+            leaves the draft static. Enrichment suggests the
+            *spatial shape* of the structure (orientation directions per field,
+            ``cyclic`` for ring-like links, ``group`` for collections) where the
+            deterministic rules fall back to a flat ``below``; the model only chooses
+            the shape and spytial supplies the render-verified selector. Enriched rows
+            are tagged ``source="llm"`` and stay off by default — candidates you pick.
+            When examples are available it additionally authors *selectors* for
+            relational cases the shape tier can't express, validating each by
+            evaluating it over every example. A spec that can't be resolved (``llm``
+            missing, unknown id) degrades to the static draft with a note — never
+            raises.
     """
     if isinstance(target, type):
         cls = target
@@ -102,7 +116,7 @@ def suggest(
         cls = type(target)
 
     # The example set drives selector validation (tier-2). Default it to the sampled
-    # instance so suggest(obj, enrich=True) just works; an explicit examples= list is
+    # instance so suggest(obj, enrich=...) just works; an explicit examples= list is
     # the instance-set form. The introspection sample falls back to the first example.
     example_objs = _coerce_examples(examples, instance)
     sample = (
@@ -115,9 +129,17 @@ def suggest(
     class_info = build_class_info(cls, instance=sample)
     draft = build_draft(class_info, reg)
     if enrich:
+        # Resolve the provider up front: a bad spec (no llm / unknown id / wrong
+        # type) degrades to the static draft with a note rather than raising.
+        try:
+            provider = as_provider(enrich)
+        except EnrichError as exc:
+            draft.notes.append(f"enrich skipped: {exc}")
+            return draft
+
         from ._enrich import enrich_draft
 
         draft = enrich_draft(
-            draft, class_info, model=enrich_model, examples=example_objs
+            draft, class_info, provider=provider, examples=example_objs
         )
     return draft

--- a/spytial/suggest/_enrich.py
+++ b/spytial/suggest/_enrich.py
@@ -1,7 +1,7 @@
 """Optional LLM *shape* enrichment for ``spytial.suggest`` (the ``[suggest-llm]``
 extra).
 
-Dormant unless you call ``suggest(..., enrich=True)``. This tier is **schema-level**:
+Dormant unless you call ``suggest(..., enrich=...)``. This tier is **schema-level**:
 it reasons over the class's structural fields, not a data instance, so it needs no
 datum — only the model call.
 
@@ -24,8 +24,10 @@ example instances are available and validates every candidate by evaluating it o
 each of them.
 
 Enriched rows are tagged ``source="llm"``, stay off by default (you pick), and every
-failure path — no ``llm`` installed, no model configured, malformed output — degrades
-to the static draft with a note. Enrichment can never crash ``suggest()``.
+failure path — an unresolvable provider, a malformed model response — degrades to the
+static draft with a note. Enrichment can never crash ``suggest()``. The provider (how
+to reach a model) is chosen by the caller via ``enrich=`` and resolved in
+:mod:`spytial.suggest.providers`; this module just calls ``provider(prompt, schema=)``.
 """
 
 from __future__ import annotations
@@ -42,13 +44,6 @@ from .rules import _children_selector, _edge_selector
 _ORIENT_DIRS = ("below", "above", "left", "right", "directlyRight", "directlyLeft")
 _CYCLIC_DIRS = ("clockwise", "counterclockwise")
 _CONTAINERS = ("list", "tuple", "set", "dict")
-
-_INSTALL_HINT = (
-    "enrich=True needs the optional 'llm' library. Install it with "
-    'pip install "spytial_diagramming[suggest-llm]" and configure a model '
-    "(e.g. `llm install llm-anthropic && llm keys set anthropic`, or any other "
-    "llm provider plugin). Returning the static draft unchanged."
-)
 
 _SHAPE_SCHEMA = {
     "type": "object",
@@ -103,16 +98,6 @@ Structural fields:
 Return one entry per field listed above."""
 
 
-def _import_llm():
-    """Return the ``llm`` module, or ``None`` if the extra isn't installed."""
-    try:
-        import llm  # type: ignore
-
-        return llm
-    except ImportError:
-        return None
-
-
 def _structural_fields(ci: ClassInfo) -> List:
     """Non-private self-referential fields — the structural edges shape applies to."""
     return [f for f in ci.fields if f.is_self_ref and not f.is_private]
@@ -122,35 +107,23 @@ def enrich_draft(
     draft: SpecDraft,
     class_info: ClassInfo,
     *,
-    model: Optional[str] = None,
+    provider: Any,
     examples: Optional[List[Any]] = None,
 ) -> SpecDraft:
     """Augment a :class:`SpecDraft` with model-suggested spatial shape and selectors.
 
-    The schema-level *shape* tier always runs. When ``examples`` (a list of instances)
-    is provided, the *selector* tier (:mod:`._enrich_from_examples`) also runs — the
-    model authors selectors that are validated by evaluation over every example.
-    Returns the same draft, mutated in place. Any failure leaves the deterministic
-    suggestions untouched and records a note in ``draft.notes`` — enrichment never
-    raises.
+    ``provider`` is an :class:`~spytial.suggest.EnrichProvider` (already resolved from
+    the caller's ``enrich=`` spec). The schema-level *shape* tier always runs. When
+    ``examples`` (a list of instances) is provided, the *selector* tier
+    (:mod:`._enrich_from_examples`) also runs — the model authors selectors that are
+    validated by evaluation over every example. Returns the same draft, mutated in
+    place. Any failure leaves the deterministic suggestions untouched and records a
+    note in ``draft.notes`` — enrichment never raises.
     """
-    llm = _import_llm()
-    if llm is None:
-        draft.notes.append(_INSTALL_HINT)
-        return draft
-
     try:
-        m = llm.get_model(model) if model else llm.get_model()
-    except Exception as exc:  # noqa: BLE001 — any provider/config error degrades
-        draft.notes.append(
-            f"enrich=True: no usable llm model ({exc}); returning the static draft."
-        )
-        return draft
-
-    try:
-        _enrich_shape(draft, class_info, m)
+        _enrich_shape(draft, class_info, provider)
     except Exception as exc:  # noqa: BLE001 — never crash suggest() on enrichment
-        draft.notes.append(f"enrich=True: shape enrichment skipped ({exc}).")
+        draft.notes.append(f"enrich: shape enrichment skipped ({exc}).")
 
     # Tier-2: model-authored selectors, validated by evaluation over example
     # instances. Runs only with examples to evaluate against; otherwise note (when
@@ -159,29 +132,31 @@ def enrich_draft(
         try:
             from . import _enrich_from_examples
 
-            _enrich_from_examples.enrich_from_examples(draft, class_info, m, examples)
+            _enrich_from_examples.enrich_from_examples(
+                draft, class_info, provider, examples
+            )
         except Exception as exc:  # noqa: BLE001 — never crash suggest() on enrichment
-            draft.notes.append(f"enrich=True: selector tier skipped ({exc}).")
+            draft.notes.append(f"enrich: selector tier skipped ({exc}).")
     elif _structural_fields(class_info):
         draft.notes.append(
-            "enrich=True: pass examples — suggest(obj, enrich=True) or "
-            "suggest(Cls, examples=[obj], enrich=True) — to also get model-authored "
+            "enrich: pass examples — suggest(obj, enrich=...) or "
+            "suggest(Cls, examples=[obj], enrich=...) — to also get model-authored "
             "selectors validated against your data."
         )
     return draft
 
 
-def _enrich_shape(draft: SpecDraft, ci: ClassInfo, model) -> None:
+def _enrich_shape(draft: SpecDraft, ci: ClassInfo, provider) -> None:
     fields = _structural_fields(ci)
     if not fields:
         return  # nothing structural to shape; don't spend a model call
 
-    shapes = _ask_shapes(model, ci, fields)
+    shapes = _ask_shapes(provider, ci, fields)
     _apply_shapes(draft, ci, fields, shapes)
 
 
-def _ask_shapes(model, ci: ClassInfo, fields: List) -> List[dict]:
-    """Prompt the model for a shape per structural field; return the raw list."""
+def _ask_shapes(provider, ci: ClassInfo, fields: List) -> List[dict]:
+    """Prompt the provider for a shape per structural field; return the raw list."""
     lines = []
     for f in fields:
         kind = f.container if f.container else "single pointer"
@@ -190,8 +165,7 @@ def _ask_shapes(model, ci: ClassInfo, fields: List) -> List[dict]:
             f"- {f.name}: type={f.type_repr or '?'}, kind={kind}, nullable={nullable}"
         )
     prompt = _SHAPE_PROMPT.format(cls=ci.cls.__name__, fields="\n".join(lines))
-    response = model.prompt(prompt, schema=_SHAPE_SCHEMA)
-    data = json.loads(response.text())
+    data = provider(prompt, schema=_SHAPE_SCHEMA)
     shapes = data.get("shapes", [])
     return [s for s in shapes if isinstance(s, dict)]
 

--- a/spytial/suggest/_enrich_from_examples.py
+++ b/spytial/suggest/_enrich_from_examples.py
@@ -8,7 +8,7 @@ relational cases the shape tier can't reach (an edge through a join or closure, 
 edge over an index/key relation, a relation the field names don't reveal).
 
 This is selector suggestion **by example**. You supply one or more example instances
-(``suggest(obj, enrich=True)`` or ``suggest(Cls, examples=[a, b, ...], enrich=True)``);
+(``suggest(obj, enrich=...)`` or ``suggest(Cls, examples=[a, b, ...], enrich=...)``);
 the model proposes selectors grounded in those instances' vocabulary, and only the
 ones that parse, are non-empty, and have the directive's arity **on every example**
 survive. Validating across a *set* of examples is what narrows the gap toward "correct
@@ -101,7 +101,7 @@ Self-referential / structural fields: {fields}
 
 
 def enrich_from_examples(
-    draft: SpecDraft, ci: ClassInfo, model, examples: List
+    draft: SpecDraft, ci: ClassInfo, provider, examples: List
 ) -> None:
     """Author selectors, validate each across the ``examples``, append survivors.
 
@@ -118,14 +118,14 @@ def enrich_from_examples(
             continue
     if not datums:
         draft.notes.append(
-            "enrich=True: selector tier skipped "
+            "enrich: selector tier skipped "
             "(couldn't build a datum from any example)."
         )
         return
 
     if not _eval.is_available():
         draft.notes.append(
-            "enrich=True: selector tier skipped (headless evaluator unavailable "
+            "enrich: selector tier skipped (headless evaluator unavailable "
             "— needs a node runtime on PATH, or set SPYTIAL_NODE to a node binary)."
         )
         return
@@ -135,10 +135,10 @@ def enrich_from_examples(
         return  # no relations to author edges over — nothing for this tier to do
 
     try:
-        candidates = _ask_selectors(model, ci, vocab, len(datums))
+        candidates = _ask_selectors(provider, ci, vocab, len(datums))
     except Exception as exc:  # noqa: BLE001 — bad model call/parse: disable tier
         draft.notes.append(
-            "enrich=True: selector tier skipped "
+            "enrich: selector tier skipped "
             f"(model call or response parse failed: {exc})."
         )
         return
@@ -163,7 +163,7 @@ def enrich_from_examples(
             last_exc = exc
     if not per_example:
         draft.notes.append(
-            "enrich=True: selector tier skipped "
+            "enrich: selector tier skipped "
             f"(no example could be evaluated: {last_exc})."
         )
         return
@@ -194,7 +194,7 @@ def enrich_from_examples(
         n = len(datums)
         across = "the example instance" if n == 1 else f"all {n} example instances"
         draft.notes.append(
-            f"enrich=True: added {kept} model-authored selector "
+            f"enrich: added {kept} model-authored selector "
             f"candidate(s), each validated over {across} "
             "(off by default — review before enabling)."
         )
@@ -243,8 +243,8 @@ def _admit(
     )
 
 
-def _ask_selectors(model, ci: ClassInfo, vocab: dict, n_examples: int) -> List[dict]:
-    """Prompt the model for selectors grounded in the vocabulary; return the list."""
+def _ask_selectors(provider, ci: ClassInfo, vocab: dict, n_examples: int) -> List[dict]:
+    """Prompt the provider for selectors grounded in the vocabulary; return the list."""
     types_line = ", ".join(f"{t} (#{n})" for t, n in vocab["types"]) or "(none)"
     rels_line = ", ".join(f"{name}/{arity}" for name, arity in vocab["relations"])
     fields = ", ".join(f.name for f in _structural_fields(ci)) or "(none detected)"
@@ -255,8 +255,7 @@ def _ask_selectors(model, ci: ClassInfo, vocab: dict, n_examples: int) -> List[d
         fields=fields,
         n=n_examples,
     )
-    response = model.prompt(prompt, schema=_SELECTOR_SCHEMA)
-    data = json.loads(response.text())
+    data = provider(prompt, schema=_SELECTOR_SCHEMA)
     out = data.get("selectors", [])
     return [c for c in out if isinstance(c, dict)]
 

--- a/spytial/suggest/providers.py
+++ b/spytial/suggest/providers.py
@@ -1,0 +1,236 @@
+"""The provider slot for ``spytial.suggest`` enrichment.
+
+Enrichment needs exactly one thing from a model: given a prompt and a JSON schema,
+return the structured reply. So a **provider is a callable** ::
+
+    (prompt: str, *, schema: dict) -> dict
+
+Anything with that shape works — a bare function, a ``lambda``, or a class with
+``__call__`` that carries config. ``suggest(obj, enrich=...)`` accepts:
+
+* ``None`` — off (no enrichment).
+* a model-id **string** — sugar for a named model in the ``llm`` library
+  (:class:`LlmModel`); e.g. ``enrich="llama3.2"``, ``enrich="gpt-4o"``.
+* any **callable** provider — for a subscription CLI, a raw API client, or a test
+  stub. Built-ins: :class:`LlmModel`, :class:`ClaudeCode`, :class:`Codex`.
+
+There is no ambient default: you always say *what* to enrich with. A provider is
+free to raise on failure — the caller (``suggest`` / ``enrich_draft``) catches it
+and degrades to the static draft with a note, so enrichment never crashes
+``suggest()``.
+
+Writing one is short. A backend with **native** JSON-schema output returns the
+object directly; a text-only backend leans on the two helpers here::
+
+    def my_provider(prompt, *, schema):
+        text = call_some_model(instruct_json(prompt, schema))
+        return extract_json(text)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from typing import Any, Mapping, runtime_checkable
+
+try:  # Protocol is stdlib on 3.8+.
+    from typing import Protocol
+except ImportError:  # pragma: no cover
+    from typing_extensions import Protocol  # type: ignore
+
+
+class EnrichError(RuntimeError):
+    """A provider couldn't be built or a provider call failed.
+
+    ``suggest`` catches this (and, at call time, any exception a provider raises)
+    and records a note instead of propagating — enrichment is best-effort.
+    """
+
+
+@runtime_checkable
+class EnrichProvider(Protocol):
+    """The provider slot: a callable ``(prompt, *, schema) -> dict``.
+
+    Implement it as a function or as a class with ``__call__``. The return value is
+    a JSON object (mapping) conforming to ``schema`` — the model's structured reply.
+    """
+
+    def __call__(self, prompt: str, *, schema: Mapping[str, Any]) -> Mapping[str, Any]:
+        ...
+
+
+# --------------------------------------------------------------------------- #
+# Helpers for text-only backends (no native structured-output mode).
+# --------------------------------------------------------------------------- #
+
+
+def instruct_json(prompt: str, schema: Mapping[str, Any]) -> str:
+    """Append a strict "reply with only this JSON" instruction to ``prompt``.
+
+    For backends without a native schema mode (e.g. ``claude -p``): pair it with
+    :func:`extract_json` on the response.
+    """
+    return (
+        f"{prompt}\n\n"
+        "Respond with ONLY a single JSON object conforming to this JSON Schema. "
+        "No prose, no explanation, no markdown code fence.\n\n"
+        f"JSON Schema:\n{json.dumps(schema)}"
+    )
+
+
+def extract_json(text: str) -> dict:
+    """Parse a JSON object out of model output, tolerating fences and stray prose.
+
+    Tries the whole string first, then falls back to the first balanced ``{...}``.
+    Raises :class:`EnrichError` if nothing parseable is found.
+    """
+    s = text.strip()
+    if s.startswith("```"):  # ```json ... ``` or ``` ... ```
+        s = s.strip("`")
+        if s.lower().startswith("json"):
+            s = s[4:]
+        s = s.strip()
+    try:
+        return json.loads(s)
+    except json.JSONDecodeError:
+        pass
+    # Fall back to the first balanced object anywhere in the text.
+    start = s.find("{")
+    if start != -1:
+        depth = 0
+        for i in range(start, len(s)):
+            if s[i] == "{":
+                depth += 1
+            elif s[i] == "}":
+                depth -= 1
+                if depth == 0:
+                    try:
+                        return json.loads(s[start : i + 1])
+                    except json.JSONDecodeError:
+                        break
+    raise EnrichError(f"no JSON object found in model output: {text[:200]!r}")
+
+
+# --------------------------------------------------------------------------- #
+# Built-in providers.
+# --------------------------------------------------------------------------- #
+
+
+class LlmModel:
+    """Provider backed by a *named* model in Simon Willison's ``llm`` library.
+
+    ``enrich="llama3.2"`` / ``enrich="gpt-4o"`` resolve here. The id is explicit — no
+    ``llm`` *default* model is ever consulted, so the same call enriches the same way
+    everywhere. Raises :class:`EnrichError` if ``llm`` isn't installed or the id is
+    unknown, so a typo fails loudly rather than silently doing nothing.
+    """
+
+    def __init__(self, model_id: str):
+        try:
+            import llm  # type: ignore
+        except ImportError as exc:
+            raise EnrichError(
+                f'enrich="{model_id}" needs the optional llm library — install it '
+                'with: pip install "spytial_diagramming[suggest-llm]" plus a provider '
+                "plugin (e.g. llm-ollama for local models, or llm-anthropic)."
+            ) from exc
+        try:
+            self._model = llm.get_model(model_id)
+        except Exception as exc:  # noqa: BLE001 — llm.UnknownModelError et al.
+            raise EnrichError(f'enrich="{model_id}": {exc}') from exc
+
+    def __call__(self, prompt: str, *, schema: Mapping[str, Any]) -> Mapping[str, Any]:
+        # llm has native schema support; it returns the JSON as text.
+        return json.loads(self._model.prompt(prompt, schema=schema).text())
+
+
+class ClaudeCode:
+    """Provider backed by the Claude Code CLI (``claude -p``) — your subscription.
+
+    Runs on Claude Code's auth (OAuth/subscription), so it needs no separate API key.
+    ``claude`` has no native JSON-schema flag, so the schema is injected into the
+    prompt and the reply is parsed with :func:`extract_json`.
+
+    Individual, local use only: Claude Code's subscription token isn't licensed for
+    multi-user or hosted services — use an API key (an :class:`LlmModel`) for those.
+    """
+
+    def __init__(self, model: str = "sonnet", *, bin: str = "claude", timeout: int = 120):
+        self.model = model
+        self.bin = bin
+        self.timeout = timeout
+
+    def __call__(self, prompt: str, *, schema: Mapping[str, Any]) -> Mapping[str, Any]:
+        exe = shutil.which(self.bin) or self.bin
+        proc = subprocess.run(
+            [exe, "-p", "--model", self.model, instruct_json(prompt, schema)],
+            capture_output=True,
+            text=True,
+            timeout=self.timeout,
+        )
+        if proc.returncode != 0:
+            raise EnrichError(
+                f"claude exited {proc.returncode}: {(proc.stderr or '').strip()[:300]}"
+            )
+        return extract_json(proc.stdout)
+
+
+class Codex:
+    """Provider backed by the OpenAI Codex CLI (``codex exec``) — your ChatGPT plan.
+
+    Uses ``--output-schema`` for *native* JSON-schema-enforced output, so the reply
+    conforms to ``schema`` by construction. Runs on your ChatGPT (Plus/Pro/…) sign-in.
+
+    Individual, local use only — as with :class:`ClaudeCode`.
+    """
+
+    def __init__(self, model: str = "", *, bin: str = "codex", timeout: int = 120):
+        self.model = model
+        self.bin = bin
+        self.timeout = timeout
+
+    def __call__(self, prompt: str, *, schema: Mapping[str, Any]) -> Mapping[str, Any]:
+        exe = shutil.which(self.bin) or self.bin
+        fd, path = tempfile.mkstemp(suffix=".json")
+        try:
+            with os.fdopen(fd, "w") as f:
+                json.dump(schema, f)
+            cmd = [exe, "exec", "--output-schema", path]
+            if self.model:
+                cmd += ["--model", self.model]
+            cmd.append(prompt)
+            proc = subprocess.run(
+                cmd, capture_output=True, text=True, timeout=self.timeout
+            )
+        finally:
+            os.unlink(path)
+        if proc.returncode != 0:
+            raise EnrichError(
+                f"codex exited {proc.returncode}: {(proc.stderr or '').strip()[:300]}"
+            )
+        return extract_json(proc.stdout)
+
+
+# --------------------------------------------------------------------------- #
+# Resolution.
+# --------------------------------------------------------------------------- #
+
+
+def as_provider(spec: Any) -> EnrichProvider:
+    """Resolve an ``enrich=`` value to a provider callable.
+
+    A ``str`` is a named ``llm`` model id (wrapped in :class:`LlmModel`); any other
+    callable is used as-is. Raises :class:`EnrichError` on anything else. ``None`` is
+    handled by the caller (it means "no enrichment") and never reaches here.
+    """
+    if isinstance(spec, str):
+        return LlmModel(spec)
+    if callable(spec):
+        return spec
+    raise EnrichError(
+        "enrich must be a model-id string or a callable provider "
+        f"(prompt, *, schema) -> dict; got {type(spec).__name__}."
+    )

--- a/test/test_suggest.py
+++ b/test/test_suggest.py
@@ -721,6 +721,31 @@ def test_enrich_filters_out_of_vocab_directions():
     assert any(s.kwargs["directions"] == ["above"] for s in _of(draft, "orientation"))
 
 
+def test_enrich_honors_falsy_callable_provider():
+    # A provider whose __bool__/__len__ is falsy must still resolve — "off" is None or
+    # False only, not truthiness. Regression for the callable provider slot.
+    payload = {"shapes": [_shape("escalation", "orientation", directions=["above"])]}
+
+    class _FalsyProvider(_FakeProvider):
+        def __len__(self):
+            return 0  # makes the instance falsy
+
+    prov = _FalsyProvider(payload)
+    assert not prov  # falsy...
+    draft = suggest(Ticket, enrich=prov)
+    assert any(  # ...yet honored, not silently skipped
+        s.kwargs["directions"] == ["above"] for s in _of(draft, "orientation")
+    )
+
+
+def test_enrich_none_and_false_are_off():
+    # The only two "off" values — neither runs a provider nor leaves an enrich note.
+    for off in (None, False):
+        draft = suggest(Ticket, enrich=off)
+        assert not _llm_rows(draft)
+        assert not any("enrich" in n.lower() for n in draft.notes)
+
+
 def test_enrich_dedups_against_deterministic():
     # The rules already orient `escalation` below; an identical model suggestion is
     # not added a second time.

--- a/test/test_suggest.py
+++ b/test/test_suggest.py
@@ -10,12 +10,14 @@ path the introspector has to handle.
 from __future__ import annotations
 
 import json
+import os
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import List, Optional
 
+import pytest
+
 import spytial
-import spytial.suggest._enrich as _enrich_mod
 from spytial.suggest import (
     HeuristicRegistry,
     Suggestion,
@@ -603,34 +605,20 @@ def test_custom_registry_is_isolated_from_default():
 # --------------------------------------------------------------------------- #
 
 
-class _FakeResponse:
-    def __init__(self, payload):
-        self._payload = payload
+class _FakeProvider:
+    """A test provider — a callable ``(prompt, *, schema) -> dict``.
 
-    def text(self):
-        return json.dumps(self._payload)
+    Returns a fixed payload dict; records each call in ``calls`` if given.
+    """
 
-
-class _FakeModel:
     def __init__(self, payload, calls=None):
         self._payload = payload
         self._calls = calls
 
-    def prompt(self, prompt, schema=None):
+    def __call__(self, prompt, *, schema):
         if self._calls is not None:
             self._calls.append({"prompt": prompt, "schema": schema})
-        return _FakeResponse(self._payload)
-
-
-def _fake_llm(payload, calls=None, seen_model=None):
-    class _LLM:
-        @staticmethod
-        def get_model(name=None):
-            if seen_model is not None:
-                seen_model.append(name)
-            return _FakeModel(payload, calls)
-
-    return _LLM
+        return self._payload
 
 
 def _llm_rows(draft):
@@ -657,19 +645,18 @@ def _shape(field, constraint, **extra):
     return {"field": field, "constraint": constraint, "why": "test", **extra}
 
 
-def test_enrich_missing_llm_degrades_with_note(monkeypatch):
-    # `llm` not installed is the real default; assert a clean no-op + a note.
-    monkeypatch.setattr(_enrich_mod, "_import_llm", lambda: None)
-    draft = suggest(Ticket, enrich=True)
+def test_enrich_bad_spec_degrades_with_note():
+    # enrich must be a model-id string or a provider object; a bad spec is a clean
+    # no-op with a note, never a crash.
+    draft = suggest(Ticket, enrich=123)
     assert not _llm_rows(draft)
-    assert any("suggest-llm" in n for n in draft.notes)
+    assert any("enrich skipped" in n for n in draft.notes)
 
 
-def test_enrich_orientation_for_unfamiliar_field(monkeypatch):
-    # The model picks a direction (above); spytial supplies the field-form selector.
+def test_enrich_orientation_for_unfamiliar_field():
+    # The provider picks a direction (above); spytial supplies the field-form selector.
     payload = {"shapes": [_shape("escalation", "orientation", directions=["above"])]}
-    monkeypatch.setattr(_enrich_mod, "_import_llm", lambda: _fake_llm(payload))
-    draft = suggest(Ticket, enrich=True)
+    draft = suggest(Ticket, enrich=_FakeProvider(payload))
     assert any(
         s.kwargs == {"selector": _edge("escalation"), "directions": ["above"]}
         and s.source == "llm"
@@ -678,10 +665,9 @@ def test_enrich_orientation_for_unfamiliar_field(monkeypatch):
     )
 
 
-def test_enrich_orientation_over_container_uses_children_selector(monkeypatch):
+def test_enrich_orientation_over_container_uses_children_selector():
     payload = {"shapes": [_shape("related", "orientation", directions=["right"])]}
-    monkeypatch.setattr(_enrich_mod, "_import_llm", lambda: _fake_llm(payload))
-    draft = suggest(Ticket, enrich=True)
+    draft = suggest(Ticket, enrich=_FakeProvider(payload))
     # The derived (parent, child) edge carries source_field=None — matching
     # rules.child_container — so it de-dups and groups like the deterministic one.
     assert any(
@@ -692,101 +678,179 @@ def test_enrich_orientation_over_container_uses_children_selector(monkeypatch):
     )
 
 
-def test_enrich_container_orientation_dedups_against_deterministic(monkeypatch):
+def test_enrich_container_orientation_dedups_against_deterministic():
     # The rules already orient `related` children below (derived edge, source_field
     # None); an identical model suggestion must collapse, not slip past _key().
     payload = {"shapes": [_shape("related", "orientation", directions=["below"])]}
-    monkeypatch.setattr(_enrich_mod, "_import_llm", lambda: _fake_llm(payload))
-    assert not _of(suggest(Ticket, enrich=True), "orientation")
+    assert not _of(suggest(Ticket, enrich=_FakeProvider(payload)), "orientation")
 
 
-def test_enrich_cyclic_over_single_pointer(monkeypatch):
+def test_enrich_cyclic_over_single_pointer():
     payload = {"shapes": [_shape("nxt", "cyclic", direction="clockwise")]}
-    monkeypatch.setattr(_enrich_mod, "_import_llm", lambda: _fake_llm(payload))
-    draft = suggest(LinkedNode, enrich=True)
+    draft = suggest(LinkedNode, enrich=_FakeProvider(payload))
     assert any(
         s.kwargs == {"selector": _edge("nxt"), "direction": "clockwise"}
         for s in _of(draft, "cyclic")
     )
 
 
-def test_enrich_group_only_for_containers(monkeypatch):
+def test_enrich_group_only_for_containers():
     # group on a scalar pointer is dropped; on a collection it emits the
     # field-based group form.
     payload = {"shapes": [_shape("escalation", "group"), _shape("related", "group")]}
-    monkeypatch.setattr(_enrich_mod, "_import_llm", lambda: _fake_llm(payload))
-    draft = suggest(Ticket, enrich=True)
+    draft = suggest(Ticket, enrich=_FakeProvider(payload))
     assert [s.kwargs for s in _of(draft, "group")] == [
         {"field": "related", "groupOn": 0, "addToGroup": 1}
     ]
 
 
-def test_enrich_rejects_unknown_field(monkeypatch):
+def test_enrich_rejects_unknown_field():
     # A field we never analyzed can't be targeted — so the model can't drive a
     # selector for something off-schema.
     payload = {"shapes": [_shape("nope", "orientation", directions=["below"])]}
-    monkeypatch.setattr(_enrich_mod, "_import_llm", lambda: _fake_llm(payload))
-    assert not _llm_rows(suggest(Ticket, enrich=True))
+    assert not _llm_rows(suggest(Ticket, enrich=_FakeProvider(payload)))
 
 
-def test_enrich_filters_out_of_vocab_directions(monkeypatch):
+def test_enrich_filters_out_of_vocab_directions():
     payload = {
         "shapes": [
             _shape("escalation", "orientation", directions=["sideways", "above"])
         ]
     }
-    monkeypatch.setattr(_enrich_mod, "_import_llm", lambda: _fake_llm(payload))
-    draft = suggest(Ticket, enrich=True)
+    draft = suggest(Ticket, enrich=_FakeProvider(payload))
     assert any(s.kwargs["directions"] == ["above"] for s in _of(draft, "orientation"))
 
 
-def test_enrich_dedups_against_deterministic(monkeypatch):
+def test_enrich_dedups_against_deterministic():
     # The rules already orient `escalation` below; an identical model suggestion is
     # not added a second time.
     payload = {"shapes": [_shape("escalation", "orientation", directions=["below"])]}
-    monkeypatch.setattr(_enrich_mod, "_import_llm", lambda: _fake_llm(payload))
-    assert not _of(suggest(Ticket, enrich=True), "orientation")
+    assert not _of(suggest(Ticket, enrich=_FakeProvider(payload)), "orientation")
 
 
-def test_enrich_works_at_type_level_without_instance(monkeypatch):
+def test_enrich_works_at_type_level_without_instance():
     payload = {"shapes": [_shape("escalation", "orientation", directions=["above"])]}
-    monkeypatch.setattr(_enrich_mod, "_import_llm", lambda: _fake_llm(payload))
-    assert _of(suggest(Ticket, enrich=True), "orientation")  # no instance= needed
+    assert _of(suggest(Ticket, enrich=_FakeProvider(payload)), "orientation")
 
 
-def test_enrich_no_structural_fields_never_calls_model(monkeypatch):
+def test_enrich_no_structural_fields_never_calls_provider():
     calls = []
-    monkeypatch.setattr(
-        _enrich_mod, "_import_llm", lambda: _fake_llm({"shapes": []}, calls)
-    )
-    suggest(Point, enrich=True)  # only scalars — nothing structural to shape
-    assert calls == []
+    suggest(Point, enrich=_FakeProvider({"shapes": []}, calls))
+    assert calls == []  # only scalars — nothing structural to shape
 
 
-def test_enrich_bad_response_degrades(monkeypatch):
-    class _BadModel:
-        def prompt(self, prompt, schema=None):
-            class _R:
-                def text(self):
-                    return "not json {"
+def test_enrich_provider_error_degrades():
+    # A provider that raises degrades to the static draft with a note, never crashes.
+    def boom(prompt, *, schema):
+        raise RuntimeError("model unreachable")
 
-            return _R()
-
-    class _LLM:
-        @staticmethod
-        def get_model(name=None):
-            return _BadModel()
-
-    monkeypatch.setattr(_enrich_mod, "_import_llm", lambda: _LLM)
-    draft = suggest(Ticket, enrich=True)
-    assert not _llm_rows(draft)  # never raises; degrades to the static draft
+    draft = suggest(Ticket, enrich=boom)
+    assert not _llm_rows(draft)  # never raises
     assert any("shape enrichment skipped" in n for n in draft.notes)
 
 
-def test_enrich_passes_through_model_id(monkeypatch):
+# --- the provider slot itself ------------------------------------------------- #
+
+
+def test_as_provider_accepts_callables_and_rejects_non_callables():
+    from spytial.suggest import EnrichProvider, providers
+
+    fn = _FakeProvider({"shapes": []})
+    assert isinstance(fn, EnrichProvider)  # a callable satisfies the protocol
+    assert providers.as_provider(fn) is fn  # passes straight through
+    assert callable(providers.as_provider(lambda prompt, *, schema: {}))
+    with pytest.raises(providers.EnrichError):
+        providers.as_provider(123)  # not a model id, not callable
+
+
+def test_llmmodel_unresolvable_raises_enrich_error():
+    # No llm installed OR an unknown id both surface as EnrichError — which suggest()
+    # catches and turns into a note.
+    from spytial.suggest import providers
+
+    with pytest.raises(providers.EnrichError):
+        providers.LlmModel("definitely-not-a-real-model-xyz")
+
+
+def test_llmmodel_passes_id_and_returns_dict(monkeypatch):
+    # A model-id string resolves the *named* model (no ambient default); the adapter
+    # parses llm's response text into a dict.
+    llm = pytest.importorskip("llm")
     seen = []
-    monkeypatch.setattr(
-        _enrich_mod, "_import_llm", lambda: _fake_llm({"shapes": []}, seen_model=seen)
-    )
-    suggest(Ticket, enrich=True, enrich_model="claude-x")
+
+    class _Resp:
+        def text(self):
+            return json.dumps({"shapes": []})
+
+    class _Model:
+        def prompt(self, prompt, *, schema):
+            return _Resp()
+
+    def _fake_get_model(model_id):
+        seen.append(model_id)
+        return _Model()
+
+    monkeypatch.setattr(llm, "get_model", _fake_get_model)
+    from spytial.suggest import providers
+
+    prov = providers.LlmModel("claude-x")
     assert seen == ["claude-x"]
+    assert prov("hi", schema={}) == {"shapes": []}
+
+
+def test_extract_json_handles_plain_fenced_and_noisy():
+    from spytial.suggest import providers
+
+    assert providers.extract_json('{"a": 1}') == {"a": 1}
+    assert providers.extract_json('```json\n{"a": 1}\n```') == {"a": 1}
+    assert providers.extract_json('Sure, here:\n{"a": 1}\nHope that helps.') == {"a": 1}
+    with pytest.raises(providers.EnrichError):
+        providers.extract_json("no json object here")
+
+
+def test_claudecode_builds_command_and_parses(monkeypatch):
+    # Injects the schema into the prompt and parses the (fenced) reply.
+    from spytial.suggest import providers
+
+    captured = {}
+
+    class _Proc:
+        returncode = 0
+        stdout = '```json\n{"shapes": []}\n```'
+        stderr = ""
+
+    monkeypatch.setattr(providers.shutil, "which", lambda b: "/usr/bin/" + b)
+    monkeypatch.setattr(
+        providers.subprocess, "run", lambda cmd, **kw: captured.update(cmd=cmd) or _Proc()
+    )
+
+    out = providers.ClaudeCode(model="opus")("hi", schema={"type": "object"})
+    assert out == {"shapes": []}
+    assert captured["cmd"][:4] == ["/usr/bin/claude", "-p", "--model", "opus"]
+    assert "JSON Schema" in captured["cmd"][-1]  # schema injected into the prompt
+
+
+def test_codex_uses_native_output_schema(monkeypatch):
+    # Passes --output-schema pointing at a real temp file present during the call.
+    from spytial.suggest import providers
+
+    captured = {}
+
+    class _Proc:
+        returncode = 0
+        stdout = '{"selectors": []}'
+        stderr = ""
+
+    def fake_run(cmd, **kw):
+        captured["cmd"] = cmd
+        i = cmd.index("--output-schema")
+        captured["schema_exists"] = os.path.exists(cmd[i + 1])
+        return _Proc()
+
+    monkeypatch.setattr(providers.shutil, "which", lambda b: "/usr/bin/" + b)
+    monkeypatch.setattr(providers.subprocess, "run", fake_run)
+
+    out = providers.Codex()("author selectors", schema={"type": "object"})
+    assert out == {"selectors": []}
+    assert "--output-schema" in captured["cmd"]
+    assert captured["schema_exists"]  # temp schema file present during the call

--- a/test/test_suggest_examples.py
+++ b/test/test_suggest_examples.py
@@ -8,8 +8,6 @@ headless evaluator and skip when the bridge isn't present.
 
 from __future__ import annotations
 
-import json
-
 import pytest
 
 from spytial.suggest import _enrich
@@ -48,24 +46,19 @@ def _draft(suggestions=None):
     return SpecDraft(LL, list(suggestions or []))
 
 
-class _Resp:
-    def __init__(self, payload):
-        self._payload = payload
-
-    def text(self):
-        return json.dumps(self._payload)
-
-
 class FakeModel:
-    """Returns a fixed ``{"selectors": [...]}`` payload; records prompts seen."""
+    """A callable provider returning a fixed ``{"selectors": [...]}`` dict.
+
+    Records prompts seen; a minimal provider for the selector tier.
+    """
 
     def __init__(self, candidates):
         self.candidates = candidates
         self.prompts = []
 
-    def prompt(self, prompt, schema=None):
+    def __call__(self, prompt, *, schema):
         self.prompts.append(prompt)
-        return _Resp({"selectors": self.candidates})
+        return {"selectors": self.candidates}
 
 
 def _v(selector, ok=True, empty=False, arity=2):
@@ -567,34 +560,29 @@ def test_vocabulary_unions_populated_types_across_examples():
 # --------------------------------------------------------------------------- #
 
 
-class _FakeLLM:
-    def get_model(self, *a, **k):
-        return _ShapeModel()
+class _ShapeProvider:
+    """A callable provider whose shape tier is a no-op — exercises enrich_draft wiring."""
+
+    def __call__(self, prompt, *, schema):
+        return {"shapes": []}
 
 
-class _ShapeModel:
-    def prompt(self, prompt, schema=None):
-        return _Resp({"shapes": []})  # shape tier no-op
-
-
-def test_enrich_draft_notes_when_no_examples(monkeypatch):
-    monkeypatch.setattr(_enrich, "_import_llm", lambda: _FakeLLM())
+def test_enrich_draft_notes_when_no_examples():
     draft = _draft()
-    _enrich.enrich_draft(draft, _ci(), model=None, examples=None)
+    _enrich.enrich_draft(draft, _ci(), provider=_ShapeProvider(), examples=None)
     assert any("pass examples" in n for n in draft.notes)
 
 
 def test_enrich_draft_runs_selector_tier_with_examples(monkeypatch):
-    monkeypatch.setattr(_enrich, "_import_llm", lambda: _FakeLLM())
     calls = []
     monkeypatch.setattr(
         sel,
         "enrich_from_examples",
-        lambda draft, ci, model, examples: calls.append(examples),
+        lambda draft, ci, provider, examples: calls.append(examples),
     )
     objs = [_instance(), _instance(2)]
     draft = _draft()
-    _enrich.enrich_draft(draft, _ci(), model=None, examples=objs)
+    _enrich.enrich_draft(draft, _ci(), provider=_ShapeProvider(), examples=objs)
     assert calls == [objs]  # selector tier invoked with the full example set
 
 


### PR DESCRIPTION
## What

Redesigns the `spytial.suggest` enrichment seam. **A provider is a callable `(prompt, *, schema) -> dict`**, and `enrich=` says *what* to enrich with — there is no ambient default.

```python
suggest(obj)                          # None → off
suggest(obj, enrich="llama3.2")       # str → a named llm model (explicit id)
suggest(obj, enrich=ClaudeCode())     # your Claude Max/Pro subscription (no API key)
suggest(obj, enrich=Codex())          # your ChatGPT plan — native --output-schema
suggest(obj, enrich=lambda p, *, schema: {...})   # any callable
```

## Why

The old surface was `enrich: bool` + `enrich_model: Optional[str]`, and `enrich=True` resolved `llm.get_model()` — i.e. **whatever `llm models default` happened to be on the machine**. That's an invisible, ambient dependency: the same call enriched differently (or silently not at all) depending on out-of-band `llm` config. And the boolean wasn't the meaningful axis — "how do I reach a model" is mandatory for enrichment to do anything. Making `enrich=` carry the provider removes the hidden state and makes the call self-describing.

It also unlocks **subscription-backed** enrichment (the recurring ask): the provider slot is small enough that `claude -p` and `codex exec` drop in as built-ins, so you can enrich from a Claude/ChatGPT subscription instead of a metered key.

## Changes

- **`spytial/suggest/providers.py`** (new): `EnrichProvider` (a `@runtime_checkable` *callable* Protocol), `as_provider()` resolver, `EnrichError`, and built-ins `LlmModel(id)` (wraps `llm`, named model — no default), `ClaudeCode(model=…)` (`claude -p`), `Codex(model=…)` (`codex exec --output-schema`, native JSON-schema). Helpers `instruct_json()` / `extract_json()` make a text-only backend a ~6-line adapter, with fence/prose-tolerant parsing written once.
- Providers return a parsed **dict** (not a JSON string) — native-schema backends skip a serialize/reparse round-trip; the tiers call `provider(prompt, schema=…)`.
- Errors **raise**; `suggest()` catches construction failures and each tier catches runtime failures, degrading to the static draft with a note — enrichment still never crashes `suggest()`.
- Dropped `enrich_model`, `_import_llm`, and the ambient-default resolution.
- Exports from `spytial.suggest`: `EnrichProvider, EnrichError, LlmModel, ClaudeCode, Codex`.

## Design notes for reviewers

- **Callable, not a named-method interface** — simplest slot that still supports stateful/config-carrying providers (via `__call__`) and inline lambdas.
- **`str` = `llm` sugar only** — no prefix-scheme registry; everything else is an explicit callable.
- **Subscriptions are individual/local use** (documented on `ClaudeCode`/`Codex`); use an API key (`LlmModel`) for hosted/multi-user.
- Breaking vs. the just-merged enrich API (`enrich=True`/`enrich_model`), which had no external users yet.

## Verification

- **266 tests pass** (+4 skipped). New coverage: the `as_provider` resolver, `extract_json`/`instruct_json`, and both subprocess providers via monkeypatched `subprocess.run`.
- **Live**: `enrich=ClaudeCode()` on the Claude subscription produced `reportsTo → above` and `mentor → above` in ~13s — the directional shapes small local (3–4B Ollama) models miss — with no API key. `enrich=Codex()` with `codex` absent degrades to a clean note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)