### PR TITLE
Add strategy-backed witnesses to suggest()

### DIFF
--- a/docs/suggest.md
+++ b/docs/suggest.md
@@ -237,13 +237,52 @@ import spytial
 from spytial.suggest import ClaudeCode
 
 draft = spytial.suggest(
-    tree,
+    TreeNode,
     ask="all binary tree children should be below their parents",
     enrich=ClaudeCode(),          # ask uses the same provider slot
 )
 draft.to_source()
 # @spytial.orientation(selector='left + right', directions=['below'])  # ask: children hang below their parent
 ```
+
+Where did the instance come from? For a class-only ask, `suggest` lazily asks
+Hypothesis for one:
+
+```python
+from spytial.suggest import suggest
+
+# implicit strategy="auto"
+draft = suggest(TreeNode, ask="put every child below its parent", enrich=ClaudeCode())
+
+# the explicit spelling
+draft = suggest(
+    TreeNode,
+    ask="put every child below its parent",
+    strategy="auto",                         # st.from_type(TreeNode)
+    enrich=ClaudeCode(),
+)
+
+# preserve domain invariants with your own family of valid values
+draft = suggest(
+    RedBlackNode,
+    ask="put every child below its parent",
+    strategy=valid_red_black_trees(),
+    enrich=ClaudeCode(),
+)
+```
+
+Install this path with `pip install "spytial_diagramming[suggest-search]"`.
+Generation is bounded and deliberately modest: it finds a concrete witness so
+the model can see a real relational vocabulary and its selector can be executed.
+For recursive types it first tries to populate every recursive root field, then
+falls back to any non-leaf witness. This is not a proof over every value the
+strategy can generate.
+
+`examples=` has a different job. Those are particular, mandatory regression
+cases, and an authored selector must validate on every one. You can combine the
+two: `examples=[awkward_tree]` pins a case you care about, while
+`strategy=valid_trees()` contributes a generated witness. Passing an instance as
+the target is shorthand for a single fixed example.
 
 A translation reaches the draft only after the full gauntlet:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,11 @@ dev = [
 e2e = [
     "playwright>=1.40",
 ]
+# Optional bounded witness generation for class-only suggest(..., ask=...) and
+# explicit strategy= calls. The ordinary static suggest(Cls) path stays stdlib-only.
+suggest-search = [
+    "hypothesis>=6.0.0",
+]
 # Optional LLM enrichment layer for spytial.suggest (spatial-shape suggestions:
 # orientation / cyclic / group over structural fields). The static analyzer needs
 # none of this — it is stdlib-only and the default path.

--- a/spytial/_version.py
+++ b/spytial/_version.py
@@ -1,3 +1,3 @@
 """Package version source of truth."""
 
-__version__ = "1.8.3"
+__version__ = "1.9.0"

--- a/spytial/suggest/__init__.py
+++ b/spytial/suggest/__init__.py
@@ -13,8 +13,10 @@ Pass ``instance=`` when a plain class can't be read statically (e.g. children
 default to ``None``), and ``registry=`` to run an isolated set of heuristics.
 Extend the rules with the :func:`heuristic` decorator.
 
-This subpackage is intentionally *not* imported by ``spytial`` itself: it adds
-no dependencies and stays dormant until you reach for it.
+This subpackage is intentionally *not* imported by ``spytial`` itself: the
+ordinary static path adds no dependencies and stays dormant until you reach for
+it.  Class-only ``ask=`` calls lazily use Hypothesis to derive a concrete
+witness; pass ``examples=`` or ``strategy=`` to control that witness set.
 """
 
 from __future__ import annotations
@@ -75,6 +77,7 @@ def suggest(
     *,
     instance: Any = None,
     examples: Optional[List[Any]] = None,
+    strategy: Any = None,
     registry: Optional[HeuristicRegistry] = None,
     enrich: Any = None,
     ask: Optional[str] = None,
@@ -92,6 +95,16 @@ def suggest(
             resolves on *every* example, so several instances narrow the gap toward
             "correct on all data". Defaults to ``[instance]`` (or the instance form of
             ``target``); pass more for the instance-set form. Ignored unless ``enrich``.
+        strategy: an optional Hypothesis strategy that supplies one generated witness
+            in addition to any fixed ``examples``. Pass ``"auto"`` to derive it with
+            ``hypothesis.strategies.from_type(target)``. If ``ask=`` is used with a
+            class and no instance/examples/strategy, ``"auto"`` is implied, so
+            ``suggest(TreeNode, ask=..., enrich=...)`` works directly for a type
+            Hypothesis can construct. Generation is bounded and provides a concrete
+            vocabulary for selector validation; it is not a proof over the whole
+            strategy. Requires the optional ``[suggest-search]`` extra. A failed
+            strategy degrades to a static-draft note unless ``ask=`` makes the witness
+            mandatory, in which case it raises :class:`AskError`.
         registry: an alternate :class:`HeuristicRegistry`; defaults to the global
             one populated with the built-in rules.
         enrich: turn on the optional LLM enrichment layer by saying *what* to enrich
@@ -127,13 +140,16 @@ def suggest(
             the ground it covers: an admitted orientation/cyclic/align row demotes
             every enabled geometric row whose selector overlaps its own (checked by
             evaluating the intersection over the examples) to ``draft.alternatives``.
-            Unlike enrichment, ``ask`` fails **loudly**: a missing provider, no example instance, no headless
-            evaluator, or a translation that can't be validated raises
+            Unlike enrichment, ``ask`` fails **loudly**: a missing provider, no
+            buildable fixed or generated witness, no headless evaluator, or a
+            translation that can't be validated raises
             :class:`AskError` with the reasons.
     """
     if ask is not None:
         if not isinstance(ask, str) or not ask.strip():
-            raise AskError("ask= must be a natural-language request (a non-empty string).")
+            raise AskError(
+                "ask= must be a natural-language request (a non-empty string)."
+            )
         ask = ask.strip()
         if enrich is None or enrich is False:
             raise AskError(
@@ -148,10 +164,36 @@ def suggest(
         instance = target if instance is None else instance
         cls = type(target)
 
-    # The example set drives selector validation (tier-2). Default it to the sampled
+    # Fixed examples drive selector validation (tier-2). Default to the sampled
     # instance so suggest(obj, enrich=...) just works; an explicit examples= list is
-    # the instance-set form. The introspection sample falls back to the first example.
+    # the instance-set form. A strategy adds one generated witness. Class-only ask
+    # implies strategy="auto": its selector translation needs a concrete datum even
+    # though the caller only named a type.
     example_objs = _coerce_examples(examples, instance)
+    strategy_note: Optional[str] = None
+    effective_strategy = strategy
+    if ask is not None and not example_objs and effective_strategy is None:
+        effective_strategy = "auto"
+    if effective_strategy is not None:
+        from ._strategy import StrategyError, find_witness
+
+        static_info = build_class_info(cls)
+        try:
+            witness = find_witness(cls, static_info, effective_strategy)
+        except StrategyError as exc:
+            if ask is not None:
+                raise AskError(f"ask: {exc}") from exc
+            strategy_note = f"strategy skipped: {exc}"
+        else:
+            example_objs.append(witness)
+            origin = (
+                "auto-derived"
+                if isinstance(effective_strategy, str) and effective_strategy == "auto"
+                else "supplied"
+            )
+            strategy_note = (
+                f"strategy: added one Hypothesis witness from the {origin} strategy."
+            )
     sample = (
         instance
         if instance is not None
@@ -161,6 +203,8 @@ def suggest(
     reg = registry if registry is not None else DEFAULT_REGISTRY
     class_info = build_class_info(cls, instance=sample)
     draft = build_draft(class_info, reg)
+    if strategy_note:
+        draft.notes.append(strategy_note)
     # ``None``/``False`` mean "no enrichment"; everything else is a provider spec.
     # Use identity checks, not truthiness — a callable provider whose ``__bool__``
     # (or ``__len__``) is falsy must still resolve, since the contract accepts *any*
@@ -187,9 +231,7 @@ def suggest(
         if ask is not None:
             from ._ask import ask_draft
 
-            ask_draft(
-                draft, class_info, ask, provider=provider, examples=example_objs
-            )
+            ask_draft(draft, class_info, ask, provider=provider, examples=example_objs)
     return draft
 
 

--- a/spytial/suggest/_strategy.py
+++ b/spytial/suggest/_strategy.py
@@ -1,0 +1,182 @@
+"""Hypothesis-backed witness generation for :mod:`spytial.suggest`.
+
+This module is deliberately lazy.  The ordinary static ``suggest(Cls)`` path
+does not import Hypothesis (and the package does not require it); only an
+explicit ``strategy=`` or class-only ``ask=`` reaches this file's imports.
+
+A strategy supplies a *witness*, not a proof.  The witness gives selector
+authoring a concrete relational vocabulary to work over.  User-provided
+``examples=`` retain the stronger, fixed-regression-case meaning: every one is
+validated.  In particular, we do not mistake bounded generation for a claim
+about every inhabitant of the type.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from ..provider_system import CnDDataInstanceBuilder
+from ._model import ClassInfo
+
+
+class StrategyError(RuntimeError):
+    """A Hypothesis strategy could not supply a usable witness."""
+
+
+_MAX_EXAMPLES = 100
+
+
+def find_witness(cls: type, ci: ClassInfo, strategy: Any) -> Any:
+    """Return one buildable ``cls`` instance drawn from ``strategy``.
+
+    ``strategy="auto"`` asks Hypothesis to derive ``from_type(cls)``.  For a
+    recursive class, first try to populate every recursive root field, then
+    search for any nontrivial object (at least two atoms of the root type).  This
+    keeps a generated binary tree from shrinking to a leaf or a one-sided tree
+    whose child relations cannot all be validated.  If the type genuinely has
+    no nontrivial inhabitant under the strategy, fall back to any buildable one.
+
+    ``hypothesis.find`` is used rather than ``SearchStrategy.example()``: it is
+    the public API for bounded search and gives us deterministic shrinking.
+    """
+    find, settings, strategies, no_such_example = _hypothesis_api()
+
+    if isinstance(strategy, str):
+        if strategy != "auto":
+            raise StrategyError(
+                f"unknown strategy={strategy!r}; use 'auto' or pass a Hypothesis "
+                "strategy."
+            )
+        try:
+            source = strategies.from_type(cls)
+        except Exception as exc:  # noqa: BLE001 — normalize Hypothesis diagnostics
+            raise StrategyError(
+                f"could not derive a Hypothesis strategy for {cls.__name__}: {exc}. "
+                "Pass strategy=<a Hypothesis strategy> or examples=[...]."
+            ) from exc
+    else:
+        source = strategy
+
+    search_settings = settings(
+        max_examples=_MAX_EXAMPLES,
+        database=None,
+        deadline=None,
+        derandomize=True,
+    )
+    buildable = _buildable_predicate(cls)
+
+    # Recursive schemas need populated structural edges to ground an ask such as
+    # "put every child below its parent". Prefer a root that exercises every
+    # recursive field (both left and right, for example). Domain invariants may
+    # make that impossible, so fall back to any graph containing another root-
+    # type atom, then finally any buildable witness.
+    if ci.self_ref_fields:
+        fully_populated = _fully_populated_predicate(cls, ci, buildable)
+        try:
+            return find(source, fully_populated, settings=search_settings)
+        except no_such_example:
+            pass
+        except Exception as exc:  # invalid strategy, bad generation, etc.
+            raise _search_error(cls, exc) from exc
+
+        nontrivial = _nontrivial_predicate(cls, buildable)
+        try:
+            return find(source, nontrivial, settings=search_settings)
+        except no_such_example:
+            pass
+        except Exception as exc:  # invalid strategy, bad generation, etc.
+            raise _search_error(cls, exc) from exc
+
+    try:
+        return find(source, buildable, settings=search_settings)
+    except Exception as exc:  # noqa: BLE001 — present one stable public error
+        raise _search_error(cls, exc) from exc
+
+
+def _hypothesis_api():
+    """Import the optional dependency only when generation is requested."""
+    try:
+        from hypothesis import find, settings, strategies
+        from hypothesis.errors import NoSuchExample
+    except ImportError as exc:
+        raise StrategyError(
+            "strategy-backed suggestion needs Hypothesis. Install "
+            "spytial_diagramming[suggest-search], or pass examples=[...] instead."
+        ) from exc
+    return find, settings, strategies, NoSuchExample
+
+
+def _buildable_predicate(cls: type) -> Callable[[Any], bool]:
+    def buildable(obj: Any) -> bool:
+        if not isinstance(obj, cls):
+            return False
+        try:
+            datum = CnDDataInstanceBuilder().build_instance(obj)
+        except Exception:  # noqa: BLE001 — Hypothesis should keep searching
+            return False
+        return bool(datum.get("atoms"))
+
+    return buildable
+
+
+def _nontrivial_predicate(
+    cls: type, buildable: Callable[[Any], bool]
+) -> Callable[[Any], bool]:
+    def nontrivial(obj: Any) -> bool:
+        if not buildable(obj):
+            return False
+        try:
+            datum = CnDDataInstanceBuilder().build_instance(obj)
+        except Exception:  # pragma: no cover — buildable just established this
+            return False
+        return sum(a.get("type") == cls.__name__ for a in datum.get("atoms", [])) >= 2
+
+    return nontrivial
+
+
+def _fully_populated_predicate(
+    cls: type, ci: ClassInfo, buildable: Callable[[Any], bool]
+) -> Callable[[Any], bool]:
+    fields = [f for f in ci.fields if f.is_self_ref and not f.is_private]
+
+    def fully_populated(obj: Any) -> bool:
+        if not buildable(obj):
+            return False
+        for field in fields:
+            try:
+                value = getattr(obj, field.name)
+            except (AttributeError, TypeError):
+                return False
+            if field.container:
+                if not _container_has(value, cls, set()):
+                    return False
+            elif not isinstance(value, cls):
+                return False
+        return True
+
+    return fully_populated
+
+
+def _container_has(value: Any, cls: type, seen: set) -> bool:
+    """Does a possibly nested built-in container contain a ``cls`` instance?"""
+    if isinstance(value, cls):
+        return True
+    if not isinstance(value, (list, tuple, set, frozenset, dict)):
+        return False
+    marker = id(value)
+    if marker in seen:
+        return False
+    seen.add(marker)
+    items = (
+        list(value.keys()) + list(value.values()) if isinstance(value, dict) else value
+    )
+    return any(_container_has(item, cls, seen) for item in items)
+
+
+def _search_error(cls: type, exc: Exception) -> StrategyError:
+    detail = str(exc).strip()
+    suffix = f" ({detail})" if detail else ""
+    return StrategyError(
+        f"strategy could not produce a buildable {cls.__name__} witness within "
+        f"the search budget{suffix}. Pass examples=[...] or a different strategy."
+    )

--- a/spytial/suggest/_strategy.py
+++ b/spytial/suggest/_strategy.py
@@ -13,10 +13,12 @@ about every inhabitant of the type.
 
 from __future__ import annotations
 
-from typing import Any, Callable
+import sys
+from typing import Any, Callable, List, Optional, Set
 
 from ..provider_system import CnDDataInstanceBuilder
-from ._model import ClassInfo
+from ._model import ClassInfo, FieldInfo
+from .introspect import _looks_node_like, _referenced_names
 
 
 class StrategyError(RuntimeError):
@@ -24,6 +26,22 @@ class StrategyError(RuntimeError):
 
 
 _MAX_EXAMPLES = 100
+
+
+class _BuildTracker:
+    """Tell 'no witness matched' apart from 'the builder is broken'.
+
+    ``find`` calls the buildable predicate many times.  If ``build_instance``
+    returns even once, the builder works and an exhausted search genuinely means
+    nothing matched the predicate.  If it raised on *every* value, the failure is
+    a builder bug, not an empty search — and we surface that instead of the
+    misleading 'within the search budget' message (which would send the user off
+    to write ``examples=`` for a witness the builder could never have accepted).
+    """
+
+    def __init__(self) -> None:
+        self.ever_built = False
+        self.last_error: Optional[Exception] = None
 
 
 def find_witness(cls: type, ci: ClassInfo, strategy: Any) -> Any:
@@ -63,34 +81,51 @@ def find_witness(cls: type, ci: ClassInfo, strategy: Any) -> Any:
         deadline=None,
         derandomize=True,
     )
-    buildable = _buildable_predicate(cls)
+    tracker = _BuildTracker()
+    buildable = _buildable_predicate(cls, tracker)
+    # The atom types that count as structural *nodes* of this graph — the root
+    # class plus any sibling node-like type its self-ref fields point at, matching
+    # introspect's own is_self_ref rule. Both witness-quality tiers key off this
+    # so a heterogeneous graph (root -> a different node type) is judged by the
+    # same rule that marked the field self-ref, not a root-only check.
+    node_names = _node_type_names(cls, ci)
 
     # Recursive schemas need populated structural edges to ground an ask such as
     # "put every child below its parent". Prefer a root that exercises every
     # recursive field (both left and right, for example). Domain invariants may
-    # make that impossible, so fall back to any graph containing another root-
-    # type atom, then finally any buildable witness.
+    # make that impossible, so fall back to any graph containing another node-
+    # like atom, then finally any buildable witness.
     if ci.self_ref_fields:
-        fully_populated = _fully_populated_predicate(cls, ci, buildable)
-        try:
-            return find(source, fully_populated, settings=search_settings)
-        except no_such_example:
-            pass
-        except Exception as exc:  # invalid strategy, bad generation, etc.
-            raise _search_error(cls, exc) from exc
+        # The fully-populated tier needs concrete fields to check. Gate it on the
+        # SAME non-private self-ref set the predicate uses: a class whose only
+        # self-ref field is private (e.g. a linked list linked by ``_next``) would
+        # otherwise enter a tier that passes vacuously and hands back a leaf —
+        # exactly the degenerate witness the tier exists to avoid. The nontrivial
+        # tier still runs for any self-ref class, private field or not.
+        populatable = [f for f in ci.fields if f.is_self_ref and not f.is_private]
+        if populatable:
+            fully_populated = _fully_populated_predicate(
+                populatable, node_names, buildable
+            )
+            try:
+                return find(source, fully_populated, settings=search_settings)
+            except no_such_example:
+                pass
+            except Exception as exc:  # invalid strategy, bad generation, etc.
+                raise _search_error(cls, exc, tracker) from exc
 
-        nontrivial = _nontrivial_predicate(cls, buildable)
+        nontrivial = _nontrivial_predicate(node_names, buildable)
         try:
             return find(source, nontrivial, settings=search_settings)
         except no_such_example:
             pass
         except Exception as exc:  # invalid strategy, bad generation, etc.
-            raise _search_error(cls, exc) from exc
+            raise _search_error(cls, exc, tracker) from exc
 
     try:
         return find(source, buildable, settings=search_settings)
     except Exception as exc:  # noqa: BLE001 — present one stable public error
-        raise _search_error(cls, exc) from exc
+        raise _search_error(cls, exc, tracker) from exc
 
 
 def _hypothesis_api():
@@ -106,21 +141,47 @@ def _hypothesis_api():
     return find, settings, strategies, NoSuchExample
 
 
-def _buildable_predicate(cls: type) -> Callable[[Any], bool]:
+def _buildable_predicate(cls: type, tracker: _BuildTracker) -> Callable[[Any], bool]:
     def buildable(obj: Any) -> bool:
         if not isinstance(obj, cls):
             return False
         try:
             datum = CnDDataInstanceBuilder().build_instance(obj)
-        except Exception:  # noqa: BLE001 — Hypothesis should keep searching
+        except Exception as exc:  # noqa: BLE001 — Hypothesis should keep searching
+            tracker.last_error = exc
             return False
+        tracker.ever_built = True
         return bool(datum.get("atoms"))
 
     return buildable
 
 
+def _node_type_names(cls: type, ci: ClassInfo) -> Set[str]:
+    """Atom-type names that count as structural *nodes* of ``cls``'s graph.
+
+    Mirrors introspect's ``_is_self_ref`` exactly — the root class, plus any
+    sibling class in the same module that a self-ref field names and that itself
+    looks node-like — so the witness-quality tiers judge "another node" by the
+    same rule that marked the field self-ref. The old root-only check silently
+    rejected sibling nodes (a heterogeneous ``Head -> Cell`` graph) and handed
+    back a leaf.
+    """
+    names = {cls.__name__}
+    module = sys.modules.get(cls.__module__)
+    if module is None:
+        return names
+    for f in ci.fields:
+        if not f.is_self_ref or not f.type_repr:
+            continue
+        for nm in _referenced_names(f.type_repr):
+            obj = getattr(module, nm, None)
+            if isinstance(obj, type) and _looks_node_like(obj):
+                names.add(obj.__name__)
+    return names
+
+
 def _nontrivial_predicate(
-    cls: type, buildable: Callable[[Any], bool]
+    node_names: Set[str], buildable: Callable[[Any], bool]
 ) -> Callable[[Any], bool]:
     def nontrivial(obj: Any) -> bool:
         if not buildable(obj):
@@ -129,16 +190,20 @@ def _nontrivial_predicate(
             datum = CnDDataInstanceBuilder().build_instance(obj)
         except Exception:  # pragma: no cover — buildable just established this
             return False
-        return sum(a.get("type") == cls.__name__ for a in datum.get("atoms", [])) >= 2
+        # >=2 node atoms means at least one structural edge exists, so a self-ref
+        # relation the ask names is non-empty. Counting node_names (not just the
+        # root type) keeps heterogeneous graphs from being read as leaves.
+        return sum(a.get("type") in node_names for a in datum.get("atoms", [])) >= 2
 
     return nontrivial
 
 
 def _fully_populated_predicate(
-    cls: type, ci: ClassInfo, buildable: Callable[[Any], bool]
+    fields: List[FieldInfo], node_names: Set[str], buildable: Callable[[Any], bool]
 ) -> Callable[[Any], bool]:
-    fields = [f for f in ci.fields if f.is_self_ref and not f.is_private]
-
+    # ``fields`` is the non-private self-ref set chosen by the caller; keeping the
+    # choice in one place (find_witness) avoids the two-definitions-of-self-ref
+    # divergence that let a private-only recursive class slip a leaf through here.
     def fully_populated(obj: Any) -> bool:
         if not buildable(obj):
             return False
@@ -148,18 +213,21 @@ def _fully_populated_predicate(
             except (AttributeError, TypeError):
                 return False
             if field.container:
-                if not _container_has(value, cls, set()):
+                if not _container_has(value, node_names, set()):
                     return False
-            elif not isinstance(value, cls):
+            elif value is None:
+                # A non-container self-ref field is populated iff it holds a node;
+                # any non-None value qualifies (it may be a sibling node type, not
+                # the root class), matching how the field was judged self-ref.
                 return False
         return True
 
     return fully_populated
 
 
-def _container_has(value: Any, cls: type, seen: set) -> bool:
-    """Does a possibly nested built-in container contain a ``cls`` instance?"""
-    if isinstance(value, cls):
+def _container_has(value: Any, node_names: Set[str], seen: set) -> bool:
+    """Does a possibly nested built-in container hold a node-like instance?"""
+    if type(value).__name__ in node_names:
         return True
     if not isinstance(value, (list, tuple, set, frozenset, dict)):
         return False
@@ -170,12 +238,43 @@ def _container_has(value: Any, cls: type, seen: set) -> bool:
     items = (
         list(value.keys()) + list(value.values()) if isinstance(value, dict) else value
     )
-    return any(_container_has(item, cls, seen) for item in items)
+    return any(_container_has(item, node_names, seen) for item in items)
 
 
-def _search_error(cls: type, exc: Exception) -> StrategyError:
+def _search_error(cls: type, exc: Exception, tracker: _BuildTracker) -> StrategyError:
+    # If the builder raised on *every* generated value, this was never an empty
+    # search — it is a builder failure wearing a NoSuchExample. Report that, and
+    # carry the real exception, rather than telling the user to write examples=
+    # for a witness the builder could not have accepted anyway.
+    if not tracker.ever_built and tracker.last_error is not None:
+        detail = str(tracker.last_error).strip()
+        suffix = f" ({detail})" if detail else ""
+        return StrategyError(
+            f"every generated {cls.__name__} failed to build into a diagram "
+            f"instance{suffix}. This is a builder error, not an exhausted search "
+            "— check that the type is buildable, or pass examples=[...]."
+        )
+
+    # Tell a bad/empty strategy apart from a genuinely exhausted search. find
+    # raises InvalidArgument when the argument is not a strategy at all, and
+    # Unsatisfiable when the strategy can generate nothing — neither is a "widen
+    # the search" situation, so don't send the user off to add more examples.
+    from hypothesis.errors import InvalidArgument, Unsatisfiable
+
     detail = str(exc).strip()
     suffix = f" ({detail})" if detail else ""
+    if isinstance(exc, InvalidArgument):
+        return StrategyError(
+            f"strategy= for {cls.__name__} is not a valid Hypothesis strategy"
+            f"{suffix}. Pass a Hypothesis strategy, strategy='auto', or "
+            "examples=[...]."
+        )
+    if isinstance(exc, Unsatisfiable):
+        return StrategyError(
+            f"the strategy for {cls.__name__} generated no usable values"
+            f"{suffix}. Pass a strategy that can build {cls.__name__}, "
+            "strategy='auto', or examples=[...]."
+        )
     return StrategyError(
         f"strategy could not produce a buildable {cls.__name__} witness within "
         f"the search budget{suffix}. Pass examples=[...] or a different strategy."

--- a/test/test_suggest_strategy.py
+++ b/test/test_suggest_strategy.py
@@ -10,7 +10,7 @@ import pytest
 from hypothesis import strategies as st
 
 from spytial.suggest import AskError, build_class_info, suggest
-from spytial.suggest import _eval
+from spytial.suggest import _eval, _strategy
 from spytial.suggest._strategy import StrategyError, find_witness
 
 
@@ -19,6 +19,30 @@ class AutoTree:
     value: int
     left: Optional["AutoTree"] = None
     right: Optional["AutoTree"] = None
+
+
+@dataclass
+class PrivateLink:
+    """A recursive class whose only self-ref field is private (``_next``)."""
+
+    value: int
+    _next: Optional["PrivateLink"] = None
+
+
+@dataclass
+class Cell:
+    """A node-like sibling that Head points at (heterogeneous graph)."""
+
+    tag: int
+    cell: Optional["Cell"] = None
+
+
+@dataclass
+class Head:
+    """Its only self-ref field points at the *sibling* node type Cell, not Head."""
+
+    name: int
+    cell: Optional["Cell"] = None
 
 
 def _nodes(root):
@@ -72,6 +96,50 @@ def test_auto_strategy_finds_a_non_leaf_recursive_witness():
     assert len(_nodes(witness)) >= 3
 
 
+def test_private_only_self_ref_still_gets_a_non_leaf_witness():
+    # The recursive-branch gate (ClassInfo.self_ref_fields) counts the private
+    # `_next`, so this class enters witness population; the fully-populated tier
+    # has no *non-private* field to check and is skipped, but the nontrivial tier
+    # must still keep it from shrinking to a single-node leaf.
+    ci = build_class_info(PrivateLink)
+    assert ci.self_ref_fields == ["_next"]
+
+    witness = find_witness(PrivateLink, ci, "auto")
+
+    datum = _strategy.CnDDataInstanceBuilder().build_instance(witness)
+    link_atoms = sum(a.get("type") == "PrivateLink" for a in datum.get("atoms", []))
+    assert link_atoms >= 2  # not the degenerate one-node leaf
+
+
+def test_heterogeneous_sibling_node_gets_a_populated_witness():
+    # Head's only self-ref field points at the *sibling* node type Cell. The old
+    # root-only predicates could never satisfy fully_populated/nontrivial for such
+    # a graph and fell back to a leaf (Head(cell=None)); node_names now counts Cell
+    # atoms too, so the child relation is populated.
+    ci = build_class_info(Head)
+    assert ci.self_ref_fields == ["cell"]
+
+    witness = find_witness(Head, ci, "auto")
+
+    assert witness.cell is not None  # the sibling-typed child is populated
+
+
+def test_builder_failure_reads_as_a_builder_error_not_an_empty_search(monkeypatch):
+    class BrokenBuilder:
+        def build_instance(self, _obj):
+            raise RuntimeError("builder exploded")
+
+    monkeypatch.setattr(_strategy, "CnDDataInstanceBuilder", BrokenBuilder)
+
+    with pytest.raises(StrategyError) as excinfo:
+        find_witness(AutoTree, build_class_info(AutoTree), "auto")
+
+    message = str(excinfo.value)
+    assert "builder error" in message
+    assert "builder exploded" in message  # the real cause is carried, not masked
+    assert "within the search budget" not in message
+
+
 def test_explicit_strategy_supplies_the_witness():
     wanted = AutoTree(7, left=AutoTree(8))
 
@@ -80,9 +148,33 @@ def test_explicit_strategy_supplies_the_witness():
     assert witness is wanted
 
 
-def test_strategy_without_a_buildable_value_has_a_clear_error():
-    with pytest.raises(StrategyError, match="buildable AutoTree witness"):
+def test_empty_strategy_says_it_generated_nothing_not_budget_exhaustion():
+    # st.nothing() generates no values at all — an empty strategy, not a search
+    # that ran out of budget. The error should say so, not point at the budget.
+    with pytest.raises(StrategyError) as excinfo:
         find_witness(AutoTree, build_class_info(AutoTree), st.nothing())
+
+    message = str(excinfo.value)
+    assert "generated no usable values" in message
+    assert "within the search budget" not in message
+
+
+def test_non_strategy_argument_names_the_real_problem():
+    # Passing something that isn't a strategy must not be reported as a failed
+    # search over the type — the argument itself is wrong.
+    with pytest.raises(StrategyError) as excinfo:
+        find_witness(AutoTree, build_class_info(AutoTree), 42)
+
+    message = str(excinfo.value)
+    assert "not a valid Hypothesis strategy" in message
+    assert "within the search budget" not in message
+
+
+def test_wrong_type_strategy_genuinely_exhausts_the_search_budget():
+    # A valid strategy that simply never yields a buildable AutoTree is a real
+    # exhausted search — here the budget wording is the accurate one.
+    with pytest.raises(StrategyError, match="within the search budget"):
+        find_witness(AutoTree, build_class_info(AutoTree), st.integers())
 
 
 def test_unknown_strategy_string_has_a_clear_error():

--- a/test/test_suggest_strategy.py
+++ b/test/test_suggest_strategy.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Tests for Hypothesis-backed witnesses in ``spytial.suggest``."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import pytest
+from hypothesis import strategies as st
+
+from spytial.suggest import AskError, build_class_info, suggest
+from spytial.suggest import _eval
+from spytial.suggest._strategy import StrategyError, find_witness
+
+
+@dataclass
+class AutoTree:
+    value: int
+    left: Optional["AutoTree"] = None
+    right: Optional["AutoTree"] = None
+
+
+def _nodes(root):
+    if root is None:
+        return []
+    return [root] + _nodes(root.left) + _nodes(root.right)
+
+
+class _Router:
+    """Serve shape, selector, and ask calls from one deterministic provider."""
+
+    def __init__(self):
+        self.prompts = []
+
+    def __call__(self, prompt, *, schema):
+        self.prompts.append(prompt)
+        props = schema.get("properties", {})
+        if "candidates" in props:
+            return {
+                "candidates": [
+                    {
+                        "directive": "orientation",
+                        "selector": "left + right",
+                        "directions": ["below"],
+                        "why": "children belong below parents",
+                    }
+                ]
+            }
+        if "selectors" in props:
+            return {"selectors": []}
+        return {"shapes": []}
+
+
+def _stub_evaluator(monkeypatch):
+    def evaluate(_datum, selectors):
+        return [
+            _eval.SelectorVerdict(selector=s, ok=True, empty=False, arity=2)
+            for s in selectors
+        ]
+
+    monkeypatch.setattr(_eval, "is_available", lambda: True)
+    monkeypatch.setattr(_eval, "evaluate_selectors", evaluate)
+
+
+def test_auto_strategy_finds_a_non_leaf_recursive_witness():
+    witness = find_witness(AutoTree, build_class_info(AutoTree), "auto")
+
+    assert isinstance(witness, AutoTree)
+    assert witness.left is not None
+    assert witness.right is not None
+    assert len(_nodes(witness)) >= 3
+
+
+def test_explicit_strategy_supplies_the_witness():
+    wanted = AutoTree(7, left=AutoTree(8))
+
+    witness = find_witness(AutoTree, build_class_info(AutoTree), st.just(wanted))
+
+    assert witness is wanted
+
+
+def test_strategy_without_a_buildable_value_has_a_clear_error():
+    with pytest.raises(StrategyError, match="buildable AutoTree witness"):
+        find_witness(AutoTree, build_class_info(AutoTree), st.nothing())
+
+
+def test_unknown_strategy_string_has_a_clear_error():
+    with pytest.raises(StrategyError, match="use 'auto'"):
+        find_witness(AutoTree, build_class_info(AutoTree), "magic")
+
+
+def test_class_only_ask_implicitly_derives_a_strategy(monkeypatch):
+    _stub_evaluator(monkeypatch)
+    provider = _Router()
+
+    draft = suggest(
+        AutoTree,
+        ask="put every child below its parent",
+        enrich=provider,
+    )
+
+    assert any(
+        s.directive == "orientation"
+        and s.kwargs == {"selector": "left + right", "directions": ["below"]}
+        and s.enabled_by_default
+        for s in draft.suggestions
+    )
+    assert any("auto-derived strategy" in note for note in draft.notes)
+    ask_prompt = next(p for p in provider.prompts if "The user's request" in p)
+    assert "AutoTree (#3)" in ask_prompt
+
+
+@pytest.mark.skipif(not _eval.is_available(), reason="headless evaluator unavailable")
+def test_class_only_ask_works_with_the_real_evaluator():
+    draft = suggest(
+        AutoTree,
+        ask="put every child below its parent",
+        enrich=_Router(),
+    )
+
+    enabled = [
+        s
+        for s in draft.suggestions
+        if s.directive == "orientation" and s.enabled_by_default
+    ]
+    assert len(enabled) == 1
+    assert enabled[0].kwargs == {
+        "selector": "left + right",
+        "directions": ["below"],
+    }
+
+
+def test_fixed_examples_and_strategy_are_both_validation_witnesses(monkeypatch):
+    _stub_evaluator(monkeypatch)
+    provider = _Router()
+    fixed = AutoTree(1, left=AutoTree(2))
+    generated = AutoTree(3, right=AutoTree(4))
+
+    draft = suggest(
+        AutoTree,
+        examples=[fixed],
+        strategy=st.just(generated),
+        ask="put every child below its parent",
+        enrich=provider,
+    )
+
+    ask_prompt = next(p for p in provider.prompts if "The user's request" in p)
+    assert "validated against 2 example instance(s)" in ask_prompt
+    assert any("supplied strategy" in note for note in draft.notes)
+
+
+def test_failed_implicit_strategy_is_loud_for_ask(monkeypatch):
+    def fail(*_args, **_kwargs):
+        raise StrategyError("no family can be generated")
+
+    monkeypatch.setattr("spytial.suggest._strategy.find_witness", fail)
+
+    with pytest.raises(AskError, match="no family can be generated"):
+        suggest(AutoTree, ask="children below", enrich=_Router())
+
+
+def test_failed_strategy_degrades_to_a_note_without_ask(monkeypatch):
+    def fail(*_args, **_kwargs):
+        raise StrategyError("no family can be generated")
+
+    monkeypatch.setattr("spytial.suggest._strategy.find_witness", fail)
+
+    draft = suggest(AutoTree, strategy="auto")
+
+    assert any("strategy skipped: no family can be generated" in n for n in draft.notes)


### PR DESCRIPTION
## Summary

- add an optional `strategy=` input to `suggest()`
- make class-only `ask=` calls implicitly derive a Hypothesis strategy with `from_type()`
- search for a representative recursive witness, preferring populated root relations before falling back to non-leaf or any buildable values
- combine generated witnesses with fixed `examples=` while preserving their regression-case semantics
- keep Hypothesis lazy and optional through the new `suggest-search` extra
- document and test automatic, explicit, combined, failure, and real-evaluator paths

## Why

A call such as:

```python
suggest(
    TreeNode,
    ask="put every child below its parent",
    enrich=ClaudeCode(),
)
```

previously failed because selector translation required a concrete example datum. The class already contains enough type information for Hypothesis to derive one in many common cases, so requiring the caller to manually construct an instance added unnecessary ceremony.

The generated value is deliberately a witness, not a proof over the full strategy. Particular cases that must always validate remain explicit in `examples=`.

## User impact

Class-only asks now work directly for types Hypothesis can construct. Domain-specific invariants can be preserved with an explicit strategy, and fixed examples can be supplied alongside it. Ordinary static `suggest(Cls)` calls do not import Hypothesis or gain a required dependency.

## Validation

- `python3 -m pytest -q`: 569 passed, 8 skipped, 2 xfailed
- focused suggest tests: 36 passed
- Black and Flake8 checks pass
- `git diff --check` passes
- strict MkDocs build passes