### PR TITLE
Docs: rewrite suggest() guide, add architecture diagram, publish API reference

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -18,6 +18,10 @@ This section is generated directly from the Spytial source code using `mkdocstri
 
 ::: spytial.structured_input
 
+## Suggestion
+
+::: spytial.suggest
+
 ## Annotations
 
 ::: spytial.annotations

--- a/docs/suggest.md
+++ b/docs/suggest.md
@@ -1,332 +1,481 @@
-# Suggesting specs
+# Suggesting a Spytial specification
 
-`spytial.suggest` reads a class and proposes a starting set of layout
-directives — a lightweight scaffold you then edit, not a finished spec. By
-default it is pure static analysis: no LLM, no network, no extra dependencies
-(an optional model-backed enrichment layer is described [below](#optional-llm-enrichment)).
-The whole point is to get you past the blank page.
+Writing a Spytial specification from a blank page requires two decisions at
+once: what the diagram should look like, and how to express that intent using
+Spytial selectors and directives. Often the missing rule only becomes obvious
+after seeing it violated: diagonal children prompt “put every child directly
+below its parent”; a visible parent pointer prompts “hide that implementation
+detail.”
 
-It lives in its own subpackage and is **not** imported by `spytial` itself —
-nothing loads until you reach for it. Both spellings work:
+`spytial.suggest` replaces the blank page with a concrete, editable
+`SpecDraft`. The design claim is simple: a default need not be correct to be
+useful. If it is right, apply it. If it is wrong, inspect its selectors and
+correct something specific.
+
+Suggestion is local and deterministic by default. Models and Hypothesis-backed
+witness search are optional and load only when requested.
+
+## High-level idea
+
+The inputs tell Spytial what structure it can inspect. The proposal layers get
+more freedom only when Spytial has a stronger way to check their output.
+
+```mermaid
+flowchart TB
+    T["target<br/>class or object"] --> C["Class analysis"]
+    T -- "object" --> W["Concrete witnesses"]
+    I["instance=<br/>one sample"] --> W
+    E["examples=<br/>fixed must-pass cases"] --> W
+    S["strategy=<br/>family of valid values"] --> H["Hypothesis search<br/>one representative witness"]
+    H --> W
+    C -. "class-only ask; no witness" .-> A["implicit strategy='auto'<br/>from_type(target)"]
+    A --> H
+
+    C --> R["Deterministic rules<br/>known-good selector forms"]
+    C --> M1["Model chooses a shape<br/>from a closed vocabulary"]
+    W --> M2["Model authors a selector<br/>or translates ask="]
+    Q["ask=<br/>desired layout"] --> M2
+    P["enrich=<br/>model provider"] --> M1
+    P --> M2
+
+    M1 --> K1["Spytial supplies the selector"]
+    M2 --> K2["Execute selector<br/>check vocabulary, arity, and authoring"]
+    R --> D["SpecDraft"]
+    K1 --> D
+    K2 --> D
+    D --> U["Inspect · edit · apply"]
+```
+
+The left side establishes evidence: a class shape and, when available,
+concrete objects. The right side turns that evidence into proposals. Static
+rules use selector forms supplied by Spytial. A model may choose among known
+spatial shapes without seeing an instance. Giving a model freedom to author a
+selector requires concrete witnesses so Spytial can execute and validate it.
+
+## Quick start
+
+Consider an ordinary Python tree:
+
+```python
+from dataclasses import dataclass
+from typing import Optional
+
+import spytial
+from spytial.suggest import suggest
+
+
+@dataclass
+class TreeNode:
+    value: int
+    left: Optional["TreeNode"] = None
+    right: Optional["TreeNode"] = None
+
+
+root = TreeNode(8, TreeNode(3), TreeNode(10))
+draft = suggest(root)
+print(draft.to_source())
+```
+
+The deterministic analyzer proposes a conventional tree layout:
+
+```python
+@spytial.orientation(
+    selector='left - (univ -> NoneType)',
+    directions=['below', 'left'],
+)
+@spytial.orientation(
+    selector='right - (univ -> NoneType)',
+    directions=['below', 'right'],
+)
+@spytial.attribute(field='value')
+@spytial.hideAtom(selector='NoneType')
+@spytial.flag(name='hideDisconnected')
+```
+
+`to_source()` emits one-line decorators with explanatory comments; they are
+expanded above for readability. Paste and edit the generated source, or apply
+the draft to the class immediately:
+
+```python
+draft.apply()
+spytial.diagram(root)
+```
+
+If the proposed geometry is close but wrong, state the correction:
+
+```python
+from spytial.suggest import ClaudeCode
+
+draft = suggest(
+    root,
+    ask="put every child directly below its parent",
+    enrich=ClaudeCode(),
+)
+```
+
+The admitted request selects `left + right` and uses `below`. The overlapping
+below-left and below-right rules move to `draft.alternatives` rather than being
+discarded.
+
+Both import styles are supported. The `suggest` subpackage is lazy and callable:
 
 ```python
 import spytial
 
