### PR TITLE
spytial-core 3.2.1 + inferredEdge draw; document the decorators; align hold/projection/value-sets

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -106,7 +106,7 @@ import spytial
 
 # Test object-level spatial annotations
 my_list = [1, 2, 3, 4, 5]
-spytial.annotate_orientation(my_list, selector='items', directions=['horizontal'])
+spytial.annotate_orientation(my_list, selector='items', directions=['left'])
 result = spytial.diagram(my_list, method='file', auto_open=False)
 print(f"Generated object annotation diagram: {result}")
 print("✓ Object annotations work")

--- a/demos/example_type_aliases_auto_method.py
+++ b/demos/example_type_aliases_auto_method.py
@@ -15,12 +15,12 @@ import spytial
 
 # Define annotated type aliases with spatial constraints
 IntList = Annotated[list[int],
-    spytial.Orientation(selector='items', directions=['horizontal']),
+    spytial.Orientation(selector='items', directions=['left']),
     spytial.AtomColor(selector='self', value='steelblue')
 ]
 
 VerticalList = Annotated[list[str],
-    spytial.Orientation(selector='items', directions=['vertical']),
+    spytial.Orientation(selector='items', directions=['below']),
     spytial.AtomColor(selector='items', value='coral'),
     spytial.Size(selector='items', height=40, width=60)
 ]
@@ -101,7 +101,7 @@ Example Usage:
    
    # Define annotated types
    IntList = Annotated[list[int],
-       spytial.Orientation(selector='items', directions=['horizontal']),
+       spytial.Orientation(selector='items', directions=['left']),
        spytial.AtomColor(selector='self', value='blue')
    ]
    

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -18,8 +18,9 @@ arguments. The sections below break each one into its parts.
 
 1. **`selector`** — the edges to orient.
 2. **`directions`** — where the target sits relative to its source, as a list
-   (e.g. `['below', 'left']`). Common values: `above`, `below`, `left`, `right`,
-   and the adjacency variants `directlyLeft` / `directlyRight`.
+   (e.g. `['below', 'left']`). One of `above`, `below`, `left`, `right`, or the
+   adjacency variants `directlyAbove`, `directlyBelow`, `directlyLeft`,
+   `directlyRight`, which also require that nothing sits in between.
 
 ```python
 @spytial.orientation(
@@ -31,12 +32,21 @@ arguments. The sections below break each one into its parts.
 ### `align` — line atoms up on a shared axis
 
 1. **`selector`** — the atoms to align.
-2. **`direction`** — the axis to share.
+2. **`direction`** — the axis to share: `'horizontal'` or `'vertical'`.
 
 ### `cyclic` — arrange atoms in a ring
 
 1. **`selector`** — the atoms/edges forming the cycle.
-2. **`direction`** — which way the ring runs.
+2. **`direction`** — which way the ring runs: `'clockwise'` or
+   `'counterclockwise'`.
+
+> These value sets are closed, and spytial checks them where you write them. The
+> easy mistake is borrowing another constraint's words — `align` takes the *axis*
+> (`horizontal`/`vertical`) while `orientation` takes *placements*
+> (`above`/`left`/…), and swapping them is not an error spytial-core reports: an
+> unknown orientation direction just quietly drops the constraint, and a
+> misspelled `cyclic` direction reads as `clockwise`. Same for `flag`, which acts
+> on exactly `hideDisconnected` and `hideDisconnectedBuiltIns`.
 
 ### `group` — enclose atoms in a labelled region
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -145,6 +145,7 @@ from spytial import LineStyle, TextStyle, BorderStyle, FillStyle
 3. **`lineStyle`** / **`textStyle`** *(optional)* — style the drawn edge and its
    label (same blocks as `edgeStyle`; the inline `color`/`style`/`weight`
    arguments are deprecated).
+4. **`draw`** *(optional)* — where each end attaches. See below.
 
 ```python
 @spytial.inferredEdge(
@@ -152,6 +153,36 @@ from spytial import LineStyle, TextStyle, BorderStyle, FillStyle
     name='edge',                                               # edge label
 )
 ```
+
+#### `draw` — attach an end to a group's hull
+
+By default an inferred edge runs atom-to-atom. **`draw`** is a string
+`'<end> -> <end>'` where each end is either `'_'` (the atom itself) or the
+**name of a `group` constraint** — in which case that end attaches to the hull
+of the group *keyed by that end's atom*. This is what makes group-to-group and
+node-to-group edges expressible.
+
+```python
+# A binary group selector: one group per Team, keyed by the Team atom.
+@spytial.group(selector='{ t : Team, l : list | l in t.members }', name='regions')
+@spytial.inferredEdge(
+    name='reports to',
+    selector='{ a : Team, b : Team | b = a.parent }',
+    draw='regions -> regions',   # hull to hull, rather than node to node
+)
+```
+
+`'_ -> regions'` runs from the atom to a group's hull; `'_ -> _'` means the same
+as omitting `draw`. The edge's own selector still ranges over atoms either way —
+and with `draw`, a unary edge selector is allowed, its atom feeding both ends.
+
+> **The referenced group must be keyed** — that is, declared with a *binary*
+> selector, whose first element becomes the key. `draw` resolves each end by
+> looking up the group of that name keyed by that end's atom, so a group built
+> from a unary selector (`selector='Team.members'`) has no key for any end to
+> match, and the edge is dropped without drawing anything. A group *name* that
+> matches no `group` constraint at all is a hard error at render time; an atom
+> that keys no group of that name is reported in the browser console.
 
 ### `tag` — attach a computed label
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -58,6 +58,18 @@ from spytial import GroupEdge, LineStyle, TextStyle
 )
 ```
 
+### `hold` — invert any constraint
+
+Every constraint takes an optional **`hold`**. It defaults to `'always'`; pass
+`'never'` to require the opposite — the layout must *not* satisfy the
+constraint. It's how you say "these must not be grouped" or "y is never below
+x", rather than leaving the relationship unconstrained.
+
+```python
+@spytial.orientation(selector='children', directions=['below'], hold='never')
+@spytial.group(selector='Team.members', name='Team', hold='never')
+```
+
 ## Directives
 
 ### `attribute` — show a field as inline text

--- a/scripts/pre_publish_check.py
+++ b/scripts/pre_publish_check.py
@@ -90,7 +90,7 @@ def validate_imports_and_functionality():
         
         # Test object annotations
         my_list = [1, 2, 3, 4, 5]
-        spytial.annotate_orientation(my_list, selector='items', directions=['horizontal'])
+        spytial.annotate_orientation(my_list, selector='items', directions=['left'])
         result = spytial.diagram(my_list, method='file', auto_open=False)
         print("✅ Object annotations work")
         

--- a/spytial/_version.py
+++ b/spytial/_version.py
@@ -1,3 +1,3 @@
 """Package version source of truth."""
 
-__version__ = "1.7.1"
+__version__ = "1.7.2"

--- a/spytial/_version.py
+++ b/spytial/_version.py
@@ -1,3 +1,3 @@
 """Package version source of truth."""
 
-__version__ = "1.7.2"
+__version__ = "1.8.0"

--- a/spytial/annotations.py
+++ b/spytial/annotations.py
@@ -246,6 +246,40 @@ def _coerce_style_blocks(annotation_type, kwargs):
     return out
 
 
+CONSTRAINT_HOLDS = ("always", "never")
+
+
+def _validate_hold(hold):
+    """Reject a `hold` value core would not recognise.
+
+    Core negates a constraint on exactly ``hold: never`` and treats every other
+    value as "not negated" (layoutspec.ts parseConstraints). A typo would
+    therefore leave the constraint positive — the inverse of what was written —
+    with nothing to show for it, so it has to fail here or not at all.
+    """
+    if hold not in CONSTRAINT_HOLDS:
+        raise ValueError(f"hold must be 'always' or 'never', got {hold!r}")
+    return hold
+
+
+def _normalize_hold(annotation_type, kwargs):
+    """Validate `hold` and drop the default on the ``**kwargs`` paths.
+
+    The Annotated[...] constraint classes take ``hold`` as a real parameter and
+    do this in ``__init__``; the decorator and object paths take it as an opaque
+    kwarg, where ``validate_fields`` only checks that the *key* is allowed. This
+    gives those paths the same contract: reject what core cannot read, and omit
+    ``always``, which carries no information.
+
+    Idempotent — the decorator-on-object path normalizes twice.
+    """
+    if "hold" not in kwargs or annotation_type not in CONSTRAINT_TYPES:
+        return kwargs
+    if _validate_hold(kwargs["hold"]) == "always":
+        return {k: v for k, v in kwargs.items() if k != "hold"}
+    return kwargs
+
+
 # Annotations spytial-core's layout-spec parser does not read at all. Unlike the
 # legacy style forms below, there is nothing to rewrite them into — they simply
 # have no effect on the diagram, so say so at the authoring site rather than let
@@ -536,8 +570,7 @@ class Orientation(SpytialAnnotation):
     _is_constraint = True
 
     def __init__(self, *, selector: str, directions: list, hold: str = "always"):
-        if hold not in ("always", "never"):
-            raise ValueError(f"hold must be 'always' or 'never', got {hold!r}")
+        _validate_hold(hold)
         kwargs = dict(selector=selector, directions=directions)
         if hold == "never":
             kwargs["hold"] = hold
@@ -556,8 +589,7 @@ class Cyclic(SpytialAnnotation):
     _is_constraint = True
 
     def __init__(self, *, selector: str, direction: str, hold: str = "always"):
-        if hold not in ("always", "never"):
-            raise ValueError(f"hold must be 'always' or 'never', got {hold!r}")
+        _validate_hold(hold)
         kwargs = dict(selector=selector, direction=direction)
         if hold == "never":
             kwargs["hold"] = hold
@@ -579,8 +611,7 @@ class Align(SpytialAnnotation):
     _is_constraint = True
 
     def __init__(self, *, selector: str, direction: str, hold: str = "always"):
-        if hold not in ("always", "never"):
-            raise ValueError(f"hold must be 'always' or 'never', got {hold!r}")
+        _validate_hold(hold)
         kwargs = dict(selector=selector, direction=direction)
         if hold == "never":
             kwargs["hold"] = hold
@@ -622,8 +653,7 @@ class Group(SpytialAnnotation):
     _is_constraint = True
 
     def __init__(self, *, hold: str = "always", **kwargs):
