### PR TITLE
suggest(ask=...): translate a prose layout request into validated directives

### DIFF
--- a/docs/suggest.md
+++ b/docs/suggest.md
@@ -6,14 +6,20 @@ default it is pure static analysis: no LLM, no network, no extra dependencies
 (an optional model-backed enrichment layer is described [below](#optional-llm-enrichment)).
 The whole point is to get you past the blank page.
 
-It lives in its own subpackage and is **not** imported by `spytial` itself, so
-you opt in:
+It lives in its own subpackage and is **not** imported by `spytial` itself —
+nothing loads until you reach for it. Both spellings work:
 
 ```python
-from spytial.suggest import suggest
+import spytial
+
+draft = spytial.suggest(TreeNode)      # the subpackage is callable
+print(draft.to_source())
+```
+
+```python
+from spytial.suggest import suggest    # or import the function
 
 draft = suggest(TreeNode)
-print(draft.to_source())
 ```
 
 ```text
@@ -219,6 +225,63 @@ A selector can only be validated by running it over data (the engine has no
 schema-only mode), which is why that tier needs the examples and the shape tier
 above does not. It runs headlessly on a vendored spytial-core evaluator, so it
 needs only a `node` runtime.
+
+## Ask for a directive in your own words
+
+The enrichment tiers propose on their own initiative. `ask=` is the other
+direction: **you** state what you want, in prose, and the model's only job is to
+translate it —
+
+```python
+import spytial
+from spytial.suggest import ClaudeCode
+
+draft = spytial.suggest(
+    tree,
+    ask="all binary tree children should be below their parents",
+    enrich=ClaudeCode(),          # ask uses the same provider slot
+)
+draft.to_source()
+# @spytial.orientation(selector='left + right', directions=['below'])  # ask: children hang below their parent
+```
+
+A translation reaches the draft only after the full gauntlet:
+
+1. **Kind + vocabulary** — the directive is one ask can author (`orientation`,
+   `cyclic`, `align`, `inferredEdge`, `hideAtom`, `atomStyle`), and its enum
+   kwargs are in the canonical sets.
+2. **Evaluation** — the selector parses, is non-empty, and has the directive's
+   exact arity on **every** example instance, via the headless evaluator. A
+   failing round is fed back to the model once, with the per-candidate
+   diagnostics, for a repair attempt.
+3. **The authoring gate** — the kwargs run the same validation the `@spytial.*`
+   decorators run, so an admitted row can't fail later in `apply()`.
+
+Because you asked, the ask is **the key thing in the draft** — authoritative on
+the ground it covers. Admitted rows come in **enabled by default** (a
+translation that lands on a row the rules already proposed just switches that
+row on), and an admitted `orientation`/`cyclic`/`align` row **demotes every
+enabled geometric row that overlaps it** — rule-proposed and model-proposed
+alike — to `draft.alternatives`, kept and one toggle away. Overlap isn't guessed
+from selector syntax: `(ask_sel) & (rival_sel)` is itself a selector, and a
+non-empty intersection on any example means both constraints claim the same
+edges. So asking for *"children below parents"* on a binary tree replaces the
+rules' `below-left`/`below-right` pair with your plain `below`, instead of
+stacking a third constraint on the same edges. Styling and hiding rows don't
+fight the layout solver, so they are left alone.
+
+One ask is not necessarily one directive. A compound sentence — *"children
+below their parents, and color the leaves green"* — translates to several
+candidates (up to three), each admitted independently. What validates lands;
+a failed part is what the repair round retries; and anything still unvalidated
+after that is recorded in `draft.notes`, so no half of a request vanishes
+without a trace.
+
+Every failure, by contrast, is **loud**.
+No provider, no example instance to validate against, no `node` runtime, or a
+sentence of which *nothing* survives translation (`"make it pretty"`) raises
+`spytial.suggest.AskError` carrying the model's own reason or the per-candidate
+diagnostics — never a silently ignored request.
 
 ## Limits
 

--- a/spytial/__init__.py
+++ b/spytial/__init__.py
@@ -209,4 +209,20 @@ __all__ = [
     "apply_if",
     # Core version
     "get_spytial_core_version",
+    # Spec scaffolding (lazy — see __getattr__)
+    "suggest",
 ]
+
+
+def __getattr__(name):
+    # ``spytial.suggest`` stays out of the eager imports (it is optional
+    # machinery that must remain dormant until reached for), but the natural
+    # call spelling — ``spytial.suggest(tree, ask=..., enrich=...)`` — should
+    # work. PEP 562: load the subpackage on first attribute access; the module
+    # itself is callable (see spytial/suggest/__init__.py), so both the call
+    # form and ``spytial.suggest.SpecDraft`` behave.
+    if name == "suggest":
+        import importlib
+
+        return importlib.import_module("spytial.suggest")
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/spytial/_version.py
+++ b/spytial/_version.py
@@ -1,3 +1,3 @@
 """Package version source of truth."""
 
-__version__ = "1.8.2"
+__version__ = "1.8.3"

--- a/spytial/suggest/__init__.py
+++ b/spytial/suggest/__init__.py
@@ -19,9 +19,12 @@ no dependencies and stays dormant until you reach for it.
 
 from __future__ import annotations
 
+import sys as _sys
+import types as _types
 from typing import Any, List, Optional
 
 from . import rules  # noqa: F401  (import for the side effect of registering built-ins)
+from ._ask import AskError
 from ._model import ClassInfo, FieldInfo, SpecDraft, Suggestion
 from .introspect import build_class_info
 from .providers import (
@@ -46,6 +49,7 @@ __all__ = [
     "build_class_info",
     "EnrichProvider",
     "EnrichError",
+    "AskError",
     "LlmModel",
     "ClaudeCode",
     "Codex",
@@ -73,6 +77,7 @@ def suggest(
     examples: Optional[List[Any]] = None,
     registry: Optional[HeuristicRegistry] = None,
     enrich: Any = None,
+    ask: Optional[str] = None,
 ) -> SpecDraft:
     """Analyze a class and return a :class:`SpecDraft` of proposed directives.
 
@@ -110,7 +115,32 @@ def suggest(
             evaluating it over every example. A spec that can't be resolved (``llm``
             missing, unknown id) degrades to the static draft with a note — never
             raises.
+        ask: a natural-language layout request to translate into directive(s) —
+            e.g. ``ask="all binary tree children should be below their parents"``.
+            Uses the same provider as ``enrich`` (which is therefore required), and
+            admits a translation only after it passes the full gauntlet: known
+            directive kind with in-vocabulary kwargs, selector evaluated at the
+            right arity on *every* example, and the same authoring-time validation
+            the ``@spytial.*`` decorators run. Admitted rows are enabled by default
+            and tagged ``source="llm"``; a translation that matches an existing row
+            enables that row instead of duplicating it. The ask is authoritative on
+            the ground it covers: an admitted orientation/cyclic/align row demotes
+            every enabled geometric row whose selector overlaps its own (checked by
+            evaluating the intersection over the examples) to ``draft.alternatives``.
+            Unlike enrichment, ``ask`` fails **loudly**: a missing provider, no example instance, no headless
+            evaluator, or a translation that can't be validated raises
+            :class:`AskError` with the reasons.
     """
+    if ask is not None:
+        if not isinstance(ask, str) or not ask.strip():
+            raise AskError("ask= must be a natural-language request (a non-empty string).")
+        ask = ask.strip()
+        if enrich is None or enrich is False:
+            raise AskError(
+                "ask= needs a model: also pass enrich= — a model-id string, a "
+                "callable provider, or a built-in like ClaudeCode() / Codex()."
+            )
+
     if isinstance(target, type):
         cls = target
     else:
@@ -137,10 +167,15 @@ def suggest(
     # callable.
     if enrich is not None and enrich is not False:
         # Resolve the provider up front: a bad spec (no llm / unknown id / wrong
-        # type) degrades to the static draft with a note rather than raising.
+        # type) degrades to the static draft with a note rather than raising —
+        # unless the user asked, in which case the ask can't be honored: loud.
         try:
             provider = as_provider(enrich)
         except EnrichError as exc:
+            if ask is not None:
+                raise AskError(
+                    f"ask: cannot resolve the enrich= provider ({exc})."
+                ) from exc
             draft.notes.append(f"enrich skipped: {exc}")
             return draft
 
@@ -149,4 +184,27 @@ def suggest(
         draft = enrich_draft(
             draft, class_info, provider=provider, examples=example_objs
         )
+        if ask is not None:
+            from ._ask import ask_draft
+
+            ask_draft(
+                draft, class_info, ask, provider=provider, examples=example_objs
+            )
     return draft
+
+
+class _CallableModule(_types.ModuleType):
+    """Let ``spytial.suggest(...)`` be the call itself.
+
+    The natural spelling — ``spytial.suggest(tree, ask=..., enrich=...)`` — treats
+    this subpackage as the function. Swapping the module's class (the PEP 562-era
+    idiom; ``__class__`` assignment on modules is supported for exactly this) makes
+    the module callable while leaving every other access — ``from spytial.suggest
+    import suggest``, ``spytial.suggest.SpecDraft`` — untouched.
+    """
+
+    def __call__(self, *args, **kwargs):
+        return suggest(*args, **kwargs)
+
+
+_sys.modules[__name__].__class__ = _CallableModule

--- a/spytial/suggest/_ask.py
+++ b/spytial/suggest/_ask.py
@@ -222,7 +222,12 @@ def ask_draft(
     seen_rows: set = set()
     for round_i in range(_MAX_ROUNDS):
         data = _call_provider(provider, ci, vocab, statement, len(datums), feedback)
-        candidates = [c for c in data.get("candidates", []) if isinstance(c, dict)]
+        raw_candidates = data.get("candidates", [])
+        candidates = (
+            [c for c in raw_candidates if isinstance(c, dict)]
+            if isinstance(raw_candidates, list)
+            else []
+        )
         cannot = _as_str(data.get("cannot")) or None
         if not candidates:
             break  # the model declined (or had nothing left to repair)

--- a/spytial/suggest/_ask.py
+++ b/spytial/suggest/_ask.py
@@ -1,0 +1,555 @@
+"""User-directed translation for ``spytial.suggest`` — the ``ask=`` tier.
+
+The enrichment tiers are *unprompted*: the model proposes shapes
+(:mod:`._enrich`) or selectors (:mod:`._enrich_from_examples`) on its own
+initiative, quietly, off-by-default or demotable. This tier is the opposite: the
+**user hands over a sentence** —
+
+    suggest(tree, ask="all binary tree children should be below their parents",
+            enrich=ClaudeCode())
+
+— and the model's only job is to translate that sentence into directive(s). A
+candidate must pass the same admission gauntlet before it reaches the draft:
+
+1. **Kind + vocabulary** (schema level): the directive kind is one we support,
+   its enum kwargs (directions, colors present) are in the canonical sets.
+2. **Selector evaluation** (instance level): the selector parses, is non-empty,
+   and has the kind's exact arity on *every* example, via the headless evaluator.
+3. **Authoring gate** (parser level): the kwargs go through the same
+   ``_prepare_kwargs`` / ``validate_fields`` pipeline the ``@spytial.*``
+   decorators run, so an admitted row is guaranteed to author cleanly.
+
+Because the user explicitly asked, the failure contract is **loud** — the
+inverse of enrichment's degrade-with-a-note. A missing provider, a dead
+evaluator, a "cannot express that" reply, or an ask of which *nothing* validates
+raises :class:`AskError` with the reasons, after one counterexample-guided
+repair round. A compound request ("children below, and color the leaves") is
+admitted per candidate: what validates lands, the failed remainder is what the
+repair round retries, and anything still unvalidated is recorded in
+``draft.notes`` rather than silently dropped. Admitted rows are enabled by
+default (the user asked for them) and tagged ``source="llm"``.
+
+And the ask is **authoritative on the ground it covers**: an admitted geometric
+row (orientation/cyclic/align) demotes every enabled geometric row — rule- or
+model-proposed — whose selector *overlaps* the ask's, the way the shape tier
+demotes the rule it beats. Overlap is decided by the evaluator, not by guessing
+at selector syntax: ``(ask_sel) & (rival_sel)`` is itself a selector, and a
+non-empty intersection on any example means both constraints claim the same
+edges. Demoted rows move to ``draft.alternatives`` — kept, off, one toggle away.
+
+Kinds covered in this first cut: the binary-selector constraints
+(``orientation``, ``cyclic``, ``align``), ``inferredEdge``, and the
+unary-selector directives ``hideAtom`` and ``atomStyle`` (fill/stroke colors).
+``group`` is deliberately left out for now — its selector is legal at either
+arity and its two kwarg forms need their own admit rules.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, List, Optional, Tuple
+
+from ..annotations import (
+    ALIGN_DIRECTIONS,
+    CONSTRAINT_TYPES,
+    DIRECTIVE_TYPES,
+    ORIENTATION_DIRECTIONS,
+    ROTATION_DIRECTIONS,
+    _prepare_kwargs,
+    validate_fields,
+)
+from ..provider_system import CnDDataInstanceBuilder
+from . import _eval
+from ._enrich import _demote
+from ._enrich_from_examples import (
+    _as_str,
+    _edge_name,
+    _evaluate_per_example,
+    _make_resolver,
+    _vocabulary,
+)
+from ._model import ClassInfo, SpecDraft, Suggestion
+
+
+class AskError(RuntimeError):
+    """``ask=`` could not be honored — and the user explicitly asked, so we say so.
+
+    Raised (never swallowed) for: no/unresolvable provider, no buildable example
+    datum, no headless evaluator, a failed provider call, a model "cannot express
+    that" reply, or a full round of candidates that all failed validation. The
+    message carries the reasons — the model's own, or the per-candidate
+    diagnostics from evaluation.
+    """
+
+
+# Directive kinds ask may author, with the selector arity each requires
+# (docs/selectors.md: orientation/align/inferredEdge — and cyclic — act on edges;
+# hideAtom/atomStyle act on atoms).
+_KIND_ARITY = {
+    "orientation": 2,
+    "cyclic": 2,
+    "align": 2,
+    "inferredEdge": 2,
+    "hideAtom": 1,
+    "atomStyle": 1,
+}
+
+# One initial translation plus at most one counterexample-guided repair, same
+# budget and rationale as the tier-2 selector rounds.
+_MAX_ROUNDS = 2
+
+# The kinds that fight over geometry: an admitted ask row of one of these demotes
+# every enabled row of these kinds whose selector overlaps its own.
+_GEOMETRIC = ("orientation", "cyclic", "align")
+
+_ASK_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "candidates": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "directive": {"type": "string", "enum": list(_KIND_ARITY)},
+                    "selector": {"type": "string"},
+                    "directions": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "enum": list(ORIENTATION_DIRECTIONS),
+                        },
+                    },
+                    "direction": {
+                        "type": "string",
+                        "enum": list(ROTATION_DIRECTIONS) + list(ALIGN_DIRECTIONS),
+                    },
+                    "name": {"type": "string"},
+                    "fill": {"type": "string"},
+                    "stroke": {"type": "string"},
+                    "why": {"type": "string"},
+                },
+                "required": ["directive", "selector", "why"],
+            },
+        },
+        "cannot": {"type": "string"},
+    },
+    "required": ["candidates"],
+}
+
+_ASK_PROMPT = """\
+You translate ONE user-written layout request into spytial directive(s) for a
+diagram of a data structure, validated against {n} example instance(s).
+
+The user's request:
+  "{statement}"
+
+A selector is a small relational expression in an Alloy-like language; spytial
+evaluates it over an instance to pick atoms (arity 1) or edges/pairs (arity 2).
+
+Grammar (use ONLY this):
+- identifiers: a type or relation name from the vocabulary below
+- join:        a.b        (follow relation b from a)
+- product:     a -> b     (the pair edge)
+- set ops:     a + b (union)   a & b (intersection)   a - b (difference)
+- closures:    ^r (transitive)   *r (reflexive-transitive)   ~r (transpose)
+- built-ins:   univ, iden, none
+
+You may reference ONLY these names — anything else resolves to nothing:
+  Types (with #atoms): {types}
+  Relations (name/arity): {relations}
+
+Express the request with these directive kinds:
+- orientation: place edge targets in a direction. selector (arity 2) plus 1-2
+  `directions` from [{orient_dirs}].
+- cyclic: lay a ring of atoms around a circle. selector (arity 2) plus
+  `direction` (clockwise / counterclockwise).
+- align: align edge endpoints on an axis. selector (arity 2) plus `direction`
+  (horizontal / vertical).
+- inferredEdge: draw a NEW named edge the structure implies. selector (arity 2)
+  plus a short identifier `name`.
+- hideAtom: hide atoms from the diagram. selector (arity 1).
+- atomStyle: recolor atoms. selector (arity 1) plus `fill` and/or `stroke`
+  (CSS colors).
+
+Prefer the simplest selector that means the request — a bare relation name when
+the request is about a single field. Each selector MUST evaluate to a non-empty
+result at the required arity on EVERY example. Translate ONLY what the request
+says (1-3 candidates); do not add extras. If the request has no expressible
+reading — it is not spatial, or the vocabulary has no relation for it — return
+an empty candidates list and explain in `cannot`.
+
+Class: {cls}
+Fields: {fields}
+"""
+
+
+def ask_draft(
+    draft: SpecDraft,
+    ci: ClassInfo,
+    statement: str,
+    *,
+    provider: Any,
+    examples: List[Any],
+) -> None:
+    """Translate ``statement`` into validated directive(s) appended to ``draft``.
+
+    Mutates ``draft`` in place. Every failure raises :class:`AskError` — the
+    caller asked for this translation, so nothing degrades quietly.
+    """
+    datums = []
+    for obj in examples:
+        try:
+            datums.append(CnDDataInstanceBuilder().build_instance(obj))
+        except Exception:  # noqa: BLE001 — skip an example we can't build a datum from
+            continue
+    if not datums:
+        raise AskError(
+            "ask: needs at least one example instance to validate against — "
+            "pass an instance as the target, or examples=[...]."
+        )
+    if not _eval.is_available():
+        raise AskError(
+            "ask: headless selector evaluation is unavailable — it needs a node "
+            "runtime on PATH (or SPYTIAL_NODE pointing at one)."
+        )
+
+    vocab = _vocabulary(datums)
+    reserved = {n for n, _ in vocab["relations"]} | {t for t, _ in vocab["types"]}
+
+    feedback: Optional[str] = None
+    cannot: Optional[str] = None
+    rejects: List[str] = []
+    installed: List[Suggestion] = []
+    seen_rows: set = set()
+    for round_i in range(_MAX_ROUNDS):
+        data = _call_provider(provider, ci, vocab, statement, len(datums), feedback)
+        candidates = [c for c in data.get("candidates", []) if isinstance(c, dict)]
+        cannot = _as_str(data.get("cannot")) or None
+        if not candidates:
+            break  # the model declined (or had nothing left to repair)
+
+        selectors = list(
+            dict.fromkeys(
+                s for s in (_as_str(c.get("selector")) for c in candidates) if s
+            )
+        )
+        per_example, last_exc = _evaluate_per_example(datums, selectors)
+        if not per_example:
+            raise AskError(f"ask: no example could be evaluated ({last_exc}).")
+
+        round_installed, rejects = _admit_round(
+            draft, candidates, _make_resolver(per_example), per_example, reserved,
+            statement,
+        )
+        # A multi-part ask admits per candidate; identity-dedup so a repair round
+        # re-sending an accepted candidate doesn't double-count it.
+        for row in round_installed:
+            if id(row) not in seen_rows:
+                seen_rows.add(id(row))
+                installed.append(row)
+        if not rejects or round_i == _MAX_ROUNDS - 1:
+            break
+        # Repair targets the failures — even after a partial success, so a
+        # compound request doesn't silently lose the half that slipped.
+        feedback = "\n".join(rejects)
+        if installed:
+            feedback += (
+                "\n(The other candidate(s) were already accepted — do NOT re-send "
+                "them. Return corrected versions of ONLY the failed ones, or drop "
+                "any you cannot fix.)"
+            )
+
+    if installed:
+        demoted = _demote_competitors(draft, installed, datums)
+        n = len(datums)
+        across = "the example instance" if n == 1 else f"all {n} example instances"
+        note = (
+            f'ask: "{statement}" -> {len(installed)} directive(s), '
+            f"each validated over {across}"
+        )
+        if demoted:
+            note += f"; {demoted} overlapping row(s) demoted to alternatives"
+        draft.notes.append(note + ".")
+        if rejects:
+            # Partial honesty: what was admitted stands, but the unvalidated
+            # remainder of the request must not vanish without a trace.
+            draft.notes.append(
+                "ask: part of the request could not be validated — "
+                + "; ".join(r.lstrip("- ") for r in rejects)
+            )
+        return
+    raise AskError(_failure_message(statement, cannot, rejects))
+
+
+def _call_provider(
+    provider, ci: ClassInfo, vocab: dict, statement: str, n: int,
+    feedback: Optional[str],
+) -> dict:
+    types_line = ", ".join(f"{t} (#{c})" for t, c in vocab["types"]) or "(none)"
+    rels_line = (
+        ", ".join(f"{name}/{arity}" for name, arity in vocab["relations"]) or "(none)"
+    )
+    fields = ", ".join(f.name for f in ci.fields if not f.is_private) or "(none)"
+    prompt = _ASK_PROMPT.format(
+        statement=statement,
+        cls=ci.cls.__name__,
+        types=types_line,
+        relations=rels_line,
+        fields=fields,
+        orient_dirs=", ".join(ORIENTATION_DIRECTIONS),
+        n=n,
+    )
+    if feedback:
+        prompt += (
+            "\n\nYour previous translation did NOT hold up when evaluated on the "
+            f"{n} example(s). Here is what went wrong, per candidate:\n{feedback}\n"
+            "Return corrected candidates that avoid these problems, using ONLY the "
+            "vocabulary above. If the request truly cannot be expressed, return an "
+            "empty candidates list and explain in `cannot`."
+        )
+    try:
+        data = provider(prompt, schema=_ASK_SCHEMA)
+    except Exception as exc:  # noqa: BLE001 — surface, don't swallow: the user asked
+        raise AskError(f'ask: provider call failed for "{statement}": {exc}') from exc
+    if not isinstance(data, dict):
+        raise AskError(
+            f"ask: provider returned {type(data).__name__}, expected a JSON object."
+        )
+    return data
+
+
+def _admit_round(
+    draft: SpecDraft,
+    candidates: List[dict],
+    resolves: Callable[[str, int], bool],
+    per_example: List[dict],
+    reserved: set,
+    statement: str,
+) -> Tuple[List[Suggestion], List[str]]:
+    """Admit every candidate that survives the full gauntlet; explain the rest.
+
+    Returns ``(installed_rows, reject_lines)`` — the rows now carrying the ask
+    (so the competitor demotion can exempt them). A candidate that duplicates an
+    existing row *satisfies* the ask by enabling that row (the user explicitly
+    asked for it) rather than appending a twin.
+    """
+    installed: List[Suggestion] = []
+    rejects: List[str] = []
+    for cand in candidates:
+        kwargs, reason = _candidate_kwargs(cand, reserved)
+        if kwargs is None:
+            rejects.append(_reject_line(cand, reason))
+            continue
+        expected = _KIND_ARITY[cand["directive"]]
+        if not resolves(kwargs["selector"], expected):
+            rejects.append(
+                _reject_line(
+                    cand, _selector_reason(kwargs["selector"], expected, per_example)
+                )
+            )
+            continue
+        try:
+            kind, prepared = _authoring_gate(cand["directive"], kwargs)
+        except ValueError as exc:
+            rejects.append(_reject_line(cand, str(exc)))
+            continue
+
+        why = _as_str(cand.get("why"))
+        rationale = f"ask: {why}" if why else f'ask: "{statement}"'
+        installed.append(
+            _install(
+                draft,
+                Suggestion(
+                    kind,
+                    prepared,
+                    "high",
+                    rationale,
+                    None,
+                    enabled_by_default=True,
+                    source="llm",
+                ),
+            )
+        )
+    return installed, rejects
+
+
+def _candidate_kwargs(cand: dict, reserved: set):
+    """Kind-level admission: ``(kwargs, None)`` or ``(None, reason)``.
+
+    Checks what the evaluator can't: the kind is known, its enum kwargs are in
+    the canonical vocabularies, an inferredEdge name is safe and non-shadowing.
+    """
+    kind = cand.get("directive")
+    selector = _as_str(cand.get("selector"))
+    if kind not in _KIND_ARITY:
+        return None, f"unknown directive {kind!r}; use one of {list(_KIND_ARITY)}"
+    if not selector:
+        return None, "no selector expression was given"
+
+    if kind == "orientation":
+        raw = cand.get("directions")
+        dirs = (
+            [d for d in raw if d in ORIENTATION_DIRECTIONS][:2]
+            if isinstance(raw, list)
+            else []
+        )
+        if not dirs:
+            return None, (
+                "orientation needs 1-2 directions from "
+                f"[{', '.join(ORIENTATION_DIRECTIONS)}]"
+            )
+        return {"selector": selector, "directions": dirs}, None
+    if kind == "cyclic":
+        direction = cand.get("direction")
+        if direction not in ROTATION_DIRECTIONS:
+            return None, "cyclic needs direction clockwise or counterclockwise"
+        return {"selector": selector, "direction": direction}, None
+    if kind == "align":
+        direction = cand.get("direction")
+        if direction not in ALIGN_DIRECTIONS:
+            return None, "align needs direction horizontal or vertical"
+        return {"selector": selector, "direction": direction}, None
+    if kind == "inferredEdge":
+        return {"name": _edge_name(cand.get("name"), reserved), "selector": selector}, None
+    if kind == "hideAtom":
+        return {"selector": selector}, None
+    # atomStyle
+    fill, stroke = _as_str(cand.get("fill")), _as_str(cand.get("stroke"))
+    if not fill and not stroke:
+        return None, "atomStyle needs fill and/or stroke (CSS colors)"
+    kwargs: dict = {"selector": selector}
+    if fill:
+        kwargs["fillStyle"] = {"color": fill}
+    if stroke:
+        kwargs["borderStyle"] = {"color": stroke}
+    return kwargs, None
+
+
+def _authoring_gate(kind: str, kwargs: dict):
+    """Run the same pipeline the ``@spytial.*`` decorators run; return its output.
+
+    ``_prepare_kwargs`` desugars legacy forms, coerces style blocks, and rejects
+    out-of-vocabulary values; ``validate_fields`` rejects a missing required
+    kwarg. What comes back is the canonical authoring form, so it is what the
+    Suggestion stores — an admitted row can't fail later in ``apply()``.
+    """
+    effective, prepared = _prepare_kwargs(kind, dict(kwargs), stacklevel=2)
+    spec = CONSTRAINT_TYPES.get(effective) or DIRECTIVE_TYPES.get(effective)
+    if spec is None:
+        raise ValueError(f"unknown annotation type {effective!r}")
+    validate_fields(effective, prepared, spec)
+    return effective, prepared
+
+
+def _install(draft: SpecDraft, sug: Suggestion) -> Suggestion:
+    """Add ``sug``, or enable the identical row that already exists.
+
+    An ask that lands on a row the rules already proposed (enabled or demoted to
+    an alternative) is agreement, not a duplicate — the user's sentence just
+    turned it on. Returns the row that now carries the ask, so competitor
+    demotion can exempt it.
+    """
+    key = sug.dedup_key()
+    for s in draft.suggestions:
+        if s.dedup_key() == key:
+            s.enabled_by_default = True
+            return s
+    for s in draft.alternatives:
+        if s.dedup_key() == key:
+            draft.alternatives.remove(s)
+            s.enabled_by_default = True
+            draft.suggestions.append(s)
+            return s
+    draft.suggestions.append(sug)
+    return sug
+
+
+def _demote_competitors(
+    draft: SpecDraft, installed: List[Suggestion], datums: List
+) -> int:
+    """The ask wins its ground: demote enabled geometric rows the ask overlaps.
+
+    "Competing" is decided by the evaluator, not by inspecting selector syntax:
+    ``(ask_sel) & (rival_sel)`` is itself a selector, and a non-empty result on
+    *any* example means both constraints claim the same edge — so the rival
+    (rule- or model-proposed alike) steps down to ``draft.alternatives``, the
+    same one-toggle-away demotion the shape tier uses. An intersection that
+    fails to evaluate is treated as no overlap: when in doubt, don't demote.
+    Non-geometric kinds (styling, hiding, inferred edges) don't fight the layout
+    solver over positions, so they are left alone.
+    """
+    ask_selectors = [
+        s.kwargs.get("selector")
+        for s in installed
+        if s.directive in _GEOMETRIC and s.kwargs.get("selector")
+    ]
+    if not ask_selectors:
+        return 0
+    installed_ids = {id(s) for s in installed}
+    rivals = [
+        s
+        for s in draft.suggestions
+        if s.directive in _GEOMETRIC
+        and s.enabled_by_default
+        and id(s) not in installed_ids
+        and s.kwargs.get("selector")
+    ]
+    if not rivals:
+        return 0
+
+    pairs = [
+        (f"({a}) & ({r.kwargs['selector']})", r) for r in rivals for a in ask_selectors
+    ]
+    selectors = list(dict.fromkeys(sel for sel, _ in pairs))
+    per_example, _exc = _evaluate_per_example(datums, selectors)
+    if not per_example:
+        return 0  # couldn't check — leave everything standing
+
+    overlapping = set()
+    for sel, rival in pairs:
+        if id(rival) in overlapping:
+            continue
+        for verdicts in per_example:
+            v = verdicts.get(sel)
+            if v is not None and v.ok and not v.empty:
+                overlapping.add(id(rival))
+                break
+
+    to_demote = [r for r in rivals if id(r) in overlapping]
+    _demote(draft, to_demote)
+    return len(to_demote)
+
+
+def _selector_reason(selector: str, expected: int, per_example: List[dict]) -> str:
+    """Why a selector failed evaluation, phrased for repair feedback."""
+    for verdicts in per_example:
+        v = verdicts.get(selector)
+        if v is None:
+            continue
+        if v.resolves and v.arity != expected:
+            return (
+                f"resolved at arity {v.arity}, but this directive needs "
+                f"arity {expected}"
+            )
+        diag = v.diagnostic
+        if diag:
+            return diag
+    return "did not resolve on every example"
+
+
+def _reject_line(cand: dict, reason: Optional[str]) -> str:
+    sel = _as_str(cand.get("selector")) or "(no selector)"
+    return f"- {cand.get('directive')} `{sel}`: {reason}"
+
+
+def _failure_message(
+    statement: str, cannot: Optional[str], rejects: List[str]
+) -> str:
+    msg = f'ask: could not translate "{statement}" into a validated directive.'
+    if cannot:
+        msg += f" The model reported: {cannot}"
+    if rejects:
+        msg += " Candidates were rejected:\n" + "\n".join(rejects)
+    return msg + (
+        "\nRephrase the request, name a field/relation that exists in the "
+        "examples, or author the directive by hand."
+    )

--- a/test/test_suggest_ask.py
+++ b/test/test_suggest_ask.py
@@ -1,0 +1,495 @@
+#!/usr/bin/env python3
+"""Tests for the user-directed ``ask=`` tier (``spytial.suggest._ask``).
+
+Same strategy as the tier-2 tests: the admission logic runs against a fake model
+and a *stubbed* evaluator, so everything is deterministic with no node and no
+network. One end-to-end test uses the real headless evaluator and skips when the
+bridge isn't present. The loud-failure contract is the point of half these tests:
+where enrichment degrades with a note, ask must raise :class:`AskError`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import spytial
+from spytial.suggest import AskError, SpecDraft, Suggestion, build_class_info, suggest
+from spytial.suggest import _ask
+from spytial.suggest import _eval
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures / fakes
+# --------------------------------------------------------------------------- #
+
+
+class LL:
+    """A singly linked list node: relations `next` and `value`, both arity 2."""
+
+    def __init__(self, value, nxt=None):
+        self.value = value
+        self.next = nxt
+
+
+def _instance(n=3):
+    head = node = LL(0)
+    for i in range(1, n):
+        node.next = LL(i)
+        node = node.next
+    return head
+
+
+def _ci():
+    return build_class_info(LL, instance=_instance())
+
+
+def _draft(suggestions=None, alternatives=None):
+    return SpecDraft(LL, list(suggestions or []), alternatives=list(alternatives or []))
+
+
+class FakeAsk:
+    """A provider returning one fixed response; records the prompts it saw."""
+
+    def __init__(self, response):
+        self.response = response
+        self.prompts = []
+
+    def __call__(self, prompt, *, schema):
+        self.prompts.append(prompt)
+        return self.response
+
+
+class RepairAsk:
+    """A provider answering with a different response per call (a repair queue)."""
+
+    def __init__(self, rounds):
+        self.rounds = list(rounds)
+        self.prompts = []
+
+    def __call__(self, prompt, *, schema):
+        self.prompts.append(prompt)
+        idx = min(len(self.prompts) - 1, len(self.rounds) - 1)
+        return self.rounds[idx]
+
+
+def _v(selector, ok=True, empty=False, arity=2):
+    return _eval.SelectorVerdict(selector=selector, ok=ok, empty=empty, arity=arity)
+
+
+def _stub_eval(monkeypatch, spec, available=True):
+    """Stub the evaluator: ``spec`` maps selector -> (ok, empty, arity), same for
+    every example. Unlisted selectors default to a clean arity-2 result."""
+
+    def fake_evaluate(datum, selectors):
+        return [_v(s, *spec.get(s, (True, False, 2))) for s in selectors]
+
+    monkeypatch.setattr(_eval, "is_available", lambda: available)
+    monkeypatch.setattr(_eval, "evaluate_selectors", fake_evaluate)
+
+
+def _llm(draft):
+    return [s for s in draft.suggestions if s.source == "llm"]
+
+
+def _cand(directive="orientation", selector="next", **extra):
+    base = {"directive": directive, "selector": selector, "why": "test"}
+    base.update(extra)
+    return base
+
+
+# --------------------------------------------------------------------------- #
+# Admission (fake model + stubbed evaluator)
+# --------------------------------------------------------------------------- #
+
+
+def test_orientation_ask_is_admitted(monkeypatch):
+    _stub_eval(monkeypatch, {"next": (True, False, 2)})
+    model = FakeAsk(
+        {"candidates": [_cand(directions=["below"], why="children read downward")]}
+    )
+    draft = _draft()
+    _ask.ask_draft(
+        draft, _ci(), "children below parents", provider=model, examples=[_instance()]
+    )
+
+    (sug,) = _llm(draft)
+    assert sug.directive == "orientation"
+    assert sug.kwargs == {"selector": "next", "directions": ["below"]}
+    assert sug.enabled_by_default is True
+    assert sug.confidence == "high"
+    assert sug.rationale == "ask: children read downward"
+    assert any('ask: "children below parents"' in n for n in draft.notes)
+    # The statement and the vocabulary both reached the model.
+    assert "children below parents" in model.prompts[0]
+    assert "next/2" in model.prompts[0]
+
+
+def test_unary_kinds_are_admitted(monkeypatch):
+    _stub_eval(monkeypatch, {"int": (True, False, 1)})
+    model = FakeAsk(
+        {
+            "candidates": [
+                _cand("hideAtom", "int"),
+                _cand("atomStyle", "int", fill="green"),
+            ]
+        }
+    )
+    draft = _draft()
+    _ask.ask_draft(draft, _ci(), "hide and tint ints", provider=model, examples=[_instance()])
+
+    out = {s.directive: s for s in _llm(draft)}
+    assert set(out) == {"hideAtom", "atomStyle"}
+    assert out["hideAtom"].kwargs == {"selector": "int"}
+    assert out["atomStyle"].kwargs == {
+        "selector": "int",
+        "fillStyle": {"color": "green"},
+    }
+
+
+def test_ask_confirms_existing_row_instead_of_duplicating(monkeypatch):
+    _stub_eval(monkeypatch, {"next": (True, False, 2)})
+    existing = Suggestion(
+        "orientation",
+        {"selector": "next", "directions": ["below"]},
+        "medium",
+        "rule",
+        "next",
+        enabled_by_default=False,
+    )
+    draft = _draft([existing])
+    model = FakeAsk({"candidates": [_cand(directions=["below"])]})
+    _ask.ask_draft(draft, _ci(), "next below", provider=model, examples=[_instance()])
+
+    assert draft.suggestions == [existing]  # no twin row appended
+    assert existing.enabled_by_default is True  # the ask turned it on
+    assert existing.source == "rule"
+
+
+def test_ask_promotes_matching_alternative(monkeypatch):
+    _stub_eval(monkeypatch, {"next": (True, False, 2)})
+    alt = Suggestion(
+        "orientation",
+        {"selector": "next", "directions": ["below"]},
+        "medium",
+        "rule",
+        "next",
+        enabled_by_default=False,
+    )
+    draft = _draft([], alternatives=[alt])
+    model = FakeAsk({"candidates": [_cand(directions=["below"])]})
+    _ask.ask_draft(draft, _ci(), "next below", provider=model, examples=[_instance()])
+
+    assert draft.alternatives == []
+    assert draft.suggestions == [alt]
+    assert alt.enabled_by_default is True
+
+
+def test_multi_part_ask_admits_several_directives(monkeypatch):
+    _stub_eval(monkeypatch, {"next": (True, False, 2), "int": (True, False, 1)})
+    model = FakeAsk(
+        {
+            "candidates": [
+                _cand(directions=["below"]),
+                _cand("atomStyle", "int", fill="green"),
+            ]
+        }
+    )
+    draft = _draft()
+    _ask.ask_draft(
+        draft, _ci(), "nodes below, ints green", provider=model, examples=[_instance()]
+    )
+
+    assert {s.directive for s in _llm(draft)} == {"orientation", "atomStyle"}
+    assert any("2 directive(s)" in n for n in draft.notes)
+
+
+def test_partial_success_still_repairs_the_failed_half(monkeypatch):
+    _stub_eval(monkeypatch, {"next": (True, False, 2)})
+    good = _cand(directions=["below"])
+    bad = _cand("cyclic", "next", direction="widdershins")  # out-of-vocab slip
+    fixed = _cand("cyclic", "next", direction="clockwise")
+    model = RepairAsk([{"candidates": [good, bad]}, {"candidates": [fixed]}])
+    draft = _draft()
+    _ask.ask_draft(
+        draft, _ci(), "below, and a clockwise ring", provider=model,
+        examples=[_instance()],
+    )
+
+    assert {s.directive for s in _llm(draft)} == {"orientation", "cyclic"}
+    assert any("2 directive(s)" in n for n in draft.notes)
+    assert len(model.prompts) == 2
+    assert "already accepted" in model.prompts[1]
+    assert "cyclic needs direction" in model.prompts[1]
+
+
+def test_partial_success_notes_the_unvalidated_remainder(monkeypatch):
+    _stub_eval(monkeypatch, {"next": (True, False, 2)})
+    good = _cand(directions=["below"])
+    bad = _cand("cyclic", "next", direction="widdershins")
+    model = FakeAsk({"candidates": [good, bad]})  # the repair gets the same slip back
+    draft = _draft()
+    _ask.ask_draft(
+        draft, _ci(), "below, and a ring", provider=model, examples=[_instance()]
+    )
+
+    (sug,) = _llm(draft)  # the accepted half stands, exactly once
+    assert sug.directive == "orientation"
+    assert any("part of the request could not be validated" in n for n in draft.notes)
+    assert any("cyclic needs direction" in n for n in draft.notes)
+
+
+def test_ask_demotes_overlapping_geometry(monkeypatch):
+    # The stub reports every selector — including the "(a) & (b)" overlap probe —
+    # as non-empty, so the enabled rule row competes with the ask and steps down.
+    _stub_eval(monkeypatch, {"^next": (True, False, 2)})
+    rule_row = Suggestion(
+        "orientation",
+        {"selector": "next", "directions": ["right"]},
+        "high",
+        "rule",
+        "next",
+        enabled_by_default=True,
+    )
+    draft = _draft([rule_row])
+    model = FakeAsk({"candidates": [_cand(selector="^next", directions=["below"])]})
+    _ask.ask_draft(
+        draft, _ci(), "everything below", provider=model, examples=[_instance()]
+    )
+
+    assert rule_row not in draft.suggestions
+    assert rule_row in draft.alternatives
+    assert rule_row.enabled_by_default is False
+    (ask_row,) = _llm(draft)
+    assert ask_row.enabled_by_default is True
+    assert any("1 overlapping row(s) demoted" in n for n in draft.notes)
+
+
+def test_ask_leaves_disjoint_geometry_alone(monkeypatch):
+    # The overlap probe for this rival evaluates to the empty set: no fight, no
+    # demotion — orthogonal constraints coexist.
+    _stub_eval(
+        monkeypatch,
+        {"^next": (True, False, 2), "(^next) & (prev)": (True, True, 2)},
+    )
+    rule_row = Suggestion(
+        "orientation",
+        {"selector": "prev", "directions": ["left"]},
+        "high",
+        "rule",
+        "prev",
+        enabled_by_default=True,
+    )
+    draft = _draft([rule_row])
+    model = FakeAsk({"candidates": [_cand(selector="^next", directions=["below"])]})
+    _ask.ask_draft(
+        draft, _ci(), "everything below", provider=model, examples=[_instance()]
+    )
+
+    assert rule_row in draft.suggestions
+    assert rule_row.enabled_by_default is True
+    assert not any("demoted" in n for n in draft.notes)
+
+
+def test_repair_round_salvages_a_bad_first_translation(monkeypatch):
+    _stub_eval(monkeypatch, {"next": (True, False, 2)})
+    model = RepairAsk(
+        [
+            {"candidates": [_cand(directions=["diagonal"])]},  # out-of-vocab slip
+            {"candidates": [_cand(directions=["below"])]},
+        ]
+    )
+    draft = _draft()
+    _ask.ask_draft(draft, _ci(), "next below", provider=model, examples=[_instance()])
+
+    (sug,) = _llm(draft)
+    assert sug.kwargs == {"selector": "next", "directions": ["below"]}
+    assert len(model.prompts) == 2
+    assert "went wrong" in model.prompts[1]
+    assert "orientation needs 1-2 directions" in model.prompts[1]
+
+
+# --------------------------------------------------------------------------- #
+# The loud-failure contract
+# --------------------------------------------------------------------------- #
+
+
+def test_cannot_reply_raises_with_the_models_reason(monkeypatch):
+    _stub_eval(monkeypatch, {})
+    model = FakeAsk({"candidates": [], "cannot": "the request is not spatial"})
+    with pytest.raises(AskError, match="the request is not spatial"):
+        _ask.ask_draft(
+            _draft(), _ci(), "make it pretty", provider=model, examples=[_instance()]
+        )
+
+
+def test_unvalidatable_translation_raises_with_diagnostics(monkeypatch):
+    # `value` resolves at arity 2 is the default; force arity 1 so orientation fails.
+    _stub_eval(monkeypatch, {"int": (True, False, 1)})
+    model = FakeAsk({"candidates": [_cand("orientation", "int", directions=["below"])]})
+    with pytest.raises(AskError, match="arity"):
+        _ask.ask_draft(
+            _draft(), _ci(), "ints below", provider=model, examples=[_instance()]
+        )
+    # Both rounds ran (the repair got the same bad answer back).
+    assert len(model.prompts) == 2
+
+
+def test_provider_exception_raises(monkeypatch):
+    _stub_eval(monkeypatch, {})
+
+    def boom(prompt, *, schema):
+        raise RuntimeError("no tokens")
+
+    with pytest.raises(AskError, match="provider call failed"):
+        _ask.ask_draft(
+            _draft(), _ci(), "next below", provider=boom, examples=[_instance()]
+        )
+
+
+def test_evaluator_unavailable_raises(monkeypatch):
+    _stub_eval(monkeypatch, {}, available=False)
+    model = FakeAsk({"candidates": [_cand(directions=["below"])]})
+    with pytest.raises(AskError, match="node"):
+        _ask.ask_draft(
+            _draft(), _ci(), "next below", provider=model, examples=[_instance()]
+        )
+
+
+def test_no_buildable_example_raises(monkeypatch):
+    _stub_eval(monkeypatch, {})
+    model = FakeAsk({"candidates": []})
+    with pytest.raises(AskError, match="example"):
+        _ask.ask_draft(_draft(), _ci(), "next below", provider=model, examples=[])
+
+
+def test_suggest_ask_requires_enrich():
+    with pytest.raises(AskError, match="enrich"):
+        suggest(_instance(), ask="next below")
+
+
+def test_suggest_ask_rejects_empty_statement():
+    with pytest.raises(AskError, match="non-empty"):
+        suggest(_instance(), ask="   ", enrich=lambda p, *, schema: {})
+
+
+def test_suggest_ask_with_unresolvable_provider_raises():
+    with pytest.raises(AskError, match="provider"):
+        suggest(_instance(), ask="next below", enrich=123)
+
+
+# --------------------------------------------------------------------------- #
+# Through suggest(), and the spytial.suggest(...) call form
+# --------------------------------------------------------------------------- #
+
+
+class SchemaRouter:
+    """One provider serving all three tiers, keyed by the schema each requests."""
+
+    def __init__(self, ask_response):
+        self.ask_response = ask_response
+
+    def __call__(self, prompt, *, schema):
+        props = schema.get("properties", {})
+        if "candidates" in props:
+            return self.ask_response
+        if "selectors" in props:
+            return {"selectors": []}
+        return {"shapes": []}
+
+
+def test_suggest_threads_ask_through(monkeypatch):
+    _stub_eval(monkeypatch, {"next": (True, False, 2)})
+    provider = SchemaRouter(
+        {"candidates": [_cand(directions=["below"], why="user asked")]}
+    )
+    draft = suggest(_instance(), ask="children below parents", enrich=provider)
+
+    assert any(
+        s.directive == "orientation"
+        and s.kwargs == {"selector": "next", "directions": ["below"]}
+        and s.enabled_by_default
+        for s in _llm(draft)
+    )
+
+
+def test_spytial_suggest_is_callable():
+    # The natural spelling: spytial.suggest(obj, ...) — module-as-function.
+    draft = spytial.suggest(_instance())
+    assert isinstance(draft, SpecDraft)
+    # The module facets still behave.
+    assert spytial.suggest.SpecDraft is SpecDraft
+    from spytial.suggest import suggest as fn
+
+    assert fn is suggest
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end with the real headless evaluator (skips without node)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.skipif(not _eval.is_available(), reason="headless evaluator unavailable")
+def test_ask_end_to_end_real_evaluator():
+    model = FakeAsk(
+        {"candidates": [_cand(directions=["below"], why="list reads downward")]}
+    )
+    draft = _draft()
+    _ask.ask_draft(
+        draft, _ci(), "each node below the previous", provider=model,
+        examples=[_instance()],
+    )
+    (sug,) = _llm(draft)
+    assert sug.kwargs == {"selector": "next", "directions": ["below"]}
+
+
+@pytest.mark.skipif(not _eval.is_available(), reason="headless evaluator unavailable")
+def test_ask_wins_its_ground_real_evaluator():
+    """The motivating scenario: the ask's plain `below` replaces the rules'
+    below-left/below-right — real datum, real intersection check."""
+
+    class BT:
+        def __init__(self, value, left=None, right=None):
+            self.value, self.left, self.right = value, left, right
+
+    tree = BT(1, BT(2, BT(4)), BT(3))
+    provider = SchemaRouter(
+        {
+            "candidates": [
+                _cand(
+                    selector="left + right",
+                    directions=["below"],
+                    why="children hang below their parent",
+                )
+            ]
+        }
+    )
+    draft = suggest(
+        tree, ask="all binary tree children should be below their parents",
+        enrich=provider,
+    )
+
+    enabled_orients = [
+        s
+        for s in draft.suggestions
+        if s.directive == "orientation" and s.enabled_by_default
+    ]
+    assert len(enabled_orients) == 1
+    assert enabled_orients[0].kwargs == {
+        "selector": "left + right",
+        "directions": ["below"],
+    }
+    # The rules' two per-field orientation rows stepped down, still one toggle away.
+    assert (
+        sum(1 for s in draft.alternatives if s.directive == "orientation") >= 2
+    )
+
+
+@pytest.mark.skipif(not _eval.is_available(), reason="headless evaluator unavailable")
+def test_ask_end_to_end_rejects_unknown_relation():
+    model = FakeAsk(
+        {"candidates": [_cand(selector="children", directions=["below"])]}
+    )
+    with pytest.raises(AskError):
+        _ask.ask_draft(
+            _draft(), _ci(), "children below", provider=model, examples=[_instance()]
+        )

--- a/test/test_suggest_ask.py
+++ b/test/test_suggest_ask.py
@@ -322,6 +322,18 @@ def test_cannot_reply_raises_with_the_models_reason(monkeypatch):
         )
 
 
+@pytest.mark.parametrize("candidates", [None, 7, "not an array", {"bad": "shape"}])
+def test_malformed_candidates_raise_with_the_models_reason(monkeypatch, candidates):
+    _stub_eval(monkeypatch, {})
+    model = FakeAsk(
+        {"candidates": candidates, "cannot": "the provider could not translate it"}
+    )
+    with pytest.raises(AskError, match="the provider could not translate it"):
+        _ask.ask_draft(
+            _draft(), _ci(), "make it pretty", provider=model, examples=[_instance()]
+        )
+
+
 def test_unvalidatable_translation_raises_with_diagnostics(monkeypatch):
     # `value` resolves at arity 2 is the default; force arity 1 so orientation fails.
     _stub_eval(monkeypatch, {"int": (True, False, 1)})


### PR DESCRIPTION
## What

A new user-directed tier for `spytial.suggest`, alongside the existing enrichment tiers:

```python
spytial.suggest(tree, ask="all binary tree children should be below their parents", enrich=ClaudeCode())
```

The sentence is translated by the `enrich=` provider into directive(s), and a translation reaches the draft only after the full admission gauntlet:

1. **Kind + vocabulary** — the directive is one ask can author (`orientation`, `cyclic`, `align`, `inferredEdge`, `hideAtom`, `atomStyle`) and its enum kwargs are in the canonical sets. `group` is deliberately deferred (dual-arity selector, two kwarg forms).
2. **Evaluation** — the selector parses, is non-empty, and has the directive's exact arity on **every** example instance, via the headless evaluator; a failing round gets one counterexample-guided repair attempt seeded with the per-candidate diagnostics.
3. **The authoring gate** — the kwargs run the same `_prepare_kwargs`/`validate_fields` pipeline the `@spytial.*` decorators run, so an admitted row cannot fail later in `apply()`.

## Semantics (the inverse of enrichment's)

- **Loud failures.** No provider, no example to validate against, no `node` runtime, a model "cannot express that" reply, or an ask of which nothing validates raises `AskError` carrying the reasons — enrichment's quiet degrade-with-a-note would silently ignore an explicit request.
- **The ask is the key thing in the draft.** Admitted rows are enabled by default (a translation landing on an existing row enables it instead of duplicating it), and an admitted geometric row demotes every enabled `orientation`/`cyclic`/`align` row whose selector overlaps its own — rule- and model-proposed alike — to `draft.alternatives`. Overlap is decided by the evaluator, not syntax: `(ask_sel) & (rival_sel)` is itself a selector, and non-empty on any example means both constraints claim the same edges. So asking for "children below parents" *replaces* the rules' below-left/below-right pair rather than stacking a third constraint on the same edges.
- **Compound requests admit per candidate** (up to 3). What validates lands, the repair round retries only the failed remainder, and anything still unvalidated is recorded in `draft.notes` — no half of a request vanishes without a trace. Only a fully failed ask raises.

## Also

- `spytial.suggest(tree, ...)` now works as written: a lazy PEP 562 attribute on the top-level package plus a callable module class on the subpackage. The subpackage stays dormant until touched; `from spytial.suggest import suggest` and every other existing form keep working.
- Docs: new "Ask for a directive in your own words" section in `docs/suggest.md`.
- Version bumped to 1.8.3.

## Reviewer notes

- The tier reuses the tier-2 machinery (`_vocabulary`, `_evaluate_per_example`, `_make_resolver`, `_edge_name`) and the shape tier's `_demote`; the new per-directive arity table in `_ask.py` follows `docs/selectors.md` (binary for orientation/align/inferredEdge/cyclic, unary for hideAtom/atomStyle).
- An intersection probe that fails to evaluate is treated as *no* overlap — when in doubt, nothing is demoted.
- Tests: 23 new in `test/test_suggest_ask.py` (fake model + stubbed evaluator for the logic; four end-to-end cases on the real headless evaluator, skipped without node). Full suite: 555 passed, 8 skipped, 2 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)