### PR TITLE
spytial-core 3.2.3: draw endpoints accept unary groups; textStyle large

### DIFF
--- a/spytial/_version.py
+++ b/spytial/_version.py
@@ -1,3 +1,3 @@
 """Package version source of truth."""
 
-__version__ = "1.8.0"
+__version__ = "1.8.1"

--- a/spytial/annotations.py
+++ b/spytial/annotations.py
@@ -1040,9 +1040,9 @@ class InferredEdge(SpytialAnnotation):
 
     ``draw`` (spytial-core 3.2) is ``'<end> -> <end>'``, each end ``'_'`` (the
     atom itself) or the name of a group constraint, in which case that end
-    attaches to the hull of the group keyed by the end's atom -- giving
-    group-to-group and node-to-group edges. ``'_ -> _'`` means the same as
-    omitting it.
+    attaches to that group's hull -- giving group-to-group and node-to-group
+    edges. A keyed group (binary selector) is picked by the end's atom; a unary
+    group is attached to directly. ``'_ -> _'`` means the same as omitting it.
 
     Usage:
         WithEdges = Annotated[Graph, InferredEdge(name='connection', selector='nodes')]
@@ -1846,8 +1846,8 @@ inferredEdge = _create_decorator(
 
     ``draw`` is a string ``'<end> -> <end>'``. Each end is either ``'_'`` (the
     atom itself -- the default) or the name of a ``group`` constraint, in which
-    case that end attaches to the hull of the group *keyed by the end's atom*.
-    That is what makes group-to-group and node-to-group edges expressible:
+    case that end attaches to that group's hull. That is what makes
+    group-to-group and node-to-group edges expressible:
 
         # binary group selector -> one group per Team, keyed by the Team atom
         @spytial.group(selector='{ t : Team, l : list | l in t.members }',
@@ -1863,11 +1863,20 @@ inferredEdge = _create_decorator(
     ranges over atoms either way; with ``draw``, a unary edge selector is
     allowed and its atom feeds both ends.
 
-    The group named by an end must be *keyed* -- declared with a binary
-    selector, whose first element is the key. A group built from a unary
-    selector has no key for an end to match, and the edge is dropped without
-    drawing. A name matching no ``group`` constraint at all is an error at
-    render time, when the whole spec is known.
+    Which group an end lands on depends on the named constraint's selector. A
+    *keyed* group -- declared with a binary selector, whose first element is the
+    key -- builds one group per key, and the end's atom picks which one. A
+    *unary* group is a single group, so the end attaches to it directly and its
+    atom plays no part (spytial-core 3.2.2; before that the edge was silently
+    dropped).
+
+    ``draw`` never decides which edges exist -- the selector does. So when both
+    ends land on the same group, the edge is kept and drawn as a self-loop on
+    that hull.
+
+    A name matching no ``group`` constraint at all is an error at render time,
+    when the whole spec is known. So is a name meaning both a keyed group and a
+    single group: with no key in play there is no way to pick between them.
     """,
 )
 

--- a/spytial/core_assets.py
+++ b/spytial/core_assets.py
@@ -1,6 +1,6 @@
 """Shared spytial-core browser asset definitions for HTML templates."""
 
-SPYTIAL_CORE_VERSION = "3.2.1"
+SPYTIAL_CORE_VERSION = "3.2.2"
 
 _CDN_BASE = f"https://cdn.jsdelivr.net/npm/spytial-core@{SPYTIAL_CORE_VERSION}"
 

--- a/spytial/core_assets.py
+++ b/spytial/core_assets.py
@@ -1,6 +1,6 @@
 """Shared spytial-core browser asset definitions for HTML templates."""
 
-SPYTIAL_CORE_VERSION = "3.2.2"
+SPYTIAL_CORE_VERSION = "3.2.3"
 
 _CDN_BASE = f"https://cdn.jsdelivr.net/npm/spytial-core@{SPYTIAL_CORE_VERSION}"
 

--- a/spytial/suggest/_vendor/README.md
+++ b/spytial/suggest/_vendor/README.md
@@ -17,7 +17,7 @@ feedback. The 3.0 style-system major left this entry's API unchanged.
 ## Regenerate (when bumping the pinned spytial-core)
 
 ```sh
-VERSION=3.2.1   # the spytial-core release to vendor
+VERSION=3.2.2   # the spytial-core release to vendor
 TMP=$(mktemp -d)
 ( cd "$TMP" && npm pack "spytial-core@$VERSION" && tar xzf "spytial-core-$VERSION.tgz" )
 cp "$TMP/package/dist/evaluator.js" spytial/suggest/_vendor/spytial-core-evaluator.js
@@ -31,4 +31,4 @@ grep -oE "require\(['\"][^'\"]+['\"]\)" spytial/suggest/_vendor/spytial-core-eva
   | grep -vE "require\(['\"](\.|node:)" | sort -u
 ```
 
-Pinned version: **spytial-core 3.2.1**.
+Pinned version: **spytial-core 3.2.2**.

--- a/spytial/suggest/_vendor/README.md
+++ b/spytial/suggest/_vendor/README.md
@@ -17,7 +17,7 @@ feedback. The 3.0 style-system major left this entry's API unchanged.
 ## Regenerate (when bumping the pinned spytial-core)
 
 ```sh
-VERSION=3.2.2   # the spytial-core release to vendor
+VERSION=3.2.3   # the spytial-core release to vendor
 TMP=$(mktemp -d)
 ( cd "$TMP" && npm pack "spytial-core@$VERSION" && tar xzf "spytial-core-$VERSION.tgz" )
 cp "$TMP/package/dist/evaluator.js" spytial/suggest/_vendor/spytial-core-evaluator.js
@@ -31,4 +31,4 @@ grep -oE "require\(['\"][^'\"]+['\"]\)" spytial/suggest/_vendor/spytial-core-eva
   | grep -vE "require\(['\"](\.|node:)" | sort -u
 ```
 
-Pinned version: **spytial-core 3.2.2**.
+Pinned version: **spytial-core 3.2.3**.

--- a/test/test_data_instance_format.py
+++ b/test/test_data_instance_format.py
@@ -1,5 +1,5 @@
 """
-Tests that build_instance() output matches the spytial-core v3.2.1 IJsonDataInstance format.
+Tests that build_instance() output matches the spytial-core v3.2.2 IJsonDataInstance format.
 
 See spytial-core/docs/JSON_DATA_INSTANCE.md for the canonical spec.
 """

--- a/test/test_data_instance_format.py
+++ b/test/test_data_instance_format.py
@@ -1,5 +1,5 @@
 """
-Tests that build_instance() output matches the spytial-core v3.2.2 IJsonDataInstance format.
+Tests that build_instance() output matches the spytial-core v3.2.3 IJsonDataInstance format.
 
 See spytial-core/docs/JSON_DATA_INSTANCE.md for the canonical spec.
 """


### PR DESCRIPTION
Bumps the pinned spytial-core from 3.2.1 to **3.2.3** and corrects the `inferredEdge` docs that 3.2.2 makes wrong. Two upstream releases landed while this was open, so the PR now tracks both.

## What changed

`./update-spytial-core.sh` handled the mechanical part of each bump: the CDN pin in `core_assets.py`, the vendor README pin, and the IJsonDataInstance test docstring. Both releases changed only the browser bundles, so the re-vendored tier-2 evaluator came back byte-identical each time and `_vendor/spytial-core-evaluator.js` is not in this diff. Patch bump to 1.8.1 covers the PR as a whole.

## 3.2.2 — [core#501](https://github.com/sidprasad/spytial-core/pull/501), and why the docstrings changed

#501 extends the `inferredEdge draw` feature we shipped in 3.2.1:

- a `draw` endpoint may now name a **unary** group constraint — it attaches to that single group directly, and the end's atom plays no part. Previously this parsed fine but silently dropped every edge at layout time.
- an edge whose ends land on the **same** group is kept and drawn as a self-loop on the hull, rather than dropped.
- a name meaning both a keyed group and a single group is now a layout-time error (with no key in play, there's no way to pick).

Our docstring stated the opposite as a rule — that a `draw` endpoint's group "must be *keyed*", and that a unary group's edge "is dropped without drawing". That's the one kind of stale doc worth catching in a version bump: not vague, but a confident instruction pointing users away from something that now works. Both the `inferredEdge` decorator doc and the `InferredEdge` class doc are rewritten to cover keyed vs. unary endpoints, the self-loop, and the new ambiguity error.

`_validate_draw` needs no change — it checks only the `'<end> -> <end>'` shape, which #501 leaves alone. The existing shape tests in `test_decorator_docs.py` still cover it.

## 3.2.3 — [core#502](https://github.com/sidprasad/spytial-core/pull/502)

Makes `textStyle: { size: large }` render perceptibly larger than the node label (tier constant 16px → 20px; edge labels no longer have the authored tier overwritten by the zoom handler's hardcoded 12px base each layout tick).

No doc change needed on this side: our `TextStyle` docs in `annotations.py` and `docs/operations.md` only enumerate `'small' | 'normal' | 'large'`, never pixel values or relative sizes, so nothing here described the behavior #502 corrected.

## Reviewer notes

- No behavior change in this package; the semantics live in core. The only judgment call is the `draw` doc rewrite — worth a read against #501's description.
- Verified: 444 tests pass. I also ran the four opt-in real-browser e2e tests (`SPYTIAL_BROWSER_TESTS=1 pytest test/test_edit_browser.py`), the ones that actually load the pinned bundle from the CDN — all pass against 3.2.3, and the three jsdelivr asset URLs return 200.
- **One flake worth knowing about:** the first browser run right after the 3.2.3 bump failed (`test_done_round_trips`), then passed on the next three full-file runs. The failing run took 39s against ~6s for the clean ones — it raced a cold jsdelivr cache for the newly published 3.5MB bundle, since the reachability check at `test_edit_browser.py:49` reads only 1 byte and doesn't warm it. That's a pre-existing first-run-after-bump fragility rather than anything about 3.2.3, but I'm flagging it rather than burying it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)