### PR TITLE
suggest: LLM is the primary shape author, built-in rules become backups

### DIFF
--- a/spytial/_version.py
+++ b/spytial/_version.py
@@ -1,3 +1,3 @@
 """Package version source of truth."""
 
-__version__ = "1.6.0"
+__version__ = "1.6.1"

--- a/spytial/suggest/__init__.py
+++ b/spytial/suggest/__init__.py
@@ -98,10 +98,13 @@ def suggest(
             enrich from a subscription instead of a metered key. ``None`` (default)
             or ``False`` leaves the draft static. Enrichment suggests the
             *spatial shape* of the structure (orientation directions per field,
-            ``cyclic`` for ring-like links, ``group`` for collections) where the
-            deterministic rules fall back to a flat ``below``; the model only chooses
-            the shape and spytial supplies the render-verified selector. Enriched rows
-            are tagged ``source="llm"`` and stay off by default — candidates you pick.
+            ``cyclic`` for ring-like links, ``group`` for collections). In this mode the
+            model is the *primary* shape author — even for fields the built-in rules
+            already name: its choice wins and is enabled, and the rule it beats is
+            demoted to a backup alternative (kept, off, one toggle away). The
+            deterministic shape returns as the active default only if the whole provider
+            call fails. The model only chooses the shape; spytial supplies the
+            render-verified selector. Enriched rows are tagged ``source="llm"``.
             When examples are available it additionally authors *selectors* for
             relational cases the shape tier can't express, validating each by
             evaluating it over every example. A spec that can't be resolved (``llm``

--- a/spytial/suggest/_enrich.py
+++ b/spytial/suggest/_enrich.py
@@ -23,10 +23,16 @@ companion tier in :mod:`spytial.suggest._enrich_from_examples`, which activates 
 example instances are available and validates every candidate by evaluating it over
 each of them.
 
-Enriched rows are tagged ``source="llm"``, stay off by default (you pick), and every
-failure path — an unresolvable provider, a malformed model response — degrades to the
-static draft with a note. Enrichment can never crash ``suggest()``. The provider (how
-to reach a model) is chosen by the caller via ``enrich=`` and resolved in
+In enrich mode the model is the *primary* shape author. When the call succeeds its
+choice for a structural field wins: it becomes the enabled suggestion and the built-in
+rule it competed with is demoted to a backup alternative — kept and visible, one toggle
+away, but off. A field the model abstains on (``none``) gets no shape, and its built-in
+shape steps down too: the model owns the field even when it deliberately chooses
+nothing. The deterministic rules only come back as the active default when the whole
+provider call fails — every failure path (an unresolvable provider, a malformed model
+response) degrades to the static draft with a note, and enrichment can never crash
+``suggest()``. Enriched rows stay tagged ``source="llm"``. The provider (how to reach a
+model) is chosen by the caller via ``enrich=`` and resolved in
 :mod:`spytial.suggest.providers`; this module just calls ``provider(prompt, schema=)``.
 """
 
@@ -171,12 +177,24 @@ def _ask_shapes(provider, ci: ClassInfo, fields: List) -> List[dict]:
 
 
 def _apply_shapes(draft: SpecDraft, ci: ClassInfo, fields: List, shapes: List) -> None:
-    """Turn validated shape choices into off-by-default, model-tagged suggestions.
+    """Let the model's shape choice win per structural field; demote the rule it beats.
 
-    Every selector is built by spytial from the field (the render-verified form the
-    deterministic rules use), never by the model. Choices that name an unknown field,
-    an out-of-vocabulary direction, or a constraint that doesn't fit the field's kind
-    are dropped — schema-level validation, no datum required.
+    The model is the primary shape author here. For each structural field it addressed:
+
+    * a **valid shape** becomes the enabled suggestion, and the built-in
+      orientation/cyclic it competed with is moved to ``draft.alternatives`` (a backup —
+      off, but one toggle away). If the model's shape is identical to the built-in's, the
+      built-in is left enabled instead (agreement, no churn, no duplicate row).
+    * an **explicit ``none``** (deliberate abstain) demotes the built-in shape too and
+      adds nothing — the model owns the field and chose no shape.
+    * an **invalid non-``none``** entry (a model slip: a direction that filtered to
+      empty, a ``group`` on a scalar) is ignored and the built-in shape stays enabled.
+
+    Every selector is still built by spytial from the field (the render-verified form the
+    deterministic rules use), never by the model. Choices that name an unknown field, an
+    out-of-vocabulary direction, or a constraint that doesn't fit the field's kind are
+    dropped — schema-level validation, no datum required. Fields the model doesn't
+    address at all keep their built-in shape untouched.
     """
     by_name = {f.name: f for f in fields}
     cls = ci.cls.__name__
@@ -187,13 +205,65 @@ def _apply_shapes(draft: SpecDraft, ci: ClassInfo, fields: List, shapes: List) -
         if f is None:
             continue  # model named a field we didn't analyze — drop it
         sug = _shape_to_suggestion(ci, cls, f, sh)
-        if sug is None:
+        builtins = _builtin_shape_rows_for_field(draft, ci, f)
+
+        if sug is not None:
+            # The model proposed a valid shape. If a built-in already says exactly this,
+            # leave it enabled (both agree) rather than relabel and duplicate.
+            if any(_same_shape(b, sug) for b in builtins):
+                continue
+            _demote(draft, builtins)  # the built-in shape becomes a backup alternative
+            key = _key(sug)
+            if key in seen:
+                continue
+            seen.add(key)
+            draft.suggestions.append(sug)
+        elif sh.get("constraint") == "none":
+            # Deliberate abstain: the model owns the field and picked no shape, so the
+            # built-in shape steps down to a backup as well (LLM wins, even as 'nothing').
+            _demote(draft, builtins)
+        # else: an invalid non-'none' entry — a model slip; leave the built-in enabled.
+
+
+def _builtin_shape_rows_for_field(draft: SpecDraft, ci: ClassInfo, f) -> List[Suggestion]:
+    """Deterministic orientation/cyclic rows whose shape the model now owns for ``f``.
+
+    A scalar self-reference carries ``source_field=f.name``; a container's derived
+    (parent, child) edge carries ``source_field=None`` and is matched by its selector
+    (the ``_children_selector`` form ``rules.child_container`` emits), so a plain-list
+    sequence's orientation — a different selector, and not a self-ref field — is left
+    alone.
+    """
+    cls = ci.cls.__name__
+    child_sel = (
+        _children_selector(cls, f.name, f.container) if f.container in _CONTAINERS else None
+    )
+    rows: List[Suggestion] = []
+    for s in draft.suggestions:
+        if s.source != "rule" or s.directive not in ("orientation", "cyclic"):
             continue
-        key = _key(sug)
-        if key in seen:
-            continue  # don't duplicate a directive the deterministic rules emitted
-        seen.add(key)
-        draft.suggestions.append(sug)
+        if s.source_field == f.name or (
+            s.source_field is None
+            and child_sel is not None
+            and s.kwargs.get("selector") == child_sel
+        ):
+            rows.append(s)
+    return rows
+
+
+def _demote(draft: SpecDraft, rows: List[Suggestion]) -> None:
+    """Move built-in shape rows out of the enabled set into backup alternatives."""
+    for s in rows:
+        try:
+            draft.suggestions.remove(s)
+        except ValueError:
+            continue  # already moved (shared by two shape choices) — skip
+        s.enabled_by_default = False
+        draft.alternatives.append(s)
+
+
+def _same_shape(a: Suggestion, b: Suggestion) -> bool:
+    return a.directive == b.directive and a.kwargs == b.kwargs
 
 
 def _shape_to_suggestion(ci: ClassInfo, cls: str, f, sh: dict) -> Optional[Suggestion]:
@@ -230,13 +300,15 @@ def _shape_to_suggestion(ci: ClassInfo, cls: str, f, sh: dict) -> Optional[Sugge
     else:
         return None  # 'none' or anything unrecognized — abstain
 
+    # The model is the primary shape author, so its pick is enabled by default; the
+    # built-in it beats is demoted to a backup in _apply_shapes.
     return Suggestion(
         kind,
         kwargs,
-        "low",
+        "medium",
         rationale,
         source_field,
-        enabled_by_default=False,
+        enabled_by_default=True,
         source="llm",
     )
 

--- a/test/test_suggest.py
+++ b/test/test_suggest.py
@@ -655,14 +655,53 @@ def test_enrich_bad_spec_degrades_with_note():
 
 def test_enrich_orientation_for_unfamiliar_field():
     # The provider picks a direction (above); spytial supplies the field-form selector.
+    # The model is the primary shape author, so its pick is enabled by default.
     payload = {"shapes": [_shape("escalation", "orientation", directions=["above"])]}
     draft = suggest(Ticket, enrich=_FakeProvider(payload))
     assert any(
         s.kwargs == {"selector": _edge("escalation"), "directions": ["above"]}
         and s.source == "llm"
-        and not s.enabled_by_default
+        and s.enabled_by_default
         for s in _of(draft, "orientation")
     )
+
+
+def test_enrich_shape_wins_and_demotes_rule_to_backup():
+    # LLM `above` beats the deterministic `below` for `escalation`: the model's row is
+    # the enabled suggestion, and the built-in `below` steps down to a backup
+    # alternative (kept, disabled) rather than vanishing.
+    payload = {"shapes": [_shape("escalation", "orientation", directions=["above"])]}
+    draft = suggest(Ticket, enrich=_FakeProvider(payload))
+    enabled = [s for s in draft.suggestions if s.directive == "orientation"
+               and s.source_field == "escalation"]
+    assert [(s.source, s.kwargs["directions"]) for s in enabled] == [("llm", ["above"])]
+    demoted = [s for s in draft.alternatives
+               if s.directive == "orientation" and s.source == "rule"
+               and s.kwargs["directions"] == ["below"]]
+    assert demoted and demoted[0].enabled_by_default is False
+
+
+def test_enrich_abstain_demotes_rule_shape():
+    # A deliberate `none` means the model owns the field and chose no shape — the
+    # built-in `below` is demoted to a backup, and nothing is enabled in its place.
+    payload = {"shapes": [_shape("escalation", "none")]}
+    draft = suggest(Ticket, enrich=_FakeProvider(payload))
+    assert not any(s.directive == "orientation" and s.source_field == "escalation"
+                   for s in draft.suggestions)
+    assert any(s.directive == "orientation" and s.source == "rule"
+               and s.source_field == "escalation" for s in draft.alternatives)
+
+
+def test_enrich_agreement_keeps_builtin_no_duplicate():
+    # When the model agrees with the deterministic rule (`below` == `below`), keep the
+    # built-in enabled — no relabelled llm duplicate, no demotion.
+    payload = {"shapes": [_shape("escalation", "orientation", directions=["below"])]}
+    draft = suggest(Ticket, enrich=_FakeProvider(payload))
+    assert not _of(draft, "orientation")  # no llm orientation row added
+    kept = [s for s in draft.suggestions if s.directive == "orientation"
+            and s.source_field == "escalation"]
+    assert [(s.source, s.enabled_by_default) for s in kept] == [("rule", True)]
+    assert not draft.alternatives  # nothing demoted
 
 
 def test_enrich_orientation_over_container_uses_children_selector():


### PR DESCRIPTION
## What

When enriching `spytial.suggest` with a model, the **shape tier** now lets the LLM own the spatial shape of every structural field it addresses — including the familiar-vocabulary fields (`left`/`right`/`next`/`prev`/`parent`/`children`) the deterministic rules already name.

Previously LLM shape rows were off-by-default *candidates* that de-duped against the rules. Now, once the provider call **succeeds**, the model's choice becomes the enabled default:

| Case | New behavior |
|---|---|
| LLM proposes a valid shape | **enabled**; the built-in `orientation`/`cyclic` it beats → `draft.alternatives` (backup — kept, off, one toggle away) |
| LLM abstains (`constraint:"none"`) | built-in **demoted** too, nothing enabled — the model owns the field even when it picks nothing |
| LLM invalid non-`none` (empty-after-filter directions, `group` on a scalar) | ignored; built-in stays enabled |
| LLM agrees with the rule (identical shape) | built-in left enabled — no relabel, no duplicate row |
| Whole provider call fails | rules are the active default again (existing degrade-to-static path) |

A field the model doesn't mention **at all** keeps its built-in shape, so a truncated/garbled response can't silently strip good rule shapes.

## Why

The old contract only surfaced the LLM's better guesses (e.g. `manager`/`escalation` → `above` instead of the rules' flat `below`) as off-by-default candidates the user had to hunt for and opt into. The intent of enrichment is that **the model does the shape suggesting and the built-in rules are the backup** — so in enrich mode the LLM's pick should be the default, with the deterministic rule one click away.

## Notes for reviewers

- Scoped entirely to the shape tier in `spytial/suggest/_enrich.py`. Core change is in `_apply_shapes`, plus new helpers `_builtin_shape_rows_for_field` / `_demote` / `_same_shape`. Shape `Suggestion`s are now `confidence="medium", enabled_by_default=True`.
- **Tier-2 (selector-by-example) is unchanged** — those remain off-by-default candidates, since they add relational selectors the rules never produced.
- **Side effect / bug fix:** the old order-sensitive duplicate wart (LLM `['left','below']` vs rule `['below','left']` surfacing as two rows) is gone — now exactly one enabled row per field.
- Verified against the **real `ClaudeCode` provider** (`claude -p --model sonnet`): `manager`/`escalation` → `above` enabled with the rule's `below` demoted; a binary tree's `left`/`right` won and demoted the rules to backups. Docstrings (`__init__.py`, `_enrich.py`) updated.

## Tests

Full suite: **278 passed, 5 skipped**. Three new tests lock the new behavior:
- `test_enrich_shape_wins_and_demotes_rule_to_backup`
- `test_enrich_abstain_demotes_rule_shape`
- `test_enrich_agreement_keeps_builtin_no_duplicate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)