-        if hold not in ("always", "never"):
-            raise ValueError(f"hold must be 'always' or 'never', got {hold!r}")
+        _validate_hold(hold)
         if hold == "never":
             kwargs["hold"] = hold
         # Accept either field-based or selector-based parameters
@@ -1324,6 +1354,7 @@ def _create_decorator(constraint_type, doc=None):
             constraint_type, kwargs, stacklevel=2
         )
         kwargs = _coerce_style_blocks(effective_type, kwargs)
+        kwargs = _normalize_hold(effective_type, kwargs)
 
         def unified_decorator(target):
             # Check if target is a class (type) or an object instance
@@ -1757,6 +1788,7 @@ def _annotate_object(obj, annotation_type, **kwargs):
         annotation_type, kwargs, stacklevel=4
     )
     kwargs = _coerce_style_blocks(annotation_type, kwargs)
+    kwargs = _normalize_hold(annotation_type, kwargs)
     _warn_if_noop(annotation_type, stacklevel=4)
 
     registry = _ensure_object_registry(obj)

--- a/spytial/annotations.py
+++ b/spytial/annotations.py
@@ -18,18 +18,22 @@ class NoAliasDumper(yaml.Dumper):
 
 # Registry to store constraints and directives
 # This is now class-level, not global
+# `hold` is valid on every constraint: core reads `hold: never` off the inner
+# block and flips the constraint to its negation (layoutspec.ts parseConstraints).
 CONSTRAINT_TYPES = {
-    "cyclic": ["selector", "direction"],
-    "orientation": ["selector", "directions"],
-    "align": ["selector", "direction"],
+    "cyclic": {"required": ["selector", "direction"], "optional": ["hold"]},
+    "orientation": {"required": ["selector", "directions"], "optional": ["hold"]},
+    "align": {"required": ["selector", "direction"], "optional": ["hold"]},
     "group": [
         {
             "required": ["field", "groupOn", "addToGroup"],
-            "optional": ["selector", "showLabel"],
+            # No showLabel: core builds GroupByField(field, groupOn, addToGroup,
+            # selector, negated) and derives label visibility from negation alone.
+            "optional": ["selector", "hold"],
         },  # Legacy, more ergonomic
         {
             "required": ["selector", "name"],
-            "optional": ["addEdge", "textStyle"],
+            "optional": ["addEdge", "textStyle", "hold"],
         },  # Selector-based group constraint
     ],
 }
@@ -240,6 +244,31 @@ def _coerce_style_blocks(annotation_type, kwargs):
             value = _coerce_block(block_cls, value, f"{annotation_type}.{key}")
         out[key] = value
     return out
+
+
+# Annotations spytial-core's layout-spec parser does not read at all. Unlike the
+# legacy style forms below, there is nothing to rewrite them into — they simply
+# have no effect on the diagram, so say so at the authoring site rather than let
+# the spec look like it applied.
+_NOOP_ANNOTATIONS = {
+    "projection": (
+        "projection has no effect: spytial-core's layout-spec parser does not read it. "
+        "Projection is a pre-layout transform over the data instance, driven by the "
+        "viewer's projection controls, not a layout directive. Remove the annotation."
+    ),
+}
+
+
+def _warn_if_noop(annotation_type, *, stacklevel):
+    """Warn at the authoring site for annotations spytial-core silently ignores.
+
+    Called from each path exactly once (the decorator's class branch, the object
+    path's ``_annotate_object``, and the ``Annotated[...]`` class's ``__init__``),
+    so a single authoring site produces a single warning.
+    """
+    message = _NOOP_ANNOTATIONS.get(annotation_type)
+    if message is not None:
+        warnings.warn(message, DeprecationWarning, stacklevel=stacklevel)
 
 
 def _drop_invalid_legacy(value, ok, what):
@@ -493,9 +522,14 @@ class Orientation(SpytialAnnotation):
     """
     Orientation constraint for spatial layout.
 
+    ``directions`` are the placement words -- above/below/left/right and the
+    adjacency variants directlyAbove/directlyBelow/directlyLeft/directlyRight.
+    (horizontal/vertical are Align's vocabulary, not this one; core matches no
+    case for them here and the constraint would be dropped.)
+
     Usage:
         from typing import Annotated
-        IntList = Annotated[list[int], Orientation(selector='items', directions=['horizontal'])]
+        IntList = Annotated[list[int], Orientation(selector='items', directions=['left'])]
     """
 
     _annotation_type = "orientation"
@@ -534,8 +568,11 @@ class Align(SpytialAnnotation):
     """
     Alignment constraint.
 
+    ``direction`` is the shared axis: 'horizontal' or 'vertical'. Core rejects
+    anything else as internally inconsistent.
+
     Usage:
-        AlignedList = Annotated[list[int], Align(selector='items', direction='left')]
+        AlignedList = Annotated[list[int], Align(selector='items', direction='horizontal')]
     """
 
     _annotation_type = "align"
@@ -799,16 +836,22 @@ class HideAtom(SpytialAnnotation):
 
 class Projection(SpytialAnnotation):
     """
-    Projection directive.
+    Deprecated projection directive; it has no effect.
+
+    spytial-core's layout-spec parser does not read ``projection`` — projecting
+    over a sig is a pre-layout transform on the data instance, driven by the
+    viewer's projection controls, rather than something a layout spec declares.
+    Authoring one emits YAML that core discards, so remove it.
 
     Usage:
-        Projected = Annotated[MyType, Projection(sig='MySig')]
+        Projected = Annotated[MyType, Projection(sig='MySig')]  # no-op
     """
 
     _annotation_type = "projection"
     _is_constraint = False
 
     def __init__(self, *, sig: str):
+        _warn_if_noop("projection", stacklevel=3)
         super().__init__(sig=sig)
 
 
@@ -1262,11 +1305,14 @@ def validate_fields(type_, kwargs, valid_fields):
             print(f"Warning: Unknown fields for '{type_}': {', '.join(unknown_fields)}")
 
 
-def _create_decorator(constraint_type):
+def _create_decorator(constraint_type, doc=None):
     """
     Create a decorator function for a specific constraint or directive type.
     This now works for both classes and objects in a more Pythonic way.
     :param constraint_type: The type of constraint or directive (e.g., 'cyclic', 'orientation').
+    :param doc: Docstring for the returned decorator. Everything these decorators
+        accept is a ``**kwargs`` key, so ``help()`` and IDE hovers have nothing to
+        show unless the accepted keys are spelled out here.
     :return: A decorator function that works on both classes and objects.
     """
 
@@ -1283,6 +1329,9 @@ def _create_decorator(constraint_type):
             # Check if target is a class (type) or an object instance
             if isinstance(target, type):
                 # Class decoration (original behavior)
+                # The object branch warns via _annotate_object instead, so a
+                # given authoring site never warns twice.
+                _warn_if_noop(effective_type, stacklevel=3)
                 # Check if this CLASS (not inherited) has its own registry
                 if "__spytial_registry__" not in target.__dict__:
                     # Create a new registry for this class
@@ -1321,27 +1370,356 @@ def _create_decorator(constraint_type):
 
         return unified_decorator
 
+    decorator.__name__ = constraint_type
+    decorator.__qualname__ = constraint_type
+    decorator.__doc__ = doc
     return decorator
 
 
 # Create individual decorator functions for each constraint and directive type