-draft = spytial.suggest(TreeNode)      # the subpackage is callable
-print(draft.to_source())
+draft = spytial.suggest(root)
 ```
 
 ```python
-from spytial.suggest import suggest    # or import the function
+from spytial.suggest import suggest
 
+draft = suggest(root)
+```
+
+## What each parameter does
+
+The complete interface is:
+
+```python
+suggest(
+    target,
+    *,
+    instance=None,
+    examples=None,
+    strategy=None,
+    enrich=None,
+    ask=None,
+    registry=None,
+)
+```
+
+The inputs are different kinds of evidence. In particular, `examples=` and
+`strategy=` are not two spellings of the same idea.
+
+| Parameter | Meaning | Use it when |
+| --- | --- | --- |
+| `target` | Required. A class to analyze, or an object. An object is shorthand for its class plus one concrete sample. | You always provide this. |
+| `instance` | One explicit sample for a class target. It exposes runtime structure that annotations and `__init__` do not. It is also the default selector-validation witness. | You have a representative object already. |
+| `examples` | Particular, fixed cases. Model-authored selectors must validate on every buildable example. | Awkward or important cases must not be lost during suggestion. |
+| `strategy` | A Hypothesis strategy describing a family of values. Suggestion performs bounded search for one representative witness. The special value `"auto"` uses `hypothesis.strategies.from_type(target)`. | Valid instances require generation, or a single hand-picked instance would be misleading. |
+| `enrich` | The model provider: a model identifier, a callable provider, or a built-in such as `ClaudeCode()` or `Codex()`. There is no ambient model. | Field names or domain conventions carry intent beyond structural types. |
+| `ask` | A natural-language statement of the desired layout. It is translated by `enrich=` and is authoritative over overlapping geometric suggestions. | You can describe the correction more easily than write its selector. |
+| `registry` | An alternate deterministic heuristic registry. | A project has its own field conventions or layout policy. |
+
+### Choose the evidence you have
+
+Static analysis of a type needs no instance, model, or optional dependency:
+
+```python
 draft = suggest(TreeNode)
 ```
 
-```text
-@spytial.orientation(selector='left', directions=['below', 'left'])   # left child of the same type → tree edge below-left
-@spytial.orientation(selector='right', directions=['below', 'right'])  # right child of the same type → tree edge below-right
-@spytial.attribute(field='value')                                      # value is scalar data → fold into the node
+Pass an object—or a type plus `instance=`—when runtime values reveal structure
+that static inspection cannot recover:
+
+```python
+draft = suggest(root)
+draft = suggest(TreeNode, instance=root)  # equivalent evidence
 ```
 
-Paste those above your class and adjust. Every suggestion carries the reasoning
-that produced it, so the scaffold doubles as a tour of the directive language.
+Use `examples=` for fixed cases every authored selector must survive:
 
-## What you get back
+```python
+draft = suggest(
+    TreeNode,
+    examples=[empty_tree, balanced_tree, zig_zag_tree],
+    enrich=model,
+)
+```
 
-`suggest()` returns a `SpecDraft` you can render four ways:
+Use `strategy=` for a family of valid values. One generated witness is added to
+the fixed validation set:
+
+```python
+draft = suggest(
+    RedBlackNode,
+    examples=[empty_tree, deletion_corner_case],
+    strategy=valid_red_black_trees(),
+    enrich=model,
+)
+```
+
+For a class-only request, `strategy="auto"` is implicit:
+
+```python
+draft = suggest(
+    TreeNode,
+    ask="put every child below its parent",
+    enrich=ClaudeCode(),
+)
+```
+
+Hypothesis derives a strategy from `TreeNode`. For a recursive class, Spytial
+first searches for a value that populates every public recursive root field,
+then for any non-leaf value, and finally for any buildable value. Supply a
+custom strategy when the type has invariants Hypothesis cannot infer.
+
+Install witness search separately:
+
+```console
+pip install "spytial_diagramming[suggest-search]"
+```
+
+The ordinary `suggest(TreeNode)` path does not import Hypothesis.
+
+## Working with `SpecDraft`
+
+`suggest()` returns a draft rather than mutating the target class. Its main
+collections expose both the proposal and the reasoning behind it:
+
+| Member | Contents |
+| --- | --- |
+| `draft.suggestions` | Current proposed `Suggestion` objects, including disabled low-confidence rows. |
+| `draft.enabled()` | The suggestions currently enabled by default. |
+| `draft.alternatives` | Conflict losers and superseded geometry, preserved for inspection or recovery. |
+| `draft.notes` | Missing evidence, skipped enrichment, validation results, and other diagnostics. |
+
+Each `Suggestion` records its `directive`, `kwargs`, `confidence`, `rationale`,
+`source_field`, whether it is enabled, and whether it came from a deterministic
+rule or a model.
+
+Render or apply the draft in four ways:
 
 | Call | Result |
-|------|--------|
-| `draft.to_source()` | the paste-able `@spytial.*` decorator stack (a string) |
-| `draft.to_registry()` | the `{"constraints": [...], "directives": [...]}` dict |
-| `draft.apply()` | decorates the class live and returns it |
-| `draft` (in Jupyter) | a rich panel of proposed directives with the reasoning |
+| --- | --- |
+| `draft.to_source()` | A pasteable stack of `@spytial.*` decorators. |
+| `draft.to_registry()` | A `{"constraints": [...], "directives": [...]}` registry dictionary. |
+| `draft.apply()` | Decorates the target class live and returns it. |
+| `draft` in Jupyter | A rich panel showing directives, rationales, alternatives, and notes. |
 
-By default these show only the high-confidence suggestions. Pass
-`enabled_only=False` to include the speculative ones too.
+These methods use enabled suggestions by default. Pass `enabled_only=False` to
+include disabled candidates. `to_source(with_comments=False)` omits generated
+rationales.
 
-## How it decides
+Review the draft before `apply()`: application installs decorators on the class
+and therefore affects subsequent diagrams of its instances.
 
-The analyzer reads two cheap facts per field — its **type** and its **name** —
-and maps them to directives:
+## How deterministic suggestion decides
 
-| Field shape | Suggestion |
-|-------------|-----------|
-| `left` + `right` of the same type | `orientation` below-left / below-right |
-| a single self-referential field | `orientation` below |
-| a list/dict of the same type (`children`) | `orientation` below |
-| `next` (+ `prev`) of the same type | `orientation` right (reverse link hidden) |
-| `parent` / back-pointer | `hideField` if child edges exist, else `orientation` above |
-| a scalar (`value`, `key`, `name`, …) | `attribute` — folded into the node |
-| an `Enum`-typed field | one `atomStyle` per member (off by default) |
-| children that can be `None` | `hideAtom(selector='NoneType')` |
+The analyzer reads field types, names, assignments in `__init__`, and optional
+instance samples. Built-in heuristics map common structures to directives:
 
-Two choices worth knowing:
+| Field shape | Suggested treatment |
+| --- | --- |
+| `left` and `right` of the same node type | Orient below-left and below-right. |
+| One self-referential field | Orient below. |
+| A list or dictionary of same-type children | Derive parent-child pairs and orient below. |
+| `next` and `prev` of the same type | Orient `next` right and hide the reverse link. |
+| `parent` or another back-pointer | Hide it when child edges already expose the structure; otherwise orient above. |
+| A scalar such as `value`, `key`, or `name` | Fold it into the node with `attribute`. |
+| An `Enum`-typed field | Propose one disabled `atomStyle` per member. |
+| Nullable children | Hide `NoneType` atoms. |
 
-- **Edge selectors are `None`-aware.** A nullable edge — a `left` that can be
-  empty — is emitted as `left - (univ -> NoneType)`: the `left` relation with its
-  `None` targets removed, so the orientation never tries to place the `NoneType`
-  atoms that `hideAtom('NoneType')` removes. Subtracting only the `None` targets
-  (rather than intersecting with a named node type,
-  `left & (TreeNode -> TreeNode)`) keeps edges to *subtype* nodes that an
-  exact-type match would wrongly drop. A non-nullable edge uses the simpler bare
-  relation name (`selector='left'`).
-- **`parent` is context-aware.** When a class also has child fields, `parent`
-  just duplicates those edges, so it is hidden by default — with the "place
-  above" orientation kept as a toggled-off alternative on
-  `draft.alternatives`. When `parent` is the only link, "above" wins.
+Nullable edge selectors remove only `None` targets—for example,
+`left - (univ -> NoneType)`. This retains edges to subtype instances that an
+exact type intersection would incorrectly discard.
 
-## Reading plain classes
+When child edges already describe the structure, a `parent` field duplicates
+them and is hidden by default. Its “place above” orientation remains in
+`draft.alternatives`. When `parent` is the only structural link, the orientation
+wins instead.
 
-Dataclasses and classes with annotations are read statically. For a plain class
-whose fields can't be typed from the source alone (children default to `None`,
-say), pass an example object so the analyzer can sample the real shape:
+## Model providers
 
-```python
-root = TreeNode(1, TreeNode(2), TreeNode(3))
-draft = suggest(TreeNode, instance=root)   # or just suggest(root)
-```
+`enrich=` always names a provider explicitly. There is no ambient model and no
+model call on the default path.
 
-Sampling walks the whole object graph, so a `parent` back-link on a child is
-enough to recognize `parent` as structural across the class.
+### Claude Code
 
-## Extending with your own heuristics
-
-The built-in rules are just functions registered with `@heuristic`. Add your
-own the same way — domain field names, project conventions, a house color
-palette:
+`ClaudeCode` uses an installed and authenticated `claude` CLI, so it needs no
+Spytial model extra or API key:
 
 ```python
-from spytial.suggest import heuristic, Suggestion
+from spytial.suggest import ClaudeCode, suggest
 
-@heuristic(scope='field', priority=100)   # >= 100 beats the built-ins
-def color_by_status(field, cls_info):
-    if field.name == 'status' and field.enum_members:
-        return [Suggestion(
-            directive='atomStyle',
-            kwargs={'selector': f'{{ x : {cls_info.cls.__name__} | @:(x.status) = active }}',
-                    'borderStyle': {'color': 'seagreen'}},
-            confidence='high',
-            rationale='active status → green',
-            source_field='status',
-        )]
-    return []
+draft = suggest(Ticket, enrich=ClaudeCode())
+draft = suggest(Ticket, enrich=ClaudeCode(model="opus"))
 ```
 
-- `scope='field'` heuristics run per field with signature `(FieldInfo, ClassInfo)`;
-  `scope='class'` heuristics run once with `(ClassInfo)` and are how multi-field
-  patterns (binary tree, linked list) are detected.
-- Higher `priority` wins a same-field conflict; the loser becomes an alternative.
-- Pass `suggest(cls, registry=my_registry)` to run an isolated rule set, or use
-  `DEFAULT_REGISTRY.copy()` to start from the built-ins and add to them.
+If `ANTHROPIC_API_KEY` is set, the CLI may use metered API billing instead of a
+Claude subscription. Consult the CLI's current authentication behavior before
+choosing a provider.
 
-## Optional: LLM enrichment
+### Codex
 
-The deterministic rules key off a fixed name vocabulary — `left`/`right`,
-`next`/`prev`, `parent`/`children` — and fall back to a flat `below` for any
-self-reference they don't recognize. The optional enrichment layer asks a model to
-suggest the *spatial shape* of those fields instead.
-
-You pass **`enrich=`** to say *what* to enrich with — there is no ambient default.
-It's either a model-id **string** (routed through the [`llm`](https://llm.datasette.io/)
-library) or a **provider**: any callable `(prompt, *, schema) -> dict`. Pick the
-backend that matches how you pay for models:
-
-### Use your Claude Max / Pro subscription (no API key)
-
-Requires only the `claude` CLI (Claude Code) installed and signed in to your plan —
-the same login you already use. `ClaudeCode` shells out to it, so you need **no
-`[suggest-llm]` extra and no API key**:
-
-```python
-from spytial.suggest import suggest, ClaudeCode
-
-draft = suggest(Ticket, enrich=ClaudeCode())               # model="sonnet" by default
-draft = suggest(Ticket, enrich=ClaudeCode(model="opus"))   # opus for best quality
-```
-
-> **Stay on your subscription:** if `ANTHROPIC_API_KEY` is set in your environment,
-> the `claude` CLI uses *that* (metered API billing) instead of your Max plan. Unset
-> it to bill against the subscription. `model=` accepts anything `claude --model`
-> takes (`sonnet`, `opus`, `haiku`, or a full model id).
-
-### Use your ChatGPT plan (Codex)
-
-Same idea with the `codex` CLI (included in ChatGPT Plus/Pro), which has *native*
+`Codex` uses an installed and authenticated `codex` CLI and its native
 JSON-schema output:
 
 ```python
-from spytial.suggest import suggest, Codex
+from spytial.suggest import Codex, suggest
 
-draft = suggest(Ticket, enrich=Codex())          # needs the `codex` CLI, signed in
+draft = suggest(Ticket, enrich=Codex())
 ```
 
-### Use an API key, or a fully-local model (via `llm`)
+### A model identifier through `llm`
 
-A **string** is a model id resolved through `llm` (Simon Willison's), which owns key
-management — spytial never sees a key. This covers metered APIs *and* local models:
+A string is resolved by Simon Willison's `llm` library. This supports hosted
+providers and local models through their respective plugins:
 
-```bash
+```console
 pip install "spytial_diagramming[suggest-llm]"
-llm install llm-anthropic        # or llm-openai, llm-gemini, llm-ollama, …
-llm keys set anthropic           # only for hosted APIs; Ollama needs no key
+llm install llm-anthropic
+llm keys set anthropic
 ```
 
 ```python
-draft = suggest(Ticket, enrich="claude-sonnet-4-6")   # a metered API model
-draft = suggest(Ticket, enrich="llama3.2")            # local via Ollama — nothing leaves your machine
+draft = suggest(Ticket, enrich="claude-sonnet-4-6")
+draft = suggest(Ticket, enrich="llama3.2")  # for example, through Ollama
 ```
 
-### Bring your own
+### A custom provider
 
-A provider is just a callable, so a few lines wire up any backend. `instruct_json` /
-`extract_json` handle the JSON round-trip for a text-only model:
+A provider is any callable with the signature `(prompt, *, schema) -> dict`.
+Helpers are available for text-only models:
 
 ```python
-from spytial.suggest.providers import instruct_json, extract_json
+from spytial.suggest.providers import extract_json, instruct_json
+
 
 def my_provider(prompt, *, schema):
     text = call_some_model(instruct_json(prompt, schema))
     return extract_json(text)
 
+
 draft = suggest(Ticket, enrich=my_provider)
 ```
 
-*What leaves your machine:* only schema-level **names** — class/field/type/relation
-names and counts, never your field *values* (those are used locally to validate
-selectors). With a local model (`enrich="llama3.2"`) nothing leaves at all. The
-`ClaudeCode`/`Codex` subscription providers are for individual, local use — for a
-hosted or multi-user service use an API-key model instead.
+The shape tier sends class, field, and type names. When instances are present,
+the selector-authoring tier additionally sends relational names, arities, and
+atom counts. Field values stay local and are used only for selector evaluation.
+With a local provider, nothing leaves the machine.
 
-It suggests **shape**: an `orientation` direction per structural field, `cyclic`
-for ring-like links, and `group` for collections. So a field named `escalation`
-— which the rules can only lay out `below` — gets a model-proposed `above`,
-because the model reads the name. The key line: **the model picks the shape, not
-the selector.** It chooses a direction from a fixed vocabulary; spytial builds the
-selector from the field, reusing the same render-verified forms the deterministic
-rules emit. That's what keeps it schema-level and safe:
+## Engineering considerations
 
-- **Type-level first.** It reasons over the class's fields, so `enrich=` needs no
-  instance.
-- **You pick.** Enriched rows are tagged `source="llm"` (a `model` chip in the
-  notebook panel) and stay **off by default** — candidates beside the
-  deterministic ones, never applied behind your back.
-- **It can't break `suggest()`.** An unresolvable `enrich=` spec (no `llm`
-  installed, an unknown model id, a non-provider value) or a malformed response
-  each degrade to the static draft with a note in `draft.notes` — never an
-  exception. Choices that name an unknown field or an out-of-vocabulary direction
-  are dropped.
+### Give inference only as much freedom as can be checked
 
-When you pass example instances (`suggest(obj, enrich=...)` or
-`suggest(Cls, examples=[a, b, ...], enrich=...)`), a second tier lets the model
-**author selector expressions** for relational cases the shape tier can't reach —
-each admitted only if it evaluates cleanly, at the right arity, on *every* example.
-A selector can only be validated by running it over data (the engine has no
-schema-only mode), which is why that tier needs the examples and the shape tier
-above does not. It runs headlessly on a vendored spytial-core evaluator, so it
-needs only a `node` runtime.
+Suggestion has three layers:
 
-## Ask for a directive in your own words
+1. The deterministic layer recognizes common program structures and emits
+   selector forms maintained by Spytial.
+2. The model shape layer chooses `orientation`, `cyclic`, `group`, or no shape,
+   with arguments from a closed vocabulary. Spytial writes the selector.
+3. With concrete witnesses, the model may author selectors or translate
+   `ask=`. Those candidates must execute before they enter the draft.
 
-The enrichment tiers propose on their own initiative. `ask=` is the other
-direction: **you** state what you want, in prose, and the model's only job is to
-translate it —
+The governing principle is:
+
+> More generative freedom requires a stronger checker.
+
+Valid shape enrichment becomes the active geometry for the fields it addresses;
+the deterministic geometry it replaces becomes an alternative. If enrichment
+fails, the deterministic draft remains usable and `draft.notes` explains what
+was skipped.
+
+Model-authored selector candidates from unsolicited enrichment remain disabled
+until reviewed. An explicit `ask=`, by contrast, is enabled when admitted
+because the user requested it.
+
+### Check denotation, not just syntax
+
+A model-authored selector must:
+
+1. use a supported directive and in-vocabulary arguments;
+2. parse, return a non-empty result, and have the directive's exact arity on
+   every buildable validation example; and
+3. pass the same authoring checks as handwritten decorators.
+
+An orientation selector must denote pairs; `hideAtom` must denote atoms. This
+arity check matters because an invented bareword can parse as an arity-zero
+literal rather than fail syntactically.
+
+An explicit request gets one repair attempt using concrete validation
+diagnostics. If no part of the request can be admitted, `suggest` raises
+`spytial.suggest.AskError`. A compound request may admit the validated parts and
+record any remainder in `draft.notes`.
+
+### Preserve alternatives and make failure asymmetric
+
+When an explicit ask supersedes overlapping geometry, the previous suggestions
+move to `draft.alternatives`; they are not destroyed. Overlap is checked by
+evaluating the intersection of selectors over the available witnesses rather
+than comparing selector strings.
+
+Optional enrichment may fail and leave the deterministic draft unchanged. An
+explicit `ask=` must either install at least one validated directive or raise an
+error. The distinction prevents a requested correction from disappearing
+silently.
+
+### A witness is not a proof
+
+`examples=` checks the particular cases supplied. `strategy=` contributes one
+representative generated witness. Neither proves that a selector works for
+every value.
+
+This distinction is important for empty structures. A child selector returning
+no pairs on a leaf does not refute “put every child below its parent”; the rule
+is merely vacuous on that object. Auto-generation therefore prefers a populated
+recursive witness that exercises the selector.
+
+Evaluation can establish that a selector denotes real atoms or edges in the
+witnesses. It cannot establish that `below` expresses the user's intent. Human
+judgment remains the final specification.
+
+### Keep the default path cheap and local
+
+Static suggestion requires no model, network, Hypothesis, or headless
+evaluator. Provider resolution, witness search, and selector evaluation load
+only when their corresponding arguments request them.
+
+Selector authoring and `ask=` require a `node` runtime on `PATH` (or a binary
+named by `SPYTIAL_NODE`) so Spytial can run the vendored headless evaluator.
+
+## Extending deterministic suggestion
+
+The built-in rules are functions registered with `@heuristic`. Add project
+conventions or domain-specific field names using the same interface:
 
 ```python
-import spytial
-from spytial.suggest import ClaudeCode
+from spytial.suggest import Suggestion, heuristic
 
-draft = spytial.suggest(
-    TreeNode,
-    ask="all binary tree children should be below their parents",
-    enrich=ClaudeCode(),          # ask uses the same provider slot
-)
-draft.to_source()
-# @spytial.orientation(selector='left + right', directions=['below'])  # ask: children hang below their parent
+
+@heuristic(scope="field", priority=100)
+def color_by_status(field, cls_info):
+    if field.name == "status" and field.enum_members:
+        return [
+            Suggestion(
+                directive="atomStyle",
+                kwargs={
+                    "selector": (
+                        f"{{ x : {cls_info.cls.__name__} | "
+                        f"@:(x.status) = active }}"
+                    ),
+                    "borderStyle": {"color": "seagreen"},
+                },
+                confidence="high",
+                rationale="active status → green",
+                source_field="status",
+            )
+        ]
+    return []
 ```
 
-Where did the instance come from? For a class-only ask, `suggest` lazily asks
-Hypothesis for one:
+Field-scope heuristics receive `(FieldInfo, ClassInfo)`; class-scope heuristics
+receive `ClassInfo` and can recognize multi-field patterns. Higher priority wins
+a same-field conflict, while the losing suggestion becomes an alternative.
 
-```python
-from spytial.suggest import suggest
-
-# implicit strategy="auto"
-draft = suggest(TreeNode, ask="put every child below its parent", enrich=ClaudeCode())
-
-# the explicit spelling
-draft = suggest(
-    TreeNode,
-    ask="put every child below its parent",
-    strategy="auto",                         # st.from_type(TreeNode)
-    enrich=ClaudeCode(),
-)
-
-# preserve domain invariants with your own family of valid values
-draft = suggest(
-    RedBlackNode,
-    ask="put every child below its parent",
-    strategy=valid_red_black_trees(),
-    enrich=ClaudeCode(),
-)
-```
-
-Install this path with `pip install "spytial_diagramming[suggest-search]"`.
-Generation is bounded and deliberately modest: it finds a concrete witness so
-the model can see a real relational vocabulary and its selector can be executed.
-For recursive types it first tries to populate every recursive root field, then
-falls back to any non-leaf witness. This is not a proof over every value the
-strategy can generate.
-
-`examples=` has a different job. Those are particular, mandatory regression
-cases, and an authored selector must validate on every one. You can combine the
-two: `examples=[awkward_tree]` pins a case you care about, while
-`strategy=valid_trees()` contributes a generated witness. Passing an instance as
-the target is shorthand for a single fixed example.
-
-A translation reaches the draft only after the full gauntlet:
-
-1. **Kind + vocabulary** — the directive is one ask can author (`orientation`,
-   `cyclic`, `align`, `inferredEdge`, `hideAtom`, `atomStyle`), and its enum
-   kwargs are in the canonical sets.
-2. **Evaluation** — the selector parses, is non-empty, and has the directive's
-   exact arity on **every** example instance, via the headless evaluator. A
-   failing round is fed back to the model once, with the per-candidate
-   diagnostics, for a repair attempt.
-3. **The authoring gate** — the kwargs run the same validation the `@spytial.*`
-   decorators run, so an admitted row can't fail later in `apply()`.
-
-Because you asked, the ask is **the key thing in the draft** — authoritative on
-the ground it covers. Admitted rows come in **enabled by default** (a
-translation that lands on a row the rules already proposed just switches that
-row on), and an admitted `orientation`/`cyclic`/`align` row **demotes every
-enabled geometric row that overlaps it** — rule-proposed and model-proposed
-alike — to `draft.alternatives`, kept and one toggle away. Overlap isn't guessed
-from selector syntax: `(ask_sel) & (rival_sel)` is itself a selector, and a
-non-empty intersection on any example means both constraints claim the same
-edges. So asking for *"children below parents"* on a binary tree replaces the
-rules' `below-left`/`below-right` pair with your plain `below`, instead of
-stacking a third constraint on the same edges. Styling and hiding rows don't
-fight the layout solver, so they are left alone.
-
-One ask is not necessarily one directive. A compound sentence — *"children
-below their parents, and color the leaves green"* — translates to several
-candidates (up to three), each admitted independently. What validates lands;
-a failed part is what the repair round retries; and anything still unvalidated
-after that is recorded in `draft.notes`, so no half of a request vanishes
-without a trace.
-
-Every failure, by contrast, is **loud**.
-No provider, no example instance to validate against, no `node` runtime, or a
-sentence of which *nothing* survives translation (`"make it pretty"`) raises
-`spytial.suggest.AskError` carrying the model's own reason or the per-candidate
-diagnostics — never a silently ignored request.
+Pass `suggest(cls, registry=my_registry)` for an isolated rule set. Use
+`DEFAULT_REGISTRY.copy()` to extend the built-ins without changing the global
+registry.
 
 ## Limits
 
-`suggest` infers structure from fields and references. It cannot recover
-structure that lives in *computation* — an array-backed heap whose tree is
-implied by index arithmetic, for example — and it will say so in `draft.notes`
-rather than invent edges. The deterministic core aims to get the structure right
-and the rest close enough to edit; the [enrichment tier](#optional-llm-enrichment)
-above helps with the spatial shape of unfamiliar fields.
+Program structure is evidence for a spatial specification, not the
+specification itself. `suggest` cannot recover a tree represented only by index
+arithmetic in an array-backed heap. A model can choose the wrong interpretation
+of a real field. A selector can pass every supplied example and fail on the next
+one.
+
+These limits are why the result is a `SpecDraft`: rationales and provenance are
+visible, alternatives survive, authored selectors run before admission,
+explicit asks fail loudly, and the user decides what becomes the final
+specification.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,7 +17,7 @@ nav:
   - Selectors: selectors.md
   - Structured Input: usage/structured-input.md
   - Custom Relationalizers: relationalizers.md
-  - Suggesting Specs: suggest.md
+  - Suggest a Specification: suggest.md
   - CLRS Notebook Examples: examples/spytial-clrs.md
   - API Reference: reference/api.md
 
@@ -61,7 +61,11 @@ markdown_extensions:
   - md_in_html
   - tables
   - pymdownx.details
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.tabbed
   - pymdownx.highlight
   - pymdownx.inlinehilite

--- a/spytial/_version.py
+++ b/spytial/_version.py
@@ -1,3 +1,3 @@
 """Package version source of truth."""
 
-__version__ = "1.9.0"
+__version__ = "1.9.1"


### PR DESCRIPTION
## Summary

Guides the current branch's documentation changes for `spytial.suggest` to completion.

The `suggest()` guide is restructured around a single organizing idea: **inference gets only as much generative freedom as Spytial can check.** Inputs (`target` / `instance` / `examples` / `strategy`) establish what evidence is available; each proposal layer (deterministic rules → model-chosen shape → model-authored selectors / `ask=`) earns freedom only where its output can be validated.

## Changes

- **`docs/suggest.md`** — full rewrite. Adds a mermaid flowchart of the evidence→proposal pipeline, a per-parameter reference table (making explicit that `examples=` and `strategy=` are different kinds of evidence, not two spellings of one), a "Working with `SpecDraft`" section, provider docs (Claude Code / Codex / `llm` string / custom callable), and an "Engineering considerations" section covering the checkability principle, arity/denotation checks, alternative preservation, and the cheap-default guarantee.
- **`mkdocs.yml`** — enables mermaid rendering via a `pymdownx.superfences` custom fence (Material lazy-loads `mermaid@11`); renames the nav entry to **Suggest a Specification**.
- **`docs/reference/api.md`** — adds a **Suggestion** section rendering `spytial.suggest` via mkdocstrings.
- **`spytial/_version.py`** — bumps `1.9.0 → 1.9.1`.

## Verification

- `mkdocs build --strict` passes with no warnings (mkdocstrings resolves `spytial.suggest`; superfences config parses; no broken links).
- The documented quickstart `to_source()` output was checked against live `suggest(root)` output — it matches exactly.
- The mermaid block renders as a `.mermaid` element in the built HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)