### PR TITLE
Bump spytial-core 2.9.0 → 2.10.1; group addEdge is now a direction

### DIFF
--- a/spytial/annotations.py
+++ b/spytial/annotations.py
@@ -268,6 +268,19 @@ class Group(SpytialAnnotation):
 
     Usage (selector-based):
         Grouped = Annotated[MyType, Group(selector='items', name='mygroup')]
+
+    For a selector-based group, ``addEdge`` controls the edge drawn between the
+    group's key and the group itself. For a binary selector with tuples
+    ``(a, b), (a, c), (a, d)`` the group is keyed by ``a`` and contains
+    ``{b, c, d}``:
+
+        - ``'none'``      -> draw nothing (default)
+        - ``'togroup'``   -> edge from the key into the group (a -> group)
+        - ``'fromgroup'`` -> edge from the group back to the key (group -> a)
+
+    Legacy ``addEdge=True`` is still accepted and maps to ``'togroup'``.
+
+        Grouped = Annotated[MyType, Group(selector='...', name='g', addEdge='togroup')]
     """
 
     _annotation_type = "group"

--- a/spytial/core_assets.py
+++ b/spytial/core_assets.py
@@ -1,6 +1,6 @@
 """Shared spytial-core browser asset definitions for HTML templates."""
 
-SPYTIAL_CORE_VERSION = "2.9.0"
+SPYTIAL_CORE_VERSION = "2.10.1"
 
 _CDN_BASE = f"https://cdn.jsdelivr.net/npm/spytial-core@{SPYTIAL_CORE_VERSION}"
 

--- a/test/test_data_instance_format.py
+++ b/test/test_data_instance_format.py
@@ -1,5 +1,5 @@
 """
-Tests that build_instance() output matches the spytial-core v2.9.0 IJsonDataInstance format.
+Tests that build_instance() output matches the spytial-core v2.10.1 IJsonDataInstance format.
 
 See spytial-core/docs/JSON_DATA_INSTANCE.md for the canonical spec.
 """

--- a/test/test_group_selector.py
+++ b/test/test_group_selector.py
@@ -32,6 +32,31 @@ def test_field_based_group_still_works():
     assert constraint['groupOn'] == 0
     assert constraint['addToGroup'] == 1
 
+def test_selector_group_addedge_direction():
+    """addEdge accepts the spytial-core >=2.10 direction values and serializes through."""
+    for direction in ('none', 'togroup', 'fromgroup'):
+        my_obj = [1, 2, 3]
+        annotate_group(
+            my_obj,
+            selector='{b : Basket, a : Fruit | a in b.fruit}',
+            name='byBasket',
+            addEdge=direction,
+        )
+        constraint = collect_decorators(my_obj)['constraints'][0]['group']
+        assert constraint['addEdge'] == direction
+
+        yaml_output = serialize_to_yaml_string(collect_decorators(my_obj))
+        assert f'addEdge: {direction}' in yaml_output
+
+
+def test_selector_group_addedge_legacy_boolean():
+    """Legacy addEdge=True still validates (spytial-core maps it to 'togroup')."""
+    my_obj = [1, 2, 3]
+    annotate_group(my_obj, selector='{x : Item | x.hot}', name='hot', addEdge=True)
+    constraint = collect_decorators(my_obj)['constraints'][0]['group']
+    assert constraint['addEdge'] is True
+
+
 def test_group_decorator_with_selector():
     """Test the group decorator with selector parameters."""
     my_dict = {'a': 1, 'b': 2}


### PR DESCRIPTION
## What changed

The CDN-pinned browser rendering engine had drifted to **2.9.0**, one minor release behind spytial-core. Bumps it to **2.10.1** and brings the `Group` annotation in line with the grouping change.

- **Version bump 2.9.0 → 2.10.1** in `spytial/core_assets.py` and the data-instance test docstring (via `update-spytial-core.sh`). All three 2.10.1 CDN assets verified reachable (`200`).
- **`Group.addEdge` is now documented as a direction.** In spytial-core [#487](https://github.com/sidprasad/spytial-core/pull/487), group-by-selector's `addEdge` went from a boolean to a three-way direction: `none` | `togroup` | `fromgroup`. For a binary selector `(a,b),(a,c),(a,d)` the group is keyed by `a` — `togroup` draws key→group, `fromgroup` draws group→key, `none` draws nothing.
- **Tests** lock in that `none`/`togroup`/`fromgroup` serialize through to YAML, and that legacy `addEdge=True` still validates.

## Why

Until this bump, diagrams rendered with a 2.9.0 engine that predates the grouping-direction feature, so `addEdge='togroup'`/`'fromgroup'` would not have taken effect in the browser.

## Notes for reviewers

- The Python schema treats `addEdge` as an opaque optional field, so the new direction *values* flow straight through to YAML with no validation change — spytial-core owns value validation and normalization (legacy `true` → `togroup`).
- The vendored headless evaluator was already at 2.10.1; only the CDN pin was behind. The two version references can drift independently.

## Verification

- `test_group_selector.py`, `test_core_embedding_assets.py`, `test_data_instance_format.py`: all pass.
- Full suite (excluding the CDN/selenium browser test): **275 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)