-orientation = _create_decorator("orientation")
-cyclic = _create_decorator("cyclic")
-align = _create_decorator("align")
-group = _create_decorator("group")
-atomColor = _create_decorator("atomColor")  # deprecated: rewrites to atomStyle
-atomStyle = _create_decorator("atomStyle")
-size = _create_decorator("size")
-icon = _create_decorator("icon")
-edgeColor = _create_decorator("edgeColor")  # deprecated: rewrites to edgeStyle
-edgeStyle = _create_decorator("edgeStyle")
-projection = _create_decorator("projection")
-attribute = _create_decorator("attribute")
-hideField = _create_decorator("hideField")
-hideAtom = _create_decorator("hideAtom")
-inferredEdge = _create_decorator("inferredEdge")
-tag = _create_decorator("tag")
-flag = _create_decorator("flag")
+#
+# Everything these take is a **kwargs key, so the docstring is the only thing
+# help() and IDE hovers can show. Each one lists the keys spytial-core actually
+# reads -- no more, no less.
+
+_HOLD_DOC = """
+    ``hold='never'`` inverts the constraint: the layout must *not* satisfy it.
+    """
+
+orientation = _create_decorator(
+    "orientation",
+    doc="""Place a relation's target relative to its source.
+
+    Usage:
+        @spytial.orientation(
+            selector='{ x : TreeNode, y : TreeNode | x.left = y }',
+            directions=['below', 'left'],
+        )
+
+    Accepted keys:
+
+    - ``selector`` -- the edges to orient (a binary selector: source, target).
+    - ``directions`` -- a list of placement words applied to every matched pair:
+
+        - ``'above'``, ``'below'``, ``'left'``, ``'right'``
+        - ``'directlyAbove'``, ``'directlyBelow'``, ``'directlyLeft'``,
+          ``'directlyRight'`` -- also require adjacency (nothing in between)
+
+      These are Orientation's vocabulary; 'horizontal'/'vertical' belong to
+      ``align`` and match nothing here.
+    - ``hold`` -- 'always' (default) or 'never'.
+    """
+    + _HOLD_DOC,
+)
+
+cyclic = _create_decorator(
+    "cyclic",
+    doc="""Arrange atoms evenly around a ring.
+
+    Usage:
+        @spytial.cyclic(selector='{ x : Node, y : Node | x.next = y }',
+                        direction='clockwise')
+
+    Accepted keys:
+
+    - ``selector`` -- the edges forming the cycle.
+    - ``direction`` -- ``'clockwise'`` or ``'counterclockwise'``; fixes the
+      traversal order around the ring. Required here, though core would
+      default it to 'clockwise'.
+    - ``hold`` -- 'always' (default) or 'never'.
+
+    Two cyclic constraints on the same selector with different directions are a
+    hard error in core, not a silent pick.
+    """
+    + _HOLD_DOC,
+)
+
+align = _create_decorator(
+    "align",
+    doc="""Line atoms up on a shared axis.
+
+    Usage:
+        @spytial.align(selector='{ x : Cell, y : Cell | y in x.row }',
+                       direction='horizontal')
+
+    Accepted keys:
+
+    - ``selector`` -- the atoms to align.
+    - ``direction`` -- the shared axis: ``'horizontal'`` or ``'vertical'``.
+      Core rejects any other value as internally inconsistent. (The placement
+      words above/below/left/right belong to ``orientation``.)
+    - ``hold`` -- 'always' (default) or 'never'.
+    """
+    + _HOLD_DOC,
+)
+group = _create_decorator(
+    "group",
+    doc="""Enclose atoms in a labelled region.
+
+    Usage (selector-based):
+        @spytial.group(selector='Team.members', name='Team')
+
+    Usage (field-based, legacy):
+        @spytial.group(field='children', groupOn=0, addToGroup=1)
+
+    A binary selector matching tuples (a, b), (a, c), (a, d) keys the group on
+    ``a`` and fills it with {b, c, d}; each distinct key gets its own region. A
+    unary selector puts every atom it matches into one region.
+
+    Accepted keys (selector-based):
+
+    - ``selector`` -- the relation (or atoms) to group.
+    - ``name`` -- the label drawn on the region.
+    - ``addEdge`` -- the connector between the group's key and the group:
+
+        - ``'none'`` (default) -- draw nothing
+        - ``'togroup'``   -- edge from the key into the group (a -> group)
+        - ``'fromgroup'`` -- edge from the group back to the key (group -> a)
+
+      Legacy ``addEdge=True`` is still accepted and means ``'togroup'``.
+
+    - ``textStyle`` -- styles the group's own label, e.g. TextStyle(color='navy').
+    - ``hold`` -- 'always' (default) or 'never'. With 'never' the selected
+      members must *not* form a group. ``name`` stays required here, though
+      core would synthesize one for a negated group.
+
+    To style the connector as well as aim it, pass a ``GroupEdge`` instead of a
+    bare string; ``points`` carries the direction:
+
+        @spytial.group(
+            selector='Team.members',
+            name='Team',
+            addEdge=GroupEdge(
+                points='fromgroup',
+                lineStyle=LineStyle(pattern='dashed', color='grey'),
+                textStyle=TextStyle(size='small'),
+            ),
+            textStyle=TextStyle(color='navy'),
+        )
+    """,
+)
+atomColor = _create_decorator(  # deprecated: rewrites to atomStyle
+    "atomColor",
+    doc="""Deprecated. Color an atom's border; rewritten to ``atomStyle``.
+
+    Raises a DeprecationWarning and becomes
+    ``atomStyle(selector=..., borderStyle=BorderStyle(color=value))`` --
+    the legacy directive tinted the *outline*, not the interior. For a filled
+    look, use ``atomStyle`` with a ``fillStyle`` block instead.
+
+    Accepted keys: ``selector``, ``value`` (a CSS color).
+    """,
+)
+
+atomStyle = _create_decorator(
+    "atomStyle",
+    doc="""Style an atom's outline, interior, and label.
+
+    Usage:
+        @spytial.atomStyle(
+            selector='Node',
+            borderStyle=BorderStyle(color='steelblue'),
+            fillStyle=FillStyle(color='#eef6ff'),
+        )
+
+    Accepted keys (all optional -- set only what you mean):
+
+    - ``selector`` -- which atoms; omit to match every atom.
+    - ``borderStyle`` -- BorderStyle(color=..., width=...) -- the outline.
+    - ``fillStyle`` -- FillStyle(color=...) -- the interior.
+    - ``textStyle`` -- TextStyle(size=..., color=...) -- the atom's label;
+      ``size`` is 'small' | 'normal' | 'large'.
+
+    Plain dicts with the same keys work wherever the blocks do.
+
+    Two rules that set the same property of the same atom to different values
+    raise a StyleCollisionError at render time (spytial-core 3.0) rather than
+    silently keeping one. Set each property in exactly one matching rule.
+    """,
+)
+
+size = _create_decorator(
+    "size",
+    doc="""Fix an atom's drawn dimensions.
+
+    Usage:
+        @spytial.size(selector='Node', height=50, width=50)
+
+    Accepted keys: ``selector``, ``height``, ``width``.
+    Height and width are required and must be greater than 0.
+    """,
+)
+
+icon = _create_decorator(
+    "icon",
+    doc="""Draw atoms as an icon instead of a plain box.
+
+    Usage:
+        @spytial.icon(selector='{ n : Node | n.is_dir = True }',
+                      path='fa:folder', showLabels=True)
+
+    Accepted keys:
+
+    - ``selector`` -- which atoms get the icon.
+    - ``path`` -- the icon source.
+    - ``showLabels`` -- keep the atom's label alongside the icon. Required here
+      (unlike the Icon class, which defaults it to True); core reads a missing
+      showLabels as False.
+    """,
+)
+
+edgeColor = _create_decorator(  # deprecated: rewrites to edgeStyle
+    "edgeColor",
+    doc="""Deprecated. Color a relation's edges; rewritten to ``edgeStyle``.
+
+    Raises a DeprecationWarning and becomes ``edgeStyle`` with a ``lineStyle``
+    block: ``value`` -> lineStyle.color, ``style`` -> lineStyle.pattern,
+    ``weight`` -> lineStyle.weight.
+
+    Accepted keys: ``field``, ``value``, and optionally ``selector``,
+    ``filter``, ``style``, ``weight``, ``showLabel``, ``hidden``.
+    """,
+)
+
+edgeStyle = _create_decorator(
+    "edgeStyle",
+    doc="""Style the edges of a relation.
+
+    Usage:
+        @spytial.edgeStyle(field='next',
+                           lineStyle=LineStyle(color='crimson', pattern='dashed'))
+        @spytial.edgeStyle(field='internal', hidden=True)
+
+    Accepted keys:
+
+    - ``field`` -- the relation whose edges this styles. Edge styling matches on
+      ``field``; a ``selector`` alone will not select edges.
+    - ``selector`` -- optional unary selector narrowing which source atoms match.
+    - ``filter`` -- optional tuple filter for n-ary relations.
+    - ``lineStyle`` -- LineStyle(color=..., pattern=..., weight=..., highlight=...);
+      ``pattern`` is 'solid' | 'dashed' | 'dotted', ``weight`` is a number > 0.
+    - ``textStyle`` -- TextStyle(size=..., color=...) -- the edge's label.
+    - ``showLabel`` -- whether the edge's label is drawn.
+    - ``hidden`` -- drop the edge entirely.
+
+    Two rules that set the same property of the same edge to different values
+    raise a StyleCollisionError at render time (spytial-core 3.0).
+    """,
+)
+
+projection = _create_decorator(
+    "projection",
+    doc="""Deprecated. Has no effect on the diagram.
+
+    spytial-core's layout-spec parser does not read ``projection``: projecting
+    over a sig is a pre-layout transform on the data instance, driven by the
+    viewer's projection controls, not something a layout spec declares. This
+    emits YAML that core discards, so remove it.
+
+    Accepted keys: ``sig``.
+    """,
+)
+
+attribute = _create_decorator(
+    "attribute",
+    doc="""Fold a field into its source atom as inline text.
+
+    Shows the field's value as a line inside the node, instead of drawing a
+    separate box and arrow for it.
+
+    Usage:
+        @spytial.attribute(field='value')
+        @spytial.attribute(field='weight', textStyle=TextStyle(size='small'))
+
+    Accepted keys:
+
+    - ``field`` -- the field to fold in.
+    - ``selector`` -- optional; which source atoms this applies to.
+    - ``filter`` -- optional tuple filter, e.g. only tuples where a flag is True.
+    - ``textStyle`` -- TextStyle(size=..., color=...) -- styles this line.
+    """,
+)
+
+hideField = _create_decorator(
+    "hideField",
+    doc="""Suppress a relation's edges and attributes.
+
+    Usage:
+        @spytial.hideField(field='_private')
+        @spytial.hideField(field='debug', filter='debug & Production')
+
+    Accepted keys: ``field``, plus optional ``selector`` and ``filter``.
+    """,
+)
+
+hideAtom = _create_decorator(
+    "hideAtom",
+    doc="""Remove selected atoms from the diagram.
+
+    Usage:
+        @spytial.hideAtom(selector='{ n : Node | n.internal }')
+
+    Accepted keys: ``selector``.
+    """,
+)
+
+inferredEdge = _create_decorator(
+    "inferredEdge",
+    doc="""Draw an edge that is not a field of the data.
+
+    Materializes a derived relation as a labelled edge.
+
+    Usage:
+        @spytial.inferredEdge(
+            selector='{ x : Vertex, y : Vertex | y in x.neighbors }',
+            name='edge',
+            lineStyle=LineStyle(color='grey', pattern='dotted'),
+        )
+
+    Accepted keys:
+
+    - ``name`` -- the label for the drawn edge.
+    - ``selector`` -- the pairs to connect.
+    - ``lineStyle`` -- LineStyle(color=..., pattern=..., weight=..., highlight=...).
+    - ``textStyle`` -- TextStyle(size=..., color=...) -- the edge's label.
+
+    The inline ``color`` / ``style`` / ``weight`` keys are the deprecated 2.x
+    form; they still parse and are rewritten into ``lineStyle``.
+    """,
+)
+
+tag = _create_decorator(
+    "tag",
+    doc="""Attach a computed label to a type's atoms.
+
+    Usage:
+        @spytial.tag(toTag='Node', name='depth', value='n.depth',
+                     textStyle=TextStyle(size='small'))
+
+    Accepted keys:
+
+    - ``toTag`` -- the type to tag.
+    - ``name`` -- the label's name.
+    - ``value`` -- the field or expression to show.
+    - ``textStyle`` -- TextStyle(size=..., color=...) -- styles this line.
+    """,
+)
+
+flag = _create_decorator(
+    "flag",
+    doc="""Flip a whole-diagram rendering switch.
+
+    Usage:
+        @spytial.flag(name='hideDisconnected')
+
+    Accepted keys: ``name``. Core acts on exactly two values:
+
+    - ``'hideDisconnected'`` -- drop atoms that have no edges.
+    - ``'hideDisconnectedBuiltIns'`` -- drop only disconnected built-in atoms.
+
+    Any other name parses and does nothing.
+    """,
+)
 
 
 def _ensure_object_registry(obj):
@@ -1379,6 +1757,7 @@ def _annotate_object(obj, annotation_type, **kwargs):
         annotation_type, kwargs, stacklevel=4
     )
     kwargs = _coerce_style_blocks(annotation_type, kwargs)
+    _warn_if_noop(annotation_type, stacklevel=4)
 
     registry = _ensure_object_registry(obj)
 

--- a/spytial/annotations.py
+++ b/spytial/annotations.py
@@ -64,7 +64,8 @@ DIRECTIVE_TYPES = {
     "inferredEdge": {
         "required": ["name", "selector"],
         # color/style/weight are the legacy inline form; they desugar to lineStyle.
-        "optional": ["color", "style", "weight", "lineStyle", "textStyle"],
+        # draw (spytial-core 3.2) attaches an end to a group's hull.
+        "optional": ["color", "style", "weight", "lineStyle", "textStyle", "draw"],
     },
     "tag": {"required": ["toTag", "name", "value"], "optional": ["textStyle"]},
     "flag": ["name"],
@@ -282,23 +283,61 @@ _ENUM_VALUES = {
 }
 
 
-def _validate_enum_values(annotation_type, kwargs):
-    """Reject kwarg values outside the closed set core recognises.
+def _validate_draw(draw):
+    """Check the shape of an inferredEdge ``draw``: ``<end> -> <end>``.
+
+    Mirrors core's parseInferredEdgeDraw. Core does reject a malformed draw —
+    but only once the spec reaches the browser, so checking the shape here puts
+    the error on the offending line instead. Whether a named group *exists* is
+    not checkable here: it needs the whole spec, and a draw may reference a
+    group declared on another class, so core keeps that check.
+    """
+    if not isinstance(draw, str):
+        raise ValueError(
+            "inferredEdge.draw must be a string of the form '<end> -> <end>' "
+            f"(each end '_' or a group name); got {draw!r}"
+        )
+    ends = draw.split("->")
+    if len(ends) != 2:
+        raise ValueError(
+            "inferredEdge.draw must contain exactly one '->' "
+            f"(e.g. 'regions -> regions' or '_ -> regions'); got {draw!r}"
+        )
+    if not all(end.strip() for end in ends):
+        raise ValueError(
+            f"inferredEdge.draw has an empty endpoint in {draw!r}; "
+            "each end must be '_' (the atom itself) or a group name"
+        )
+
+
+# (annotation type, kwarg) -> a checker, for values with more shape than a
+# closed set.
+_VALUE_VALIDATORS = {
+    ("inferredEdge", "draw"): _validate_draw,
+}
+
+
+def _validate_values(annotation_type, kwargs):
+    """Reject kwarg values core cannot read.
 
     Shared by every authoring form, so ``@spytial.align(direction='left')`` and
     ``Align(direction='left')`` fail the same way — with the vocabulary named,
     since the usual mistake is reaching for another constraint's words.
     """
     for key, value in kwargs.items():
-        choices = _ENUM_VALUES.get((annotation_type, key))
-        if choices is None or value is None:
+        if value is None:
             continue
-        for item in value if isinstance(value, (list, tuple)) else (value,):
-            if item not in choices:
-                raise ValueError(
-                    f"{annotation_type}.{key} must be one of "
-                    f"{', '.join(choices)}; got {item!r}"
-                )
+        choices = _ENUM_VALUES.get((annotation_type, key))
+        if choices is not None:
+            for item in value if isinstance(value, (list, tuple)) else (value,):
+                if item not in choices:
+                    raise ValueError(
+                        f"{annotation_type}.{key} must be one of "
+                        f"{', '.join(choices)}; got {item!r}"
+                    )
+        checker = _VALUE_VALIDATORS.get((annotation_type, key))
+        if checker is not None:
+            checker(value)
 
 
 def _validate_hold(hold):
@@ -332,7 +371,7 @@ def _prepare_kwargs(annotation_type, kwargs, *, stacklevel):
     )
     kwargs = _coerce_style_blocks(annotation_type, kwargs)
     kwargs = _normalize_hold(annotation_type, kwargs)
-    _validate_enum_values(annotation_type, kwargs)
+    _validate_values(annotation_type, kwargs)
     return annotation_type, kwargs
 
 
@@ -612,7 +651,7 @@ class SpytialAnnotation:
     def __init__(self, **kwargs):
         # Every subclass funnels here, so the Annotated[...] form gets the same
         # vocabulary check as the **kwargs paths without restating it per class.
-        _validate_enum_values(self._annotation_type, kwargs)
+        _validate_values(self._annotation_type, kwargs)
         self.kwargs = kwargs
 
     def to_entry(self):
@@ -999,10 +1038,18 @@ class InferredEdge(SpytialAnnotation):
     Styling uses the shared lineStyle/textStyle blocks (spytial-core 3.0); the
     inline color/style/weight keys are deprecated and rewritten into lineStyle.
 
+    ``draw`` (spytial-core 3.2) is ``'<end> -> <end>'``, each end ``'_'`` (the
+    atom itself) or the name of a group constraint, in which case that end
+    attaches to the hull of the group keyed by the end's atom -- giving
+    group-to-group and node-to-group edges. ``'_ -> _'`` means the same as
+    omitting it.
+
     Usage:
         WithEdges = Annotated[Graph, InferredEdge(name='connection', selector='nodes')]
         StyledEdges = Annotated[Graph, InferredEdge(name='ancestor', selector='^parent',
                                                     lineStyle=LineStyle(color='gray', pattern='dotted'))]
+        HullEdges = Annotated[Graph, InferredEdge(name='reports to', selector='^parent',
+                                                  draw='regions -> regions')]
     """
 
     _annotation_type = "inferredEdge"
@@ -1018,6 +1065,7 @@ class InferredEdge(SpytialAnnotation):
         weight: int = None,
         lineStyle=None,
         textStyle=None,
+        draw: str = None,
     ):
         kwargs = {"name": name, "selector": selector}
         if color is not None:
@@ -1030,6 +1078,8 @@ class InferredEdge(SpytialAnnotation):
             kwargs["lineStyle"] = lineStyle
         if textStyle is not None:
             kwargs["textStyle"] = textStyle
+        if draw is not None:
+            kwargs["draw"] = draw
         _, kwargs = _desugar_legacy_style("inferredEdge", kwargs, stacklevel=3)
         super().__init__(**_coerce_style_blocks("inferredEdge", kwargs))
 
@@ -1789,9 +1839,35 @@ inferredEdge = _create_decorator(
     - ``selector`` -- the pairs to connect.
     - ``lineStyle`` -- LineStyle(color=..., pattern=..., weight=..., highlight=...).
     - ``textStyle`` -- TextStyle(size=..., color=...) -- the edge's label.
+    - ``draw`` -- where each end attaches (spytial-core 3.2). See below.
 
     The inline ``color`` / ``style`` / ``weight`` keys are the deprecated 2.x
     form; they still parse and are rewritten into ``lineStyle``.
+
+    ``draw`` is a string ``'<end> -> <end>'``. Each end is either ``'_'`` (the
+    atom itself -- the default) or the name of a ``group`` constraint, in which
+    case that end attaches to the hull of the group *keyed by the end's atom*.
+    That is what makes group-to-group and node-to-group edges expressible:
+
+        # binary group selector -> one group per Team, keyed by the Team atom
+        @spytial.group(selector='{ t : Team, l : list | l in t.members }',
+                       name='regions')
+        @spytial.inferredEdge(
+            name='reports to',
+            selector='{ a : Team, b : Team | b = a.parent }',
+            draw='regions -> regions',   # hull to hull
+        )
+
+    ``'_ -> regions'`` draws from the atom to a group's hull, and
+    ``'_ -> _'`` means the same as omitting ``draw``. The edge's selector still
+    ranges over atoms either way; with ``draw``, a unary edge selector is
+    allowed and its atom feeds both ends.
+
+    The group named by an end must be *keyed* -- declared with a binary
+    selector, whose first element is the key. A group built from a unary
+    selector has no key for an end to match, and the edge is dropped without
+    drawing. A name matching no ``group`` constraint at all is an error at
+    render time, when the whole spec is known.
     """,
 )
 

--- a/spytial/annotations.py
+++ b/spytial/annotations.py
@@ -246,7 +246,59 @@ def _coerce_style_blocks(annotation_type, kwargs):
     return out
 
 
+# The closed value sets spytial-core recognises, mirroring its unions in
+# layout/layoutspec.ts: RelativeDirection, RotationDirection, AlignDirection, and
+# the two flag names parseDirectives acts on.
+#
+# Those unions are TypeScript types, so they are erased at runtime and nothing
+# downstream re-checks them. An unrecognised value is kept by the parser and then
+# quietly does the wrong thing: an out-of-vocab orientation direction matches no
+# case and the constraint evaporates, a misspelled cyclic direction reads as
+# 'clockwise' (so a typo'd 'counterclockwise' silently spins the other way), and
+# an unknown flag name does nothing. Only align is checked by core itself.
+# Authoring time is the one place these can surface, so they are checked here.
+ORIENTATION_DIRECTIONS = (
+    "above",
+    "below",
+    "left",
+    "right",
+    "directlyAbove",
+    "directlyBelow",
+    "directlyLeft",
+    "directlyRight",
+)
+ROTATION_DIRECTIONS = ("clockwise", "counterclockwise")
+ALIGN_DIRECTIONS = ("horizontal", "vertical")
+FLAG_NAMES = ("hideDisconnected", "hideDisconnectedBuiltIns")
 CONSTRAINT_HOLDS = ("always", "never")
+
+# (annotation type, kwarg) -> the values core accepts for it. List-valued kwargs
+# are checked element-wise.
+_ENUM_VALUES = {
+    ("orientation", "directions"): ORIENTATION_DIRECTIONS,
+    ("cyclic", "direction"): ROTATION_DIRECTIONS,
+    ("align", "direction"): ALIGN_DIRECTIONS,
+    ("flag", "name"): FLAG_NAMES,
+}
+
+
+def _validate_enum_values(annotation_type, kwargs):
+    """Reject kwarg values outside the closed set core recognises.
+
+    Shared by every authoring form, so ``@spytial.align(direction='left')`` and
+    ``Align(direction='left')`` fail the same way — with the vocabulary named,
+    since the usual mistake is reaching for another constraint's words.
+    """
+    for key, value in kwargs.items():
+        choices = _ENUM_VALUES.get((annotation_type, key))
+        if choices is None or value is None:
+            continue
+        for item in value if isinstance(value, (list, tuple)) else (value,):
+            if item not in choices:
+                raise ValueError(
+                    f"{annotation_type}.{key} must be one of "
+                    f"{', '.join(choices)}; got {item!r}"
+                )
 
 
 def _validate_hold(hold):
@@ -260,6 +312,28 @@ def _validate_hold(hold):
     if hold not in CONSTRAINT_HOLDS:
         raise ValueError(f"hold must be 'always' or 'never', got {hold!r}")
     return hold
+
+
+def _prepare_kwargs(annotation_type, kwargs, *, stacklevel):
+    """The authoring-time gate every ``**kwargs`` path shares.
+
+    Desugars legacy forms, flattens style blocks, then rejects anything core
+    cannot read. There are three of these paths — the decorator, the object
+    registry, and the type-alias registry — and each one that open-codes this
+    sequence is a path a later check can be forgotten on. Returns the possibly
+    rewritten ``(annotation_type, kwargs)``.
+
+    Idempotent: the decorator-on-object path runs it twice. ``_warn_if_noop`` is
+    deliberately *not* here — it fires once per authoring site, which is a
+    per-path decision.
+    """
+    annotation_type, kwargs = _desugar_legacy_style(
+        annotation_type, kwargs, stacklevel=stacklevel
+    )
+    kwargs = _coerce_style_blocks(annotation_type, kwargs)
+    kwargs = _normalize_hold(annotation_type, kwargs)
+    _validate_enum_values(annotation_type, kwargs)
+    return annotation_type, kwargs
 
 
 def _normalize_hold(annotation_type, kwargs):
@@ -516,7 +590,7 @@ _OBJECT_ID_COUNTER = 0
 #   import spytial
 #
 #   IntList = Annotated[list[int],
-#       spytial.Orientation(selector='items', directions=['horizontal']),
+#       spytial.Orientation(selector='items', directions=['left']),
 #       spytial.AtomColor(selector='self', value='blue')
 #   ]
 #
@@ -536,6 +610,9 @@ class SpytialAnnotation:
     _is_constraint: bool = True
 
     def __init__(self, **kwargs):
+        # Every subclass funnels here, so the Annotated[...] form gets the same
+        # vocabulary check as the **kwargs paths without restating it per class.
+        _validate_enum_values(self._annotation_type, kwargs)
         self.kwargs = kwargs
 
     def to_entry(self):
@@ -961,8 +1038,12 @@ class Flag(SpytialAnnotation):
     """
     Flag directive.
 
+    ``name`` is one of the two whole-diagram switches core acts on:
+    'hideDisconnected' (drop atoms with no edges) or
+    'hideDisconnectedBuiltIns' (drop only disconnected built-in atoms).
+
     Usage:
-        Flagged = Annotated[MyType, Flag(name='debug')]
+        Flagged = Annotated[MyType, Flag(name='hideDisconnected')]
     """
 
     _annotation_type = "flag"
@@ -1104,22 +1185,19 @@ def annotate_type_alias(type_alias, annotation_type, **kwargs):
         IntList = list[int]
 
         # Annotate it
-        annotate_type_alias(IntList, 'orientation', selector='items', directions=['horizontal'])
+        annotate_type_alias(IntList, 'orientation', selector='items', directions=['left'])
         annotate_type_alias(IntList, 'atomColor', selector='self', value='blue')
 
         # Or use the convenience functions:
-        annotate_type_alias_orientation(IntList, selector='items', directions=['horizontal'])
+        annotate_type_alias_orientation(IntList, selector='items', directions=['left'])
 
     :param type_alias: The type alias to annotate (e.g., list[int], MyClass, etc.)
     :param annotation_type: The type of annotation ('orientation', 'group', etc.)
     :param kwargs: The annotation parameters.
     :return: The type alias (for chaining).
     """
-    # Rewrite deprecated 2.x style forms and flatten style blocks.
-    annotation_type, kwargs = _desugar_legacy_style(
-        annotation_type, kwargs, stacklevel=3
-    )
-    kwargs = _coerce_style_blocks(annotation_type, kwargs)
+    annotation_type, kwargs = _prepare_kwargs(annotation_type, kwargs, stacklevel=3)
+    _warn_if_noop(annotation_type, stacklevel=3)
 
     key = _normalize_type_alias_key(type_alias)
 
@@ -1350,11 +1428,9 @@ def _create_decorator(constraint_type, doc=None):
         # Rewrite deprecated 2.x style forms once, at the authoring site, so the
         # deprecation warning points at the user's line and fires once even if
         # the returned decorator is applied to many targets.
-        effective_type, kwargs = _desugar_legacy_style(
+        effective_type, kwargs = _prepare_kwargs(
             constraint_type, kwargs, stacklevel=2
         )
-        kwargs = _coerce_style_blocks(effective_type, kwargs)
-        kwargs = _normalize_hold(effective_type, kwargs)
 
         def unified_decorator(target):
             # Check if target is a class (type) or an object instance
@@ -1784,11 +1860,7 @@ def _annotate_object(obj, annotation_type, **kwargs):
     """
     # Rewrite deprecated 2.x style forms and flatten style blocks. Idempotent,
     # so the decorator path (already desugared) doesn't warn twice.
-    annotation_type, kwargs = _desugar_legacy_style(
-        annotation_type, kwargs, stacklevel=4
-    )
-    kwargs = _coerce_style_blocks(annotation_type, kwargs)
-    kwargs = _normalize_hold(annotation_type, kwargs)
+    annotation_type, kwargs = _prepare_kwargs(annotation_type, kwargs, stacklevel=4)
     _warn_if_noop(annotation_type, stacklevel=4)
 
     registry = _ensure_object_registry(obj)

--- a/spytial/core_assets.py
+++ b/spytial/core_assets.py
@@ -1,6 +1,6 @@
 """Shared spytial-core browser asset definitions for HTML templates."""
 
-SPYTIAL_CORE_VERSION = "3.1.1"
+SPYTIAL_CORE_VERSION = "3.2.1"
 
 _CDN_BASE = f"https://cdn.jsdelivr.net/npm/spytial-core@{SPYTIAL_CORE_VERSION}"
 

--- a/spytial/suggest/_enrich.py
+++ b/spytial/suggest/_enrich.py
@@ -41,14 +41,19 @@ from __future__ import annotations
 import json
 from typing import Any, List, Optional
 
+from ..annotations import ORIENTATION_DIRECTIONS, ROTATION_DIRECTIONS
 from ._model import ClassInfo, SpecDraft, Suggestion
 from .rules import _children_selector, _edge_selector
 
 # Render-verified spatial vocabularies the model picks from. Validated in Python
 # (not just declared in the schema) so a provider that ignores nested enums can't
 # slip an unknown token into a directive.
-_ORIENT_DIRS = ("below", "above", "left", "right", "directlyRight", "directlyLeft")
-_CYCLIC_DIRS = ("clockwise", "counterclockwise")
+#
+# Sourced from the canonical sets rather than restated: this list used to omit
+# directlyAbove/directlyBelow, so a model that correctly proposed either had it
+# silently filtered out.
+_ORIENT_DIRS = ORIENTATION_DIRECTIONS
+_CYCLIC_DIRS = ROTATION_DIRECTIONS
 _CONTAINERS = ("list", "tuple", "set", "dict")
 
 _SHAPE_SCHEMA = {

--- a/spytial/suggest/_vendor/README.md
+++ b/spytial/suggest/_vendor/README.md
@@ -17,7 +17,7 @@ feedback. The 3.0 style-system major left this entry's API unchanged.
 ## Regenerate (when bumping the pinned spytial-core)
 
 ```sh
-VERSION=3.1.1   # the spytial-core release to vendor
+VERSION=3.2.1   # the spytial-core release to vendor
 TMP=$(mktemp -d)
 ( cd "$TMP" && npm pack "spytial-core@$VERSION" && tar xzf "spytial-core-$VERSION.tgz" )
 cp "$TMP/package/dist/evaluator.js" spytial/suggest/_vendor/spytial-core-evaluator.js
@@ -31,4 +31,4 @@ grep -oE "require\(['\"][^'\"]+['\"]\)" spytial/suggest/_vendor/spytial-core-eva
   | grep -vE "require\(['\"](\.|node:)" | sort -u
 ```
 
-Pinned version: **spytial-core 3.1.1**.
+Pinned version: **spytial-core 3.2.1**.

--- a/test/test_annotation_registry_isolation.py
+++ b/test/test_annotation_registry_isolation.py
@@ -105,7 +105,7 @@ def test_reused_id_does_not_leak():
 
 def test_fresh_builtins_never_inherit_phantom_annotations():
     a = {"x": 1}
-    annotate_orientation(a, selector="k", directions=["horizontal"])
+    annotate_orientation(a, selector="k", directions=["left"])
     assert len(collect_decorators(a)["constraints"]) == 1
 
     # Many fresh, never-annotated builtins must all come back clean — even if
@@ -131,8 +131,8 @@ def test_set_annotation_evicted_after_gc():
 def test_distinct_builtins_keep_independent_annotations():
     a = [1, 2, 3]
     b = [1, 2, 3]  # equal but distinct object
-    annotate_orientation(a, selector="a", directions=["horizontal"])
-    annotate_orientation(b, selector="b", directions=["vertical"])
+    annotate_orientation(a, selector="a", directions=["left"])
+    annotate_orientation(b, selector="b", directions=["below"])
 
     a_sel = collect_decorators(a)["constraints"][0]["orientation"]["selector"]
     b_sel = collect_decorators(b)["constraints"][0]["orientation"]["selector"]
@@ -144,7 +144,7 @@ def test_distinct_builtins_keep_independent_annotations():
 
 def test_reset_object_ids_clears_annotation_registry():
     a = [1, 2]
-    annotate_orientation(a, selector="items", directions=["horizontal"])
+    annotate_orientation(a, selector="items", directions=["left"])
     assert collect_decorators(a)["constraints"]
 
     reset_object_ids()

--- a/test/test_data_instance_format.py
+++ b/test/test_data_instance_format.py
@@ -1,5 +1,5 @@
 """
-Tests that build_instance() output matches the spytial-core v3.1.1 IJsonDataInstance format.
+Tests that build_instance() output matches the spytial-core v3.2.1 IJsonDataInstance format.
 
 See spytial-core/docs/JSON_DATA_INSTANCE.md for the canonical spec.
 """

--- a/test/test_decorator_deduplication.py
+++ b/test/test_decorator_deduplication.py
@@ -17,8 +17,8 @@ from spytial.annotations import (
 def test_duplicate_object_annotations_are_deduplicated():
     """Applying the same annotation twice to an object should result in a single entry."""
     my_list = [1, 2, 3]
-    annotate_orientation(my_list, selector='items', directions=['horizontal'])
-    annotate_orientation(my_list, selector='items', directions=['horizontal'])
+    annotate_orientation(my_list, selector='items', directions=['left'])
+    annotate_orientation(my_list, selector='items', directions=['left'])
 
     decorators = collect_decorators(my_list)
     # Only one orientation constraint should remain
@@ -33,13 +33,13 @@ def test_duplicate_object_annotations_are_deduplicated():
 def test_class_and_instance_duplicates_are_deduplicated():
     """If identical annotations appear at the class and instance level, they should be collapsed."""
 
-    @orientation(selector='items', directions=['horizontal'])
+    @orientation(selector='items', directions=['left'])
     class Thing:
         pass
 
     t = Thing()
     # Apply same annotation to instance
-    annotate_orientation(t, selector='items', directions=['horizontal'])
+    annotate_orientation(t, selector='items', directions=['left'])
     # Also add a duplicate directive (legacy form; registers as atomStyle)
     from spytial.annotations import annotate_atomColor
     annotate_atomColor(t, selector='items', value='blue')

--- a/test/test_decorator_docs.py
+++ b/test/test_decorator_docs.py
@@ -1,0 +1,161 @@
+"""
+Tests for the decorator surface itself, rather than what it serializes.
+
+Every spytial decorator is built by `_create_decorator` and takes `**kwargs`, so
+its docstring is the only thing `help()` and IDE hovers can show. These tests
+guard that the docstrings exist, name themselves correctly, and stay honest
+about what spytial-core actually reads.
+"""
+
+import warnings
+
+import pytest
+from typing import Annotated
+
+import spytial
+
+
+ALL_DECORATORS = [
+    "orientation", "cyclic", "align", "group",
+    "atomStyle", "atomColor", "size", "icon",
+    "edgeStyle", "edgeColor", "projection", "attribute",
+    "hideField", "hideAtom", "inferredEdge", "tag", "flag",
+]
+
+
+@pytest.mark.parametrize("name", ALL_DECORATORS)
+def test_decorator_is_documented(name):
+    """`**kwargs` tells help() nothing, so every decorator needs a docstring."""
+    fn = getattr(spytial, name)
+    assert fn.__doc__, f"@{name} has no docstring; help() would show only (**kwargs)"
+
+
+@pytest.mark.parametrize("name", ALL_DECORATORS)
+def test_decorator_reports_its_own_name(name):
+    """help() should say `group(...)`, not the factory's inner `decorator(...)`."""
+    assert getattr(spytial, name).__name__ == name
+
+
+@pytest.mark.parametrize("name", ["atomColor", "edgeColor", "projection"])
+def test_deprecated_decorators_say_so(name):
+    doc = getattr(spytial, name).__doc__
+    assert "Deprecated" in doc
+
+
+def test_align_documents_axis_not_placement_words():
+    """Core's AlignConstraint rejects anything but horizontal/vertical, so the
+    docstring must not advertise the orientation vocabulary (it once did)."""
+    doc = spytial.align.__doc__
+    assert "'horizontal'" in doc and "'vertical'" in doc
+
+
+def test_orientation_documents_placement_words_not_axes():
+    doc = spytial.orientation.__doc__
+    for word in ("'above'", "'below'", "'left'", "'right'", "'directlyAbove'"):
+        assert word in doc
+
+
+# --------------------------------------------------------------------------- #
+# hold: never — core's negation switch
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "name, kwargs",
+    [
+        ("orientation", {"selector": "e", "directions": ["below"]}),
+        ("cyclic", {"selector": "e", "direction": "clockwise"}),
+        ("align", {"selector": "a", "direction": "horizontal"}),
+        ("group", {"selector": "Team.members", "name": "Team"}),
+    ],
+)
+def test_hold_never_is_accepted_on_every_constraint(name, kwargs, capsys):
+    """Core reads `hold: never` off the inner block to negate a constraint, so
+    the schema must accept it rather than warn about an unknown field."""
+    decorator = getattr(spytial, name)
+
+    @decorator(hold="never", **kwargs)
+    class Target:
+        pass
+
+    assert "Unknown fields" not in capsys.readouterr().out
+    entry = Target.__spytial_registry__["constraints"][0][name]
+    assert entry["hold"] == "never"
+
+
+def test_hold_always_stays_out_of_the_spec():
+    """'always' is the default; emitting it would be noise in the YAML."""
+
+    @spytial.group(selector="Team.members", name="Team")
+    class Target:
+        pass
+
+    assert "hold" not in Target.__spytial_registry__["constraints"][0]["group"]
+
+
+# --------------------------------------------------------------------------- #
+# projection — a no-op in spytial-core
+# --------------------------------------------------------------------------- #
+
+
+def test_projection_on_class_warns_once():
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+
+        @spytial.projection(sig="Node")
+        class Target:
+            pass
+
+    deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert len(deprecations) == 1
+    assert "no effect" in str(deprecations[0].message)
+
+
+def test_projection_on_object_warns_exactly_once():
+    """The object path runs through both the decorator and _annotate_object;
+    only one of them may warn."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        spytial.projection(sig="Node")([1, 2, 3])
+
+    deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert len(deprecations) == 1
+
+
+def test_projection_via_annotate_helper_warns():
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        spytial.annotate_projection([1, 2, 3], sig="Node")
+
+    assert [w for w in caught if issubclass(w.category, DeprecationWarning)]
+
+
+def test_projection_class_form_warns():
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        Annotated[list, spytial.Projection(sig="Node")]
+
+    assert [w for w in caught if issubclass(w.category, DeprecationWarning)]
+
+
+def test_projection_still_serializes_after_deprecation():
+    """Deprecated, not removed: existing specs keep working (core ignores it)."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+
+        @spytial.projection(sig="Node")
+        class Target:
+            pass
+
+    assert Target.__spytial_registry__["directives"] == [{"projection": {"sig": "Node"}}]
+
+
+def test_non_noop_decorators_do_not_warn():
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+
+        @spytial.hideAtom(selector="Node")
+        class Target:
+            pass
+
+    assert not [w for w in caught if issubclass(w.category, DeprecationWarning)]

--- a/test/test_decorator_docs.py
+++ b/test/test_decorator_docs.py
@@ -301,3 +301,72 @@ def test_error_names_the_vocabulary():
     with pytest.raises(ValueError) as e:
         spytial.align(selector="a", direction="left")(type("T", (), {}))
     assert "horizontal" in str(e.value) and "vertical" in str(e.value)
+
+
+# --------------------------------------------------------------------------- #
+# inferredEdge draw (spytial-core 3.2)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "draw",
+    ["regions -> regions", "_ -> regions", "regions -> _", "_ -> _", " regions->regions "],
+)
+def test_draw_accepts_the_forms_core_parses(draw):
+    @spytial.group(selector="{ t : Team, m : Member | m in t.members }", name="regions")
+    @spytial.inferredEdge(name="link", selector="{a:T,b:T|b = a.parent}", draw=draw)
+    class Target:
+        pass
+
+    entry = Target.__spytial_registry__["directives"][0]["inferredEdge"]
+    assert entry["draw"] == draw
+
+
+@pytest.mark.parametrize(
+    "draw",
+    [
+        "regions",           # no arrow
+        "a -> b -> c",       # more than one arrow
+        "-> regions",        # empty source
+        "regions ->",        # empty target
+        42,                  # not a string
+    ],
+)
+def test_draw_rejects_shapes_core_cannot_parse(draw):
+    """Core throws on these too, but only once the spec reaches the browser —
+    the shape is checkable here, so the error lands on the offending line."""
+    with pytest.raises(ValueError, match="inferredEdge.draw"):
+        spytial.inferredEdge(name="link", selector="x.y", draw=draw)(type("T", (), {}))
+
+
+def test_draw_is_validated_on_the_class_form_too():
+    with pytest.raises(ValueError, match="inferredEdge.draw"):
+        spytial.InferredEdge(name="link", selector="x.y", draw="regions")
+
+
+def test_draw_class_form_round_trips():
+    ann = spytial.InferredEdge(name="link", selector="x.y", draw="regions -> _")
+    assert ann.to_entry()["inferredEdge"]["draw"] == "regions -> _"
+
+
+def test_draw_is_optional():
+    """A plain node-to-node inferred edge must not acquire a draw key."""
+
+    @spytial.inferredEdge(name="link", selector="x.y")
+    class Target:
+        pass
+
+    assert "draw" not in Target.__spytial_registry__["directives"][0]["inferredEdge"]
+
+
+def test_draw_group_name_is_left_to_core():
+    """Whether a named group exists needs the whole spec — and the group may be
+    declared on another class — so that check is core's, not ours."""
+
+    @spytial.inferredEdge(name="link", selector="x.y", draw="declared_elsewhere -> _")
+    class Target:
+        pass
+
+    assert Target.__spytial_registry__["directives"][0]["inferredEdge"]["draw"] == (
+        "declared_elsewhere -> _"
+    )

--- a/test/test_decorator_docs.py
+++ b/test/test_decorator_docs.py
@@ -219,3 +219,85 @@ def test_non_noop_decorators_do_not_warn():
             pass
 
     assert not [w for w in caught if issubclass(w.category, DeprecationWarning)]
+
+
+# --------------------------------------------------------------------------- #
+# Closed value sets
+#
+# Core's RelativeDirection / RotationDirection / AlignDirection unions are
+# TypeScript types, erased at runtime, so nothing downstream re-checks them.
+# Only align is validated by core itself; the rest silently misbehave, which is
+# why these are checked at authoring time.
+# --------------------------------------------------------------------------- #
+
+
+BAD_VALUES = [
+    ("orientation", {"selector": "e", "directions": ["bogus"]}),
+    # The classic mix-up: align's axis words used as orientation directions.
+    ("orientation", {"selector": "e", "directions": ["horizontal"]}),
+    ("orientation", {"selector": "e", "directions": ["below", "vertical"]}),
+    ("cyclic", {"selector": "e", "direction": "widdershins"}),
+    # ...and orientation's placement words used as an align axis.
+    ("align", {"selector": "a", "direction": "left"}),
+    ("flag", {"name": "debug"}),
+]
+
+
+@pytest.mark.parametrize("name, kwargs", BAD_VALUES)
+def test_decorator_rejects_out_of_vocab_values(name, kwargs):
+    with pytest.raises(ValueError, match="must be one of"):
+        getattr(spytial, name)(**kwargs)(type("T", (), {}))
+
+
+@pytest.mark.parametrize("name, kwargs", BAD_VALUES)
+def test_object_path_rejects_out_of_vocab_values(name, kwargs):
+    with pytest.raises(ValueError, match="must be one of"):
+        spytial.annotate([1, 2], name, **kwargs)
+
+
+@pytest.mark.parametrize("name, kwargs", BAD_VALUES)
+def test_type_alias_path_rejects_out_of_vocab_values(name, kwargs):
+    """The type-alias registry is a third authoring path with its own call into
+    validation — it has drifted from the other two before."""
+    with pytest.raises(ValueError, match="must be one of"):
+        spytial.annotate_type_alias(list[float], name, **kwargs)
+
+
+@pytest.mark.parametrize(
+    "cls, kwargs",
+    [
+        ("Orientation", {"selector": "e", "directions": ["horizontal"]}),
+        ("Cyclic", {"selector": "e", "direction": "widdershins"}),
+        ("Align", {"selector": "a", "direction": "left"}),
+        ("Flag", {"name": "debug"}),
+    ],
+)
+def test_annotated_class_form_rejects_out_of_vocab_values(cls, kwargs):
+    """The Annotated[...] classes validate through the same shared check, so the
+    two authoring forms cannot disagree about what a valid value is."""
+    with pytest.raises(ValueError, match="must be one of"):
+        getattr(spytial, cls)(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "name, kwargs",
+    [
+        ("orientation", {"selector": "e", "directions": ["directlyAbove", "above"]}),
+        ("orientation", {"selector": "e", "directions": ["directlyBelow"]}),
+        ("cyclic", {"selector": "e", "direction": "counterclockwise"}),
+        ("align", {"selector": "a", "direction": "vertical"}),
+        ("flag", {"name": "hideDisconnectedBuiltIns"}),
+    ],
+)
+def test_every_value_core_reads_is_accepted(name, kwargs):
+    """The check must not be narrower than core: each of these reaches a real
+    case in core's layout switch."""
+    getattr(spytial, name)(**kwargs)(type("T", (), {}))
+
+
+def test_error_names_the_vocabulary():
+    """The usual mistake is reaching for another constraint's words, so the
+    message has to say which words are valid here."""
+    with pytest.raises(ValueError) as e:
+        spytial.align(selector="a", direction="left")(type("T", (), {}))
+    assert "horizontal" in str(e.value) and "vertical" in str(e.value)

--- a/test/test_decorator_docs.py
+++ b/test/test_decorator_docs.py
@@ -93,6 +93,66 @@ def test_hold_always_stays_out_of_the_spec():
     assert "hold" not in Target.__spytial_registry__["constraints"][0]["group"]
 
 
+@pytest.mark.parametrize(
+    "name, kwargs",
+    [
+        ("orientation", {"selector": "e", "directions": ["below"]}),
+        ("cyclic", {"selector": "e", "direction": "clockwise"}),
+        ("align", {"selector": "a", "direction": "horizontal"}),
+        ("group", {"selector": "Team.members", "name": "Team"}),
+    ],
+)
+def test_explicit_hold_always_is_dropped_like_the_class_form(name, kwargs):
+    """The Annotated[...] classes omit hold='always'; the kwargs paths must too,
+    so the same spec doesn't depend on which form authored it."""
+    decorator = getattr(spytial, name)
+
+    @decorator(hold="always", **kwargs)
+    class Target:
+        pass
+
+    assert "hold" not in Target.__spytial_registry__["constraints"][0][name]
+
+
+@pytest.mark.parametrize("bad", ["neevr", "", "true", True, None])
+@pytest.mark.parametrize(
+    "name, kwargs",
+    [
+        ("orientation", {"selector": "e", "directions": ["below"]}),
+        ("cyclic", {"selector": "e", "direction": "clockwise"}),
+        ("align", {"selector": "a", "direction": "horizontal"}),
+        ("group", {"selector": "Team.members", "name": "Team"}),
+    ],
+)
+def test_unrecognised_hold_is_rejected_not_passed_through(name, kwargs, bad):
+    """Core negates on exactly 'never' and reads anything else as 'not negated',
+    so a typo would silently leave the constraint positive. Fail at authoring."""
+    decorator = getattr(spytial, name)
+
+    with pytest.raises(ValueError, match="hold must be 'always' or 'never'"):
+
+        @decorator(hold=bad, **kwargs)
+        class Target:
+            pass
+
+
+def test_unrecognised_hold_is_rejected_on_the_object_path():
+    """annotate()/decorator-on-object funnel through _annotate_object, which is a
+    separate choke point from the decorator's own."""
+    with pytest.raises(ValueError, match="hold must be 'always' or 'never'"):
+        spytial.annotate([1, 2], "cyclic", selector="x", direction="clockwise", hold="nope")
+
+    with pytest.raises(ValueError, match="hold must be 'always' or 'never'"):
+        spytial.cyclic(selector="x", direction="clockwise", hold="nope")([1, 2])
+
+
+def test_object_path_drops_hold_always():
+    from spytial.annotations import collect_decorators
+
+    obj = spytial.annotate([1, 2], "cyclic", selector="x", direction="clockwise", hold="always")
+    assert "hold" not in collect_decorators(obj)["constraints"][0]["cyclic"]
+
+
 # --------------------------------------------------------------------------- #
 # projection — a no-op in spytial-core
 # --------------------------------------------------------------------------- #

--- a/test/test_group_selector.py
+++ b/test/test_group_selector.py
@@ -103,6 +103,31 @@ def test_selector_group_addedge_block_dict_form():
     }
 
 
+def test_group_decorator_documents_addedge_directions():
+    """@group takes **kwargs, so its docstring is the only place help() can show
+    the addEdge surface. Keep the three directions discoverable from the decorator."""
+    doc = group.__doc__
+    assert doc, "@group needs a docstring; **kwargs tells help() nothing"
+    for direction in ('none', 'togroup', 'fromgroup'):
+        assert f"'{direction}'" in doc
+    assert 'GroupEdge' in doc
+    assert 'textStyle' in doc
+    # help() reports the decorator by name, not as the factory's inner function.
+    assert group.__name__ == 'group'
+
+
+def test_field_group_rejects_showlabel():
+    """Core's GroupByField never reads showLabel (it derives label visibility from
+    negation), so accepting it silently would promise something core drops."""
+    import io, contextlib
+
+    my_list = [1, 2, 3]
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        annotate_group(my_list, field='elements', groupOn=0, addToGroup=1, showLabel=True)
+    assert 'showLabel' in buf.getvalue()
+
+
 def test_group_decorator_with_selector():
     """Test the group decorator with selector parameters."""
     my_dict = {'a': 1, 'b': 2}

--- a/test/test_object_annotations.py
+++ b/test/test_object_annotations.py
@@ -22,7 +22,7 @@ def test_object_annotations_basic():
     
     # Test with a list
     my_list = [1, 2, 3]
-    annotate_orientation(my_list, selector='items', directions=['horizontal'])
+    annotate_orientation(my_list, selector='items', directions=['left'])
     
     decorators = collect_decorators(my_list)
     assert len(decorators['constraints']) == 1
@@ -87,7 +87,7 @@ def test_general_annotate_function():
 
     # Use general annotate function (legacy atomColor registers as atomStyle)
     annotate(my_dict, 'atomColor', selector='keys', value='blue')
-    annotate(my_dict, 'orientation', selector='layout', directions=['vertical'])
+    annotate(my_dict, 'orientation', selector='layout', directions=['below'])
 
     decorators = collect_decorators(my_dict)
     assert len(decorators['constraints']) == 1
@@ -101,7 +101,7 @@ def test_yaml_serialization():
     print("=== Testing YAML Serialization ===")
 
     my_list = [1, 2, 3]
-    annotate_orientation(my_list, selector='items', directions=['horizontal'])
+    annotate_orientation(my_list, selector='items', directions=['left'])
     annotate_atomColor(my_list, selector='nums', value='green')
 
     decorators = collect_decorators(my_list)
@@ -113,7 +113,7 @@ def test_yaml_serialization():
     assert 'orientation:' in yaml_output
     assert 'atomStyle:' in yaml_output
     assert 'borderStyle:' in yaml_output
-    assert 'horizontal' in yaml_output
+    assert 'left' in yaml_output
     assert 'green' in yaml_output
     print("✓ YAML serialization works")
 

--- a/test/test_relationalizers.py
+++ b/test/test_relationalizers.py
@@ -218,7 +218,7 @@ def test_integration_with_existing_functionality():
     
     # Create test data with annotations
     test_data = [1, 2, 3, 4, 5]
-    annotate_orientation(test_data, selector='items', directions=['horizontal'])
+    annotate_orientation(test_data, selector='items', directions=['left'])
     annotate_group(test_data, field='elements', groupOn=0, addToGroup=1)
     
     # Test that visualization still works

--- a/test/test_suggest.py
+++ b/test/test_suggest.py
@@ -764,6 +764,29 @@ def test_enrich_filters_out_of_vocab_directions():
     assert any(s.kwargs["directions"] == ["above"] for s in _of(draft, "orientation"))
 
 
+def test_enrich_keeps_the_directly_variants():
+    # The vocabulary is sourced from the canonical set rather than restated; it
+    # used to omit directlyAbove/directlyBelow, so a model proposing either had
+    # a direction core handles filtered out from under it.
+    payload = {
+        "shapes": [
+            _shape("escalation", "orientation", directions=["directlyAbove"])
+        ]
+    }
+    draft = suggest(Ticket, enrich=_FakeProvider(payload))
+    assert any(
+        s.kwargs["directions"] == ["directlyAbove"] for s in _of(draft, "orientation")
+    )
+
+
+def test_enrich_vocabulary_is_the_canonical_one():
+    from spytial.annotations import ORIENTATION_DIRECTIONS, ROTATION_DIRECTIONS
+    from spytial.suggest._enrich import _ORIENT_DIRS, _CYCLIC_DIRS
+
+    assert _ORIENT_DIRS == ORIENTATION_DIRECTIONS
+    assert _CYCLIC_DIRS == ROTATION_DIRECTIONS
+
+
 def test_enrich_honors_falsy_callable_provider():
     # A provider whose __bool__/__len__ is falsy must still resolve — "off" is None or
     # False only, not truthiness. Regression for the callable provider slot.

--- a/test/test_type_alias_annotations.py
+++ b/test/test_type_alias_annotations.py
@@ -13,21 +13,21 @@ class TestAnnotatedTypeAliases:
     def test_basic_orientation_annotation(self):
         """Test basic Orientation annotation with Annotated."""
         IntList = Annotated[
-            list[int], spytial.Orientation(selector="items", directions=["horizontal"])
+            list[int], spytial.Orientation(selector="items", directions=["left"])
         ]
 
         annotations = spytial.extract_spytial_annotations(IntList)
         assert annotations is not None
         assert len(annotations["constraints"]) == 1
         assert annotations["constraints"][0]["orientation"]["directions"] == [
-            "horizontal"
+            "left"
         ]
 
     def test_multiple_annotations(self):
         """Test multiple annotations on same type."""
         StyledList = Annotated[
             list[str],
-            spytial.Orientation(selector="items", directions=["vertical"]),
+            spytial.Orientation(selector="items", directions=["below"]),
             spytial.AtomStyle(selector="self", borderStyle=spytial.BorderStyle(color="blue")),
             spytial.Size(selector="items", height=50, width=100),
         ]
@@ -45,7 +45,7 @@ class TestAnnotatedTypeAliases:
         ann2 = spytial.Cyclic(selector="x", direction="clockwise")
         assert ann2._annotation_type == "cyclic"
 
-        ann3 = spytial.Align(selector="x", direction="left")
+        ann3 = spytial.Align(selector="x", direction="horizontal")
         assert ann3._annotation_type == "align"
 
         ann4 = spytial.Group(field="children", groupOn=0, addToGroup=1)
@@ -66,7 +66,7 @@ class TestAnnotatedTypeAliases:
             spytial.Projection(sig="MySig"),
             spytial.Attribute(field="value"),
             spytial.InferredEdge(name="link", selector="nodes"),
-            spytial.Flag(name="debug"),
+            spytial.Flag(name="hideDisconnected"),
         ]
 
         for d in directives:
@@ -94,11 +94,11 @@ class TestAnnotatedTypeAliases:
 
     def test_annotation_repr(self):
         """Test annotation repr for debugging."""
-        ann = spytial.Orientation(selector="items", directions=["horizontal"])
+        ann = spytial.Orientation(selector="items", directions=["left"])
         repr_str = repr(ann)
         assert "Orientation" in repr_str
         assert "items" in repr_str
-        assert "horizontal" in repr_str
+        assert "left" in repr_str
 
     def test_complex_nested_types(self):
         """Test annotations on complex nested types."""
@@ -115,18 +115,18 @@ class TestAnnotatedTypeAliases:
 
     def test_to_entry_format(self):
         """Test that to_entry produces correct format."""
-        ann = spytial.Orientation(selector="items", directions=["horizontal"])
+        ann = spytial.Orientation(selector="items", directions=["left"])
         entry = ann.to_entry()
 
-        assert entry == {"orientation": {"selector": "items", "directions": ["horizontal"]}}
+        assert entry == {"orientation": {"selector": "items", "directions": ["left"]}}
 
     def test_flag_to_entry_special_format(self):
         """Test that Flag directive uses scalar format."""
-        flag = spytial.Flag(name="debug")
+        flag = spytial.Flag(name="hideDisconnected")
         entry = flag.to_entry()
 
         # Flag uses scalar format, not dict
-        assert entry == {"flag": "debug"}
+        assert entry == {"flag": "hideDisconnected"}
 
     @pytest.mark.filterwarnings("ignore::DeprecationWarning")
     def test_optional_parameters(self):
@@ -169,7 +169,7 @@ class TestLegacyTypeAliasRegistry:
         """Test legacy annotate_type_alias function still works."""
         IntList = list[int]
         spytial.annotate_type_alias(
-            IntList, "orientation", selector="items", directions=["horizontal"]
+            IntList, "orientation", selector="items", directions=["left"]
         )
         annotations = spytial.get_type_alias_annotations(IntList)
 


### PR DESCRIPTION
Started from "`@group` doesn't seem to have the addEdge/direction stuff I need — or at least it's not well documented." The feature was entirely there and correct; it was invisible. Pulling that thread found a family of related problems, all the same shape: **a value that looks applied but isn't.**

Ships **spytial-py 1.8.0** on **spytial-core 3.2.1**.

## spytial-core 3.1.1 → 3.2.1, and `draw`

3.2.0-beta.1 was never published — npm went straight to 3.2.1. Pin, vendored evaluator and version docstring move via `update-spytial-core.sh`. The vendored `evaluator.js` is byte-identical across the bump (`draw` is a layout concern, not an evaluator one); confirmed by diffing a fresh `npm pack` of both, so the empty diff is real rather than a copy that silently no-op'd.

New: **`draw: '<end> -> <end>'`** on `inferredEdge`. Each end is `_` or a group-constraint name; a named end attaches to the hull of the group *keyed by that end's atom*. It's the first way to express group-to-group and node-to-group edges. The shape is validated at the authoring site (core rejects a malformed `draw` too, but only once the spec reaches the browser); whether a named group *exists* needs the whole spec and may be declared on another class, so that stays core's check.

Verified by rendering a real diagram against the published 3.2.1 bundle and reading the geometry back out of the DOM — not by round-tripping YAML alone:

```
edge 'reports to': stroke=crimson, dash=6,4, width=3px   <- the lineStyle authored in Python
start [573,350] on hull perimeter x=572        -> true
end   [353,350] on hull perimeter x=197+156    -> true
```

That render caught a bad example this PR would otherwise have shipped — see below.

## The original problem

Every decorator is built by `_create_decorator` and takes `**kwargs`, so `help()` and IDE hover showed `decorator(**kwargs)` and nothing else. The reference material lived on the annotation **classes** (the `Annotated[...]` form) — not where you look when typing `@spytial.group(`. `group`'s `addEdge` has supported `none`/`togroup`/`fromgroup` plus the `GroupEdge` block since #124/#127, with no way to discover it from the call site.

`_create_decorator` now takes `doc=` and sets `__name__`/`__qualname__`/`__doc__`. All 17 decorators document exactly the keys core reads — verified against core's real `parseLayoutSpec`, not the existing prose.

## What verification found

**Closed value sets were unchecked, and core fails silently on three of four.** The direction unions are TypeScript types — erased at runtime, so nothing re-checks them:

| key | bad value | what core does |
|---|---|---|
| `cyclic.direction` | `'widdershins'` | kept, read as **clockwise** — a typo'd `counterclockwise` silently spins the other way |
| `orientation.directions` | `['bogus']` | kept, matches no case — constraint silently evaporates |
| `flag.name` | typo | silent no-op |
| `align.direction` | `'sideways'` | core throws (the only checked one) |

Now enforced on every authoring form, including the `Annotated[...]` classes via one hook in `SpytialAnnotation`, so the two forms can't disagree.

**The check found 25 call sites that were already wrong** — 6 test files, a demo, `pre_publish_check.py`, the copilot instructions — all using align's axis words as orientation directions, i.e. asserting on constraints that do nothing. They trace to a wrong example in the `Orientation` docstring, propagated by copy. `Flag(name='debug')` and `Align(direction='left')` were the same. That's the argument for the check: the docs taught the wrong vocabulary and nothing downstream objected.

**`hold='never'` was broken.** Core's only negation mechanism, but `CONSTRAINT_TYPES` didn't list it — every use printed `Warning: Unknown fields` while quietly working. Now accepted, validated, with the no-op `always` dropped to match the class form.

**There were three `**kwargs` paths, not two.** `annotate_type_alias` open-coded the desugar sequence and so never got the `hold` fix or the projection warning. All three now share `_prepare_kwargs`.

**`suggest` restated the vocabulary and got it wrong.** `_ORIENT_DIRS` omitted `directlyAbove`/`directlyBelow`, so a model proposing either had a direction core handles filtered out from under it. It now sources the canonical set.

**`projection` is a no-op — deprecated.** Core's parser never reads it: `projection: {sig: Node}` yields zero directives and no trace. It's a pre-layout transform driven by the viewer's controls; core's own module says it is "intentionally decoupled from the layout engine." Now warns on all four authoring paths, exactly once each. Still serializes: deprecation, not removal.

**`group`'s field form listed `showLabel`,** which core never reads.

**A `draw` example that didn't work.** `draw` needs a group from a *binary* selector, since it resolves each end by the group *keyed by* that atom. My example `{ t : Team, m : Member | m in t.members }` forms no groups for a `List[Member]` field (`members` relationalizes as `Team -> list -> Member`, so `m in t.members` never holds), and the docs' usual `Team.members` idiom is **unary** — one unkeyed group, against which `draw` is dropped with no edge, no warning, no error. Only rendering it surfaced this. Examples now use a keyed binary selector and both docs and docstring state the requirement.

## Left strict, documented rather than changed

`@icon` requires `showLabels` (core reads missing as `False`; the `Icon` class defaults it to `True` — looks like an oversight), `@cyclic` requires `direction` (core defaults `clockwise`), `@group` requires `name` even when negated (core synthesizes one). Happy to loosen any separately.

## Testing

443 pass, up from 323. New `test/test_decorator_docs.py` covers the decorator surface, the value sets across all four authoring paths (including that the check isn't *narrower* than core), `hold`, projection, and `draw`. Every `@spytial.*` example in `docs/` is executed against the validator.

One judgment call: out-of-vocab values **raise** rather than warn. It's a behavior change for anyone passing one today — but they're currently getting a constraint that does nothing, or the opposite direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)