### PR TITLE
Docs: Simple Technical English rewrite, slimmer nav, reworked suggest page

### DIFF
--- a/docs/examples/spytial-clrs.md
+++ b/docs/examples/spytial-clrs.md
@@ -1,6 +1,11 @@
 # CLRS Notebook Examples
 
-[`spytial-clrs`](https://github.com/sidprasad/spytial-clrs) is a Jupyter notebook collection that implements the data structures from the **CLRS algorithms textbook** (Cormen, Leiserson, Rivest, Stein) using Spytial. Each notebook is organized by CLRS chapter and walks through one or more textbook structures, declaring the spatial constraints that make their structure legible.
+[`spytial-clrs`](https://github.com/sidprasad/spytial-clrs) is a Jupyter
+notebook collection. It implements the data structures from the **CLRS
+algorithms textbook** (Cormen, Leiserson, Rivest, Stein) with Spytial.
+Each notebook is organized by one CLRS chapter and covers one or more
+textbook structures. The notebook declares the spatial constraints that
+make each structure legible.
 
 ## What's in it
 
@@ -16,13 +21,14 @@
 | 21.3 | Disjoint-set forests (forest and set views) | `disjoint-sets.ipynb` |
 | 22, 22.4, 22.5, 23 | Graphs, topological sort, strongly connected components, MST | `graphs.ipynb` |
 
-Bonus: BDDs in `simple-bdd.ipynb`.
+The collection also contains BDDs in `simple-bdd.ipynb`.
 
 ## Run the notebooks
 
-There are three ways to use the collection without installing anything locally beyond the notebooks themselves.
+The collection can be used in three ways. No local installation is
+necessary beyond the notebooks themselves.
 
-**Docker** (zero local setup):
+**Docker** (no local setup):
 
 ```bash
 docker pull sidprasad/spytial-clrs:latest
@@ -30,7 +36,9 @@ docker run -p 8888:8888 sidprasad/spytial-clrs
 # open http://localhost:8888
 ```
 
-**JupyterLite** (in-browser, no install): see the [`spytial-clrs` README](https://github.com/sidprasad/spytial-clrs) for the deployed link.
+**JupyterLite** (in-browser, no installation): refer to the
+[`spytial-clrs` README](https://github.com/sidprasad/spytial-clrs) for the
+deployed link.
 
 **Local clone**:
 
@@ -43,7 +51,7 @@ jupyter notebook src/
 
 ## Reading guide
 
-Use the notebooks as a guide depending on what you want to visualize:
+Use the notebooks as a guide, based on the structure to visualize:
 
 | Notebook | Structures | Good docs topics |
 | --- | --- | --- |
@@ -58,6 +66,9 @@ Use the notebooks as a guide depending on what you want to visualize:
 
 ## How to use these examples
 
-- Start with `stacksqueues.ipynb` or `linked-lists.ipynb` if you are new to Spytial.
-- Browse `trees.ipynb` and `graphs.ipynb` for richer layouts and more advanced operation combinations.
-- Use the notebook closest to your own data shape as a template for your first diagram.
+- Start with `stacksqueues.ipynb` or `linked-lists.ipynb` for an
+  introduction to Spytial.
+- Browse `trees.ipynb` and `graphs.ipynb` for more complex layouts and
+  more advanced operation combinations.
+- Use the notebook closest to the target data shape as a template for a
+  first diagram.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,17 +12,17 @@
 pip install spytial-diagramming
 ```
 
-!!! tip "Don't want to install yet?"
-    The [**Playground**](playground/index.html) runs this exact example in your
-    browser. Come back here when you want to run it locally.
+!!! tip "Try it without installing"
+    The [**Playground**](playground/index.html) runs this exact example in the
+    browser. Return here to run it locally.
 
-## Your first diagram — a binary tree
+## A first diagram: a binary tree
 
-Copy this whole block into a `.py` file or a notebook cell and run it. It defines a
-binary tree, says how it should be laid out, and draws an instance. We walk through
-what each decorator does just below.
+Copy this block into a `.py` file or a notebook cell and run it. The block
+defines a binary tree, states how the tree is laid out, and draws one instance.
+Each decorator is described below.
 
-<!-- canonical example — keep in sync with docs/index.md and the playground -->
+<!-- canonical example: keep in sync with docs/index.md and the playground -->
 ```python
 from spytial import orientation, attribute, hideAtom, flag, diagram
 
@@ -46,43 +46,44 @@ root = TreeNode(
 diagram(root)
 ```
 
-Running a script opens the diagram in a new browser tab; running it in a notebook
-renders it inline. You'll see `10` at the root, `5` below-left and `15`
-below-right, and their children beneath them.
+A script opens the diagram in a new browser tab. A notebook renders it inline.
+The output shows `10` at the root, `5` below-left, `15` below-right, and their
+children below them.
 
 ### What each decorator does
 
-The decorators *are* the Spytial layout — each is one rule. Reading top to bottom:
+The decorators *are* the Spytial layout. Each decorator is one rule. The table
+reads from top to bottom:
 
 | Decorator | What it does |
 | --- | --- |
-| `@orientation(selector='{ x : TreeNode, y : TreeNode \| x.left = y }', directions=['below','left'])` | Place each node's left child **below and to the left**. The selector matches the pairs `(x, y)` where `y` is `x`'s left child — i.e. the left-child edges. |
+| `@orientation(selector='{ x : TreeNode, y : TreeNode \| x.left = y }', directions=['below','left'])` | Place each node's left child **below and to the left**. The selector matches the pairs `(x, y)` where `y` is the left child of `x`. These are the left-child edges. |
 | `@orientation(selector='{ x : TreeNode, y : TreeNode \| x.right = y }', directions=['below','right'])` | The mirror image, for the right child. |
 | `@attribute(field='value')` | Render `node.value` as text **inside** the node, instead of as a separate box with an arrow. |
 | `@hideAtom(selector='NoneType')` | Hide the empty `None` leaves. |
-| `@flag(name="hideDisconnected")` | Drop any atom left with no edges, keeping the picture tidy. |
+| `@flag(name="hideDisconnected")` | Drop any atom that has no edges, to keep the picture tidy. |
 
 The `selector` strings are Spytial's **relational query language**. The
-`{ x : T, y : T | … }` form matches *pairs* of atoms (here, parent-and-child edges);
-see [Selectors](selectors.md) for a Python-oriented guide to the syntax.
+`{ x : T, y : T | … }` form matches *pairs* of atoms, here the parent-and-child
+edges. See [Selectors](selectors.md) for a Python-oriented guide to the syntax.
 
 !!! note "Build it up incrementally"
-    A good workflow is to call `diagram(obj)` first with **no** decorators to see
-    the raw structure, then add one rule at a time. The
-    [Playground](playground/index.html) is the fastest place to do this — edit,
-    run, repeat.
+    A good workflow is to call `diagram(obj)` first with **no** decorators, to
+    see the raw structure. Then add one rule at a time. The
+    [Playground](playground/index.html) is the fastest place to do this: edit,
+    run, and repeat.
 
 ## Where the diagram shows up
 
 `Spytial` works in three places without any configuration:
 
-| Where you run it | Default output |
+| Where it runs | Default output |
 | --- | --- |
-| Jupyter / IPython notebook | Inline HTML |
-| Script / REPL | Opens a new browser tab |
+| Jupyter or IPython notebook | Inline HTML |
+| Script or REPL | Opens a new browser tab |
 | Anywhere, on demand | Writes an HTML file |
 
-You can always force one explicitly:
+One output method can be forced explicitly:
 
 ```python
 import spytial
@@ -92,16 +93,16 @@ spytial.diagram(t, method="file")      # save spytial_visualization.html
 spytial.diagram(t, method="inline")    # force inline (notebook) output
 ```
 
-The actual rendering is done in the browser by
-[`spytial-core`](https://github.com/sidprasad/spytial-core), loaded from a CDN the
-first time you render. There is nothing extra to install; the bundle is cached
-after first load.
+The browser does the actual rendering, through
+[`spytial-core`](https://github.com/sidprasad/spytial-core). This bundle loads
+from a CDN on the first render. Nothing extra is installed, and the bundle is
+cached after the first load.
 
-## Inspect before you diagram
+## Inspect before diagramming
 
-If you want to confirm exactly how an object is being serialized into atoms and
-relations — useful when debugging a custom class or annotation — use the
-[evaluator](usage/evaluator.md):
+To confirm exactly how an object is serialized into atoms and relations, use the
+[evaluator](usage/evaluator.md). This is useful when debugging a custom class or
+annotation:
 
 ```python
 import spytial
@@ -112,12 +113,15 @@ spytial.evaluate(t)
 
 ## Next steps
 
-- Try the [Playground](playground/index.html) — edit and run Spytial in your browser.
+- Try the [Playground](playground/index.html) to edit and run Spytial in the
+  browser.
 - Read [Diagramming](usage/diagramming.md) for the main rendering workflow.
-- Read [Operations](operations.md) for every layout constraint and drawing directive.
-- Read the [Evaluator](usage/evaluator.md) guide for inspecting serialized data.
-- Browse [CLRS Notebook Examples](examples/spytial-clrs.md) for worked examples on
-  classic data structures (heaps, trees, graphs, hash tables, disjoint-set forests).
+- Read [Operations](operations.md) for every layout constraint and drawing
+  directive.
+- Read the [Evaluator](usage/evaluator.md) guide to inspect serialized data.
+- Browse [CLRS Notebook Examples](examples/spytial-clrs.md) for worked examples
+  on classic data structures (heaps, trees, graphs, hash tables, and
+  disjoint-set forests).
 
 - **PyPI:** [pypi.org/project/spytial-diagramming](https://pypi.org/project/spytial-diagramming/)
 - **Source:** [github.com/sidprasad/spytial](https://github.com/sidprasad/spytial)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,18 +1,19 @@
 # Spytial
 
 
-Sometimes you just want to see your program values. 
-You don't need an interactive dashboard or a production-grade visualization system. You just need a diagram that lays it out clearly so you can understand what's going on.
+Often, all that is needed is a clear picture of a program's values. An
+interactive dashboard or a production-grade visualization system is not
+required. A diagram that lays the values out clearly is enough to show what is
+happening.
 
-That's what Spytial is for. It is diagramming system 
-built to make it as easy to get a diagram as it is to call
-`print`. 
+Spytial is built for this. It is a diagramming system that makes a diagram as
+easy to get as a call to `print`.
 
-You always get a diagram **for free** for any value, and then
-use Spytial's constraint vocabulary to refine it til it resembles what you might expect.
+Every value gets a diagram by default. Spytial's constraint vocabulary then
+refines that diagram until it matches the expected result.
 
 [Get started](getting-started.md){ .md-button .md-button--primary }
-[Try it in your browser](playground/index.html){ .md-button }
+[Try it in the browser](playground/index.html){ .md-button }
 
 <div class="sp-hero" markdown="1">
 
@@ -45,30 +46,34 @@ diagram(root)
 
 <div class="sp-viz">
   <iframe src="assets/hero-tree.html" title="A binary tree rendered by Spytial" loading="lazy"></iframe>
-  <div class="sp-cap">↑ The real, live output of the code above — drag to explore, scroll to zoom</div>
+  <div class="sp-cap">↑ The live output of the code above. Drag to explore, and scroll to zoom.</div>
 </div>
 
 </div>
 
-## Get started 
+## Get started
 
-1. **Install** — `pip install spytial-diagramming` (Python 3.8–3.12, nothing else to set up).
-2. **Decorate** — add layout rules to your class with decorators like `@orientation` and `@attribute`.
-3. **Draw** — call `spytial.diagram(obj)`. It opens in your browser, or renders inline in a notebook.
+1. **Install**: `pip install spytial-diagramming` (Python 3.8 to 3.12, with
+   nothing else to set up).
+2. **Decorate**: add layout rules to a class with decorators such as
+   `@orientation` and `@attribute`.
+3. **Draw**: call `spytial.diagram(obj)`. It opens in the browser, or renders
+   inline in a notebook.
 
-That's the whole loop. [Walk through the example above, line by line →](getting-started.md)
+That is the whole loop. [Walk through the example above, line by line.](getting-started.md)
 
 ## Operations at a glance
 
 Layout is controlled by two kinds of operation. Attach them as class decorators
-(`@spytial.orientation(...)`), to individual objects, or via `typing.Annotated`.
-Full details and arguments are in [Operations](operations.md).
+(`@spytial.orientation(...)`), attach them to individual objects, or apply them
+through `typing.Annotated`. Full details and arguments are in
+[Operations](operations.md).
 
 <div class="sp-ops" markdown="1">
 
 <div markdown="1">
 
-**Constraints** — shape the geometry
+**Constraints**: shape the geometry
 
 | Operation | What it does |
 | --- | --- |
@@ -81,16 +86,16 @@ Full details and arguments are in [Operations](operations.md).
 
 <div markdown="1">
 
-**Directives** — change how things are drawn
+**Directives**: change how things are drawn
 
 | Operation | What it does |
 | --- | --- |
 | `attribute` | Show a field as a label inside the node |
-| `atomStyle` · `edgeStyle` | Style nodes / edges (border, fill, line, labels) |
-| `hideAtom` · `hideField` | Hide nodes / fields |
+| `atomStyle` · `edgeStyle` | Style nodes and edges (border, fill, line, labels) |
+| `hideAtom` · `hideField` | Hide nodes and fields |
 | `tag` | Add a computed label to matching nodes |
 | `inferredEdge` | Draw a derived edge between nodes |
-| `size` · `icon` | Resize / icon-ify nodes |
+| `size` · `icon` | Resize nodes, or add an icon |
 
 </div>
 
@@ -98,7 +103,8 @@ Full details and arguments are in [Operations](operations.md).
 
 ## More
 
-- [Playground](playground/index.html) — edit and run Spytial in your browser.
-- [Getting Started](getting-started.md) — install and a walkthrough.
-- [Operations](operations.md) — every constraint and directive.
-- [`spytial-clrs`](https://github.com/sidprasad/spytial-clrs) — more examples: CLRS data structures rendered with Spytial.
+- [Playground](playground/index.html): edit and run Spytial in the browser.
+- [Getting Started](getting-started.md): install and a walkthrough.
+- [Operations](operations.md): every constraint and directive.
+- [`spytial-clrs`](https://github.com/sidprasad/spytial-clrs): more examples,
+  the CLRS data structures rendered with Spytial.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,26 +1,28 @@
 # Operations
 
-Operations are the rules that shape a diagram. Each is one **constraint** or
-**directive** you attach to a class (or an object). They are declarative and
-order-independent — every rule narrows the set of acceptable layouts, turning the
-raw value graph into the picture you want.
+Operations are the rules that shape a diagram. Each operation is one
+**constraint** or **directive** that attaches to a class, or to an object. The
+operations are declarative and order-independent. Each rule narrows the set of
+acceptable layouts, which turns the raw value graph into the required picture.
 
-- **Constraints** shape the geometry — *where* things go.
-- **Directives** change the drawing — *how* things look.
+- A **constraint** shapes the geometry. It sets *where* things go.
+- A **directive** changes the drawing. It sets *how* things look.
 
-Almost every operation is built from a **`selector`** — which atoms or edges it
-applies to (see [Selectors](selectors.md)) — plus a few operation-specific
-arguments. The sections below break each one into its parts.
+Almost every operation is built from a **`selector`**, which selects the atoms
+or edges that the operation applies to (see [Selectors](selectors.md)). Each
+operation also takes a few specific arguments. The sections below describe each
+operation part by part.
 
 ## Constraints
 
-### `orientation` — place a target in a direction
+### `orientation`: place a target in a direction
 
-1. **`selector`** — the edges to orient.
-2. **`directions`** — where the target sits relative to its source, as a list
-   (e.g. `['below', 'left']`). One of `above`, `below`, `left`, `right`, or the
-   adjacency variants `directlyAbove`, `directlyBelow`, `directlyLeft`,
-   `directlyRight`, which also require that nothing sits in between.
+1. **`selector`**: the edges to orient.
+2. **`directions`**: where the target sits relative to its source, given as a
+   list (for example `['below', 'left']`). Each direction is one of `above`,
+   `below`, `left`, `right`, or an adjacency variant: `directlyAbove`,
+   `directlyBelow`, `directlyLeft`, or `directlyRight`. An adjacency variant
+   also requires that nothing sits between the two atoms.
 
 ```python
 @spytial.orientation(
@@ -29,33 +31,34 @@ arguments. The sections below break each one into its parts.
 )
 ```
 
-### `align` — line atoms up on a shared axis
+### `align`: line atoms up on a shared axis
 
-1. **`selector`** — the atoms to align.
-2. **`direction`** — the axis to share: `'horizontal'` or `'vertical'`.
+1. **`selector`**: the atoms to align.
+2. **`direction`**: the axis to share, `'horizontal'` or `'vertical'`.
 
-### `cyclic` — arrange atoms in a ring
+### `cyclic`: arrange atoms in a ring
 
-1. **`selector`** — the atoms/edges forming the cycle.
-2. **`direction`** — which way the ring runs: `'clockwise'` or
+1. **`selector`**: the atoms or edges that form the cycle.
+2. **`direction`**: the direction of the ring, `'clockwise'` or
    `'counterclockwise'`.
 
-> These value sets are closed, and spytial checks them where you write them. The
-> easy mistake is borrowing another constraint's words — `align` takes the *axis*
-> (`horizontal`/`vertical`) while `orientation` takes *placements*
-> (`above`/`left`/…), and swapping them is not an error spytial-core reports: an
-> unknown orientation direction just quietly drops the constraint, and a
-> misspelled `cyclic` direction reads as `clockwise`. Same for `flag`, which acts
-> on exactly `hideDisconnected` and `hideDisconnectedBuiltIns`.
+> These value sets are closed, and Spytial checks them at the point where they
+> are written. A common mistake is to borrow another constraint's words. `align`
+> takes the *axis* (`horizontal` or `vertical`), and `orientation` takes a
+> *placement* (`above`, `left`, and so on). spytial-core does not report a swap
+> of the two as an error. An unknown orientation direction drops the constraint
+> without notice, and a misspelled `cyclic` direction is read as `clockwise`.
+> The same applies to `flag`, which acts on exactly `hideDisconnected` and
+> `hideDisconnectedBuiltIns`.
 
-### `group` — enclose atoms in a labelled region
+### `group`: enclose atoms in a labelled region
 
-1. **`selector`** — the relation (or atoms) whose members are grouped.
-2. **`name`** — the label drawn on the bounding box.
-3. **`addEdge`** *(optional)* — the connector between the group's key and the
-   group: `'none'` (default), `'togroup'`, or `'fromgroup'`. To also style the
-   connector, pass a `GroupEdge` instead of a bare string.
-4. **`textStyle`** *(optional)* — styles the group's own label.
+1. **`selector`**: the relation, or the atoms, whose members are grouped.
+2. **`name`**: the label drawn on the bounding box.
+3. **`addEdge`** *(optional)*: the connector between the group's key and the
+   group. It is `'none'` (default), `'togroup'`, or `'fromgroup'`. To also style
+   the connector, pass a `GroupEdge` instead of a bare string.
+4. **`textStyle`** *(optional)*: styles the group's own label.
 
 ```python
 from spytial import GroupEdge, LineStyle, TextStyle
@@ -68,12 +71,12 @@ from spytial import GroupEdge, LineStyle, TextStyle
 )
 ```
 
-### `hold` — invert any constraint
+### `hold`: invert any constraint
 
-Every constraint takes an optional **`hold`**. It defaults to `'always'`; pass
-`'never'` to require the opposite — the layout must *not* satisfy the
-constraint. It's how you say "these must not be grouped" or "y is never below
-x", rather than leaving the relationship unconstrained.
+Every constraint takes an optional **`hold`**. It defaults to `'always'`. Pass
+`'never'` to require the opposite, so that the layout shall not satisfy the
+constraint. Use `'never'` to state that atoms are not grouped, or that `y` is
+never below `x`, instead of leaving the relationship unconstrained.
 
 ```python
 @spytial.orientation(selector='children', directions=['below'], hold='never')
@@ -82,11 +85,11 @@ x", rather than leaving the relationship unconstrained.
 
 ## Directives
 
-### `attribute` — show a field as inline text
+### `attribute`: show a field as inline text
 
-1. **`field`** — the field to fold into the node as a label (instead of a separate
-   box and arrow).
-2. **`textStyle`** *(optional)* — styles this attribute's line
+1. **`field`**: the field to fold into the node as a label, instead of a
+   separate box and arrow.
+2. **`textStyle`** *(optional)*: styles this attribute's line
    (`TextStyle(size=..., color=...)`).
 
 ```python
@@ -94,23 +97,25 @@ x", rather than leaving the relationship unconstrained.
 @spytial.attribute(field='weight', textStyle=spytial.TextStyle(size='small'))
 ```
 
-### `atomStyle` / `edgeStyle` — styling
+### `atomStyle` and `edgeStyle`: styling
 
-Styling is built from small **style blocks** (import them from `spytial`):
+Styling is built from small **style blocks**, imported from `spytial`:
 
-- `LineStyle(color, pattern, weight, highlight)` — a drawn edge line;
-  `pattern` is `'solid'`, `'dashed'`, or `'dotted'`, `weight` is a number > 0.
-- `TextStyle(size, color)` — any label; `size` is `'small'`/`'normal'`/`'large'`.
-- `BorderStyle(color, width)` / `FillStyle(color)` — an atom's outline and interior.
+- `LineStyle(color, pattern, weight, highlight)`: a drawn edge line. `pattern` is
+  `'solid'`, `'dashed'`, or `'dotted'`. `weight` is a number greater than 0.
+- `TextStyle(size, color)`: any label. `size` is `'small'`, `'normal'`, or
+  `'large'`.
+- `BorderStyle(color, width)` and `FillStyle(color)`: an atom's outline and
+  interior.
 
-Every field is optional — set only what you mean. Plain dicts with the same
-keys work everywhere the blocks do.
+Every field is optional. Set only the fields that are needed. Plain dicts with
+the same keys work everywhere the blocks do.
 
-- `atomStyle`: **`selector`** (which atoms; omit for all) + any of
-  **`borderStyle`**, **`fillStyle`**, **`textStyle`**.
-- `edgeStyle`: **`field`** (which relation) + any of **`lineStyle`**,
-  **`textStyle`** (the edge's label), **`showLabel`**, **`hidden`**, plus
-  optional `selector` / `filter`.
+- `atomStyle`: **`selector`** (which atoms; omit for all), and any of
+  **`borderStyle`**, **`fillStyle`**, and **`textStyle`**.
+- `edgeStyle`: **`field`** (which relation), and any of **`lineStyle`**,
+  **`textStyle`** (the edge's label), **`showLabel`**, and **`hidden`**, plus an
+  optional `selector` or `filter`.
 
 ```python
 from spytial import LineStyle, TextStyle, BorderStyle, FillStyle
@@ -121,31 +126,33 @@ from spytial import LineStyle, TextStyle, BorderStyle, FillStyle
 ```
 
 > **Migrating from 2.x:** `atomColor` and `edgeColor` still work but are
-> deprecated — they are rewritten to `atomStyle` / `edgeStyle` and raise a
-> `DeprecationWarning`. The mapping: `edgeColor`'s `value` → `lineStyle.color`,
-> `style` → `lineStyle.pattern`, `weight` → `lineStyle.weight`; `atomColor`'s
-> `value` → `borderStyle.color` (the legacy directive colored the **border**,
-> not the fill — reach for `fillStyle` only if you want a filled look).
+> deprecated. They are rewritten to `atomStyle` or `edgeStyle` and raise a
+> `DeprecationWarning`. The mapping is: `edgeColor.value` becomes
+> `lineStyle.color`, `edgeColor.style` becomes `lineStyle.pattern`, and
+> `edgeColor.weight` becomes `lineStyle.weight`; `atomColor.value` becomes
+> `borderStyle.color`. The legacy directive colored the **border**, not the
+> fill, so use `fillStyle` only for a filled look.
 
-> **Breaking in spytial-core 3.0:** two style rules that set the same property
-> of the same edge/atom to *different* values now raise a `StyleCollisionError`
-> at render time (2.x silently kept the first). Set each property in exactly one
-> matching rule. spytial warns at spec-collection time for the statically
-> detectable case (identical `field`/`selector`/`filter`).
+> **Breaking change in spytial-core 3.0:** two style rules that set the same
+> property of the same edge or atom to *different* values now raise a
+> `StyleCollisionError` at render time. Version 2.x kept the first rule without
+> notice. Set each property in exactly one matching rule. Spytial warns at
+> spec-collection time for the case that it can detect statically (identical
+> `field`, `selector`, and `filter`).
 
-### `hideAtom` / `hideField` — remove things from the picture
+### `hideAtom` and `hideField`: remove things from the picture
 
 - `hideAtom`: **`selector`** (the atoms to hide).
 - `hideField`: **`field`** (the relation to hide).
 
-### `inferredEdge` — draw a derived edge
+### `inferredEdge`: draw a derived edge
 
-1. **`selector`** — the pairs to connect.
-2. **`name`** — the label for the new edge.
-3. **`lineStyle`** / **`textStyle`** *(optional)* — style the drawn edge and its
-   label (same blocks as `edgeStyle`; the inline `color`/`style`/`weight`
-   arguments are deprecated).
-4. **`draw`** *(optional)* — where each end attaches. See below.
+1. **`selector`**: the pairs to connect.
+2. **`name`**: the label for the new edge.
+3. **`lineStyle`** and **`textStyle`** *(optional)*: style the drawn edge and its
+   label. These use the same blocks as `edgeStyle`. The inline `color`, `style`,
+   and `weight` arguments are deprecated.
+4. **`draw`** *(optional)*: where each end attaches. See below.
 
 ```python
 @spytial.inferredEdge(
@@ -154,12 +161,12 @@ from spytial import LineStyle, TextStyle, BorderStyle, FillStyle
 )
 ```
 
-#### `draw` — attach an end to a group's hull
+#### `draw`: attach an end to a group's hull
 
-By default an inferred edge runs atom-to-atom. **`draw`** is a string
-`'<end> -> <end>'` where each end is either `'_'` (the atom itself) or the
-**name of a `group` constraint** — in which case that end attaches to the hull
-of the group *keyed by that end's atom*. This is what makes group-to-group and
+By default, an inferred edge runs atom to atom. **`draw`** is a string
+`'<end> -> <end>'`. Each end is either `'_'` (the atom itself) or the **name of a
+`group` constraint**. For a group name, that end attaches to the hull of the
+group *keyed by that end's atom*. This is what makes group-to-group and
 node-to-group edges expressible.
 
 ```python
@@ -172,40 +179,41 @@ node-to-group edges expressible.
 )
 ```
 
-`'_ -> regions'` runs from the atom to a group's hull; `'_ -> _'` means the same
-as omitting `draw`. The edge's own selector still ranges over atoms either way —
-and with `draw`, a unary edge selector is allowed, its atom feeding both ends.
+`'_ -> regions'` runs from the atom to a group's hull. `'_ -> _'` is the same as
+an omitted `draw`. In both cases the edge's own selector ranges over atoms. With
+`draw`, a unary edge selector is allowed, and its atom feeds both ends.
 
-> **The referenced group must be keyed** — that is, declared with a *binary*
-> selector, whose first element becomes the key. `draw` resolves each end by
-> looking up the group of that name keyed by that end's atom, so a group built
-> from a unary selector (`selector='Team.members'`) has no key for any end to
-> match, and the edge is dropped without drawing anything. A group *name* that
-> matches no `group` constraint at all is a hard error at render time; an atom
-> that keys no group of that name is reported in the browser console.
+> **The referenced group shall be keyed.** That is, it shall be declared with a
+> *binary* selector, and the first element becomes the key. `draw` resolves each
+> end by looking up the group of that name keyed by that end's atom. A group
+> built from a unary selector (`selector='Team.members'`) has no key for any end
+> to match, so the edge is dropped and nothing is drawn. A group *name* that
+> matches no `group` constraint is a hard error at render time. An atom that keys
+> no group of that name is reported in the browser console.
 
-### `tag` — attach a computed label
+### `tag`: attach a computed label
 
-1. **`toTag`** — the type to tag.
-2. **`name`** — the label name.
-3. **`value`** — the field/expression to show.
-4. **`textStyle`** *(optional)* — styles this tag's line
+1. **`toTag`**: the type to tag.
+2. **`name`**: the label name.
+3. **`value`**: the field or expression to show.
+4. **`textStyle`** *(optional)*: styles this tag's line
    (`TextStyle(size=..., color=...)`).
 
-### `size` / `icon` — adjust drawing
+### `size` and `icon`: adjust drawing
 
-- `size`: **`selector`** + **`height`** + **`width`**.
-- `icon`: **`selector`** + **`path`** (+ `showLabels`).
+- `size`: **`selector`**, **`height`**, and **`width`**.
+- `icon`: **`selector`** and **`path`** (plus optional `showLabels`).
 
-### `flag` — a rendering switch
+### `flag`: a rendering switch
 
-1. **`name`** — e.g. `'hideDisconnected'` to drop atoms with no edges.
+1. **`name`**: for example `'hideDisconnected'`, which drops atoms with no
+   edges.
 
 ## Attaching operations
 
-The same operations can be attached three ways.
+The same operations can be attached in three ways.
 
-**As class decorators** (most common):
+**As class decorators** (the most common way):
 
 ```python
 import spytial
@@ -218,7 +226,7 @@ class Node:
         self.children = children or []
 ```
 
-**On a single object**, without touching the class:
+**On a single object**, without a change to the class:
 
 ```python
 node = Node('root')
@@ -236,8 +244,9 @@ class Node:
     ...
 ```
 
-## See it in action
+## Examples
 
-Try these on real data structures in the [Playground](playground/index.html), or
-browse the [`spytial-clrs`](https://github.com/sidprasad/spytial-clrs) notebooks
-for idiomatic usage on heaps, trees, hash tables, disjoint sets, and graphs.
+Try these operations on real data structures in the
+[Playground](playground/index.html). The
+[`spytial-clrs`](https://github.com/sidprasad/spytial-clrs) notebooks also show
+idiomatic usage on heaps, trees, hash tables, disjoint sets, and graphs.

--- a/docs/relationalizers.md
+++ b/docs/relationalizers.md
@@ -1,23 +1,26 @@
 # Custom Relationalizers
 
 
-> Custom relationalizers are still very much a W.I.P.
+> Custom relationalizers are a work in progress.
 
-Relationalizers are plug-ins that teach Spytial how to serialize your custom objects into atoms and relations.
+Relationalizers are plug-ins. They define how Spytial serializes custom
+objects into atoms and relations.
 
 ## When to use a relationalizer
 
 Use a relationalizer when:
 
-- you want fine-grained control over how an object becomes nodes and edges
-- your objects are not handled well by the built-in defaults
-- you need domain-specific relations such as `depends_on` or `flows_to`
+- fine-grained control over how an object becomes nodes and edges is
+  necessary
+- the built-in defaults do not handle the objects well
+- domain-specific relations such as `depends_on` or `flows_to` are
+  necessary
 
 ## Anatomy of a relationalizer
 
 A relationalizer inherits from `RelationalizerBase` and implements two methods:
 
-- `can_handle(obj)` returns `True` when the relationalizer should handle the object
+- `can_handle(obj)` returns `True` when the relationalizer can handle the object
 - `relationalize(obj, walker_func)` returns `Atom` and `Relation` instances
 
 ```python
@@ -39,22 +42,27 @@ class WidgetRelationalizer(RelationalizerBase):
 
 ## Built-in coverage first
 
-Before you write a custom relationalizer, check whether the built-ins already cover your case. `spytial-py` already ships relationalizers for:
+Before writing a custom relationalizer, check whether the built-ins cover
+the case. `spytial-py` includes relationalizers for:
 
 - primitives
 - `dict`, `list`, `tuple`, and `set`
 - dataclasses
 - generic Python objects as a fallback
 
-Most examples in `spytial-clrs` work without custom relationalizers because regular Python objects plus operations are usually enough.
+Most examples in `spytial-clrs` work without custom relationalizers.
+Regular Python objects plus operations are usually enough.
 
 ## Priorities
 
-Relationalizers with higher priorities are checked first. Priorities from **0-99** are reserved for built-ins, so custom relationalizers should use **100 or higher**.
+Spytial checks relationalizers with higher priority first. The built-ins
+reserve priorities **0 to 99**. Custom relationalizers should use
+**100 or higher**.
 
 ## Registering and inspecting
 
-The `@relationalizer` decorator registers the class automatically when the module is imported. You can inspect the active registry like this:
+The `@relationalizer` decorator registers the class automatically when the
+module is imported. The active registry can be inspected as follows:
 
 ```python
 from spytial import RelationalizerRegistry
@@ -64,4 +72,6 @@ print(RelationalizerRegistry.list_relationalizers())
 
 ## Next steps
 
-Once your relationalizer is in place, use `spytial.evaluate()` first to validate the emitted structure, then `spytial.diagram()` to tune layout and directives.
+After the relationalizer is in place, use `spytial.evaluate()` first to
+validate the emitted structure. Then use `spytial.diagram()` to adjust
+layout and directives.

--- a/docs/selectors.md
+++ b/docs/selectors.md
@@ -1,77 +1,82 @@
 # Selectors
 
-Most Spytial operations take a `selector`: a small expression for **which atoms or
-edges a rule applies to**. It is a pattern match over the *value graph* Spytial
-builds from your object, so it matches across instances — not just one. The selector
-language is a subset of [Alloy](https://alloytools.org).
+Most Spytial operations take a `selector`. A selector is a small expression for
+**which atoms or edges a rule applies to**. It is a pattern match over the
+*value graph* that Spytial builds from an object, so it matches across
+instances, not one instance only. The selector language is a subset of
+[Alloy](https://alloytools.org).
 
 ## The value graph: atoms, relations, types
 
-Before laying anything out, Spytial turns your object into a graph:
+Before any layout, Spytial turns an object into a graph:
 
-- An **atom** is one object or value — a node, an `int`, a `str`, `None`.
-- A **relation** is a field. `node.left` becomes a relation named `left`: the set of
-  `(source, dest)` tuples, one for each object that has a `left`.
+- An **atom** is one object or value: a node, an `int`, a `str`, or `None`.
+- A **relation** is a field. `node.left` becomes a relation named `left`. It is
+  the set of `(source, dest)` tuples, one tuple for each object that has a
+  `left`.
 - A **type** is the set of all atoms of that type, named by the Python class:
-  `TreeNode`, `int`, `str`, `list`, `dict`. (The type of `None` is `NoneType` — not
-  `None`.)
+  `TreeNode`, `int`, `str`, `list`, `dict`. The type of `None` is `NoneType`,
+  not `None`.
 
 ## Unary and binary selectors
 
-A selector selects either **one thing or two**:
+A selector selects one thing or two:
 
-- A **unary** selector selects a **set** of atoms — e.g. `TreeNode`,
+- A **unary** selector selects a set of atoms, for example `TreeNode` or
   `{ x : TreeNode | … }`. Operations that act on atoms (`hideAtom`, `atomStyle`)
   take a unary selector.
-- A **binary** selector selects a **set of `(source, dest)` tuples** — e.g. `left`,
-  `~left`, `{ x : TreeNode, y : TreeNode | … }`. Operations that act on edges
-  (`orientation`, `align`, `inferredEdge`) take a binary selector.
+- A **binary** selector selects a set of `(source, dest)` tuples, for example
+  `left`, `~left`, or `{ x : TreeNode, y : TreeNode | … }`. Operations that act
+  on edges (`orientation`, `align`, `inferredEdge`) take a binary selector.
 
-**An edge label is already a selector.** A field/relation name like `left`, `next`,
-or `parent` is a binary selector standing for that edge's `(source, dest)` tuples —
-so `selector='left'` selects every left-edge, no comprehension required.
+An edge label is already a selector. A field or relation name such as `left`,
+`next`, or `parent` is a binary selector for that edge's `(source, dest)`
+tuples. So `selector='left'` selects every left edge, and no comprehension is
+required.
 
 ## Operators
 
 | Selector | Arity | Meaning |
 | --- | --- | --- |
 | `TreeNode` | unary | every atom of that type |
-| `left` | binary | an edge label — that relation's `(source, dest)` tuples |
+| `left` | binary | an edge label: that relation's `(source, dest)` tuples |
 | `{ x : T \| cond }` | unary | the atoms of `T` where `cond` holds |
 | `{ x : T, y : T \| cond }` | binary | the pairs `(x, y)` where `cond` holds |
 | `A.f` | unary | follow `f` from every atom in `A` (a join) |
-| `~f` | binary | `f` reversed — swaps each tuple's two ends |
-| `^f` | binary | reachability — `f` followed one or more times |
-| `*f` | binary | `^f` plus identity — reachability including self |
+| `~f` | binary | `f` reversed: swaps each tuple's two ends |
+| `^f` | binary | reachability: `f` followed one or more times |
+| `*f` | binary | `^f` plus identity: reachability including self |
 | `a + b`, `a & b`, `a - b` | same | union, intersection, difference |
-| `a -> b` | binary | cross product — every tuple `(x, y)`, `x in a`, `y in b` |
+| `a -> b` | binary | cross product: every tuple `(x, y)`, `x in a`, `y in b` |
 
-Inside a comprehension's `cond` you can use comparisons (`=`, `in`, `<`, `<=`, `>`,
-`>=`), the multiplicities `some` / `no` / `one` / `lone`, an atom's display label
-`@:x` (e.g. `@:x = "10"`), and `and` / `or` / `not`.
+Inside a comprehension's `cond`, the following are available: the comparisons
+`=`, `in`, `<`, `<=`, `>`, and `>=`; the multiplicities `some`, `no`, `one`, and
+`lone`; an atom's display label `@:x` (for example `@:x = "10"`); and the
+operators `and`, `or`, and `not`.
 
 ## Worked example: the binary tree
 
 The [binary tree](getting-started.md) orients children with a two-variable
-comprehension — a binary selector matching parent/child **pairs**:
+comprehension. This is a binary selector that matches parent and child
+**pairs**:
 
 ```text
 { x : TreeNode, y : TreeNode | x.left = y }
 ```
 
-`x` and `y` range over nodes, and `x.left = y` keeps the pairs where `y` is `x`'s
-left child — so this is the set of left-child tuples, exactly what `orientation`
-needs. (`left` on its own is already a binary selector; the comprehension just makes
-the intent explicit.) `hideAtom(selector='NoneType')` is the unary counterpart — it
-drops the empty `None` leaves.
+`x` and `y` range over nodes. `x.left = y` keeps the pairs where `y` is the left
+child of `x`. This is the set of left-child tuples, which is what `orientation`
+needs. (`left` on its own is already a binary selector. The comprehension only
+makes the intent explicit.) `hideAtom(selector='NoneType')` is the unary
+counterpart. It drops the empty `None` leaves.
 
-When you need to be surgical, combine operators: `left & (TreeNode -> TreeNode)`
-keeps only left-edges whose endpoints are both nodes, and `~left` is the
-child→parent direction.
+For a more precise result, combine operators. `left & (TreeNode -> TreeNode)`
+keeps only the left edges whose endpoints are both nodes. `~left` is the
+child-to-parent direction.
 
 ## Where selectors show up
 
-Every [operation](operations.md) that takes a `selector` (and the related `field` /
-`filter` arguments). For simple objects an edge label or a type name is usually
-enough; reach for the operators above when you need to target *exactly* the right
-atoms or tuples.
+A selector is used by every [operation](operations.md) that takes a `selector`
+argument, and by the related `field` and `filter` arguments. For a simple
+object, an edge label or a type name is usually enough. Use the operators above
+to target exactly the right atoms or tuples.

--- a/docs/suggest.md
+++ b/docs/suggest.md
@@ -1,60 +1,43 @@
-# Suggesting a Spytial specification
+# Suggesting Spytial Annotations
 
-Writing a Spytial specification from a blank page requires two decisions at
-once: what the diagram should look like, and how to express that intent using
-Spytial selectors and directives. Often the missing rule only becomes obvious
-after seeing it violated: diagonal children prompt “put every child directly
-below its parent”; a visible parent pointer prompts “hide that implementation
-detail.”
+Spytial annotations are the decorators that shape a diagram, such as
+`@orientation` and `@hideAtom`. The hard part is starting them from a blank
+page. A blank page asks for two decisions at once: what the diagram should look
+like, and which selectors and directives express that. A missing rule is often
+noticed only after it is broken. Diagonal children suggest the rule "put every
+child directly below its parent." A visible parent pointer suggests the rule
+"hide that implementation detail."
 
-`spytial.suggest` replaces the blank page with a concrete, editable
-`SpecDraft`. The design claim is simple: a default need not be correct to be
-useful. If it is right, apply it. If it is wrong, inspect its selectors and
-correct something specific.
+`spytial.suggest` replaces the blank page with a concrete, editable draft, a
+`SpecDraft`. A draft that is almost right is easier to fix than a blank page is
+to fill. Even a wrong suggestion points at one specific thing to change. So a
+suggested default need not be correct to be useful. If it is correct, apply it.
+If it is wrong, read its selectors and correct one part.
 
-Suggestion is local and deterministic by default. Models and Hypothesis-backed
-witness search are optional and load only when requested.
+By default, `suggest` runs locally and is deterministic. Models and Hypothesis
+witness search are optional. They load only when they are requested.
 
-## High-level idea
+## How it works
 
-The inputs tell Spytial what structure it can inspect. The proposal layers get
-more freedom only when Spytial has a stronger way to check their output.
+`suggest` inspects a class or object and returns a `SpecDraft`: a set of
+proposed annotations, each with a rationale and a source.
 
-```mermaid
-flowchart TB
-    T["target<br/>class or object"] --> C["Class analysis"]
-    T -- "object" --> W["Concrete witnesses"]
-    I["instance=<br/>one sample"] --> W
-    E["examples=<br/>fixed must-pass cases"] --> W
-    S["strategy=<br/>family of valid values"] --> H["Hypothesis search<br/>one representative witness"]
-    H --> W
-    C -. "class-only ask; no witness" .-> A["implicit strategy='auto'<br/>from_type(target)"]
-    A --> H
+The default path is deterministic. It matches common field shapes to directives,
+with no model and no network. These built-in rules are covered under
+[Deterministic heuristics](#deterministic-heuristics).
 
-    C --> R["Deterministic rules<br/>known-good selector forms"]
-    C --> M1["Model chooses a shape<br/>from a closed vocabulary"]
-    W --> M2["Model authors a selector<br/>or translates ask="]
-    Q["ask=<br/>desired layout"] --> M2
-    P["enrich=<br/>model provider"] --> M1
-    P --> M2
+`enrich=` adds a model. The model can pick a layout shape from a fixed
+vocabulary, or author a selector, including one translated from a plain-language
+`ask=`. A model can be wrong, so anything it authors is checked: the selector
+runs against the values in `instance=`, `examples=`, or `strategy=`, and shall
+denote real atoms or edges before it joins the draft.
 
-    M1 --> K1["Spytial supplies the selector"]
-    M2 --> K2["Execute selector<br/>check vocabulary, arity, and authoring"]
-    R --> D["SpecDraft"]
-    K1 --> D
-    K2 --> D
-    D --> U["Inspect · edit · apply"]
-```
-
-The left side establishes evidence: a class shape and, when available,
-concrete objects. The right side turns that evidence into proposals. Static
-rules use selector forms supplied by Spytial. A model may choose among known
-spatial shapes without seeing an instance. Giving a model freedom to author a
-selector requires concrete witnesses so Spytial can execute and validate it.
+Nothing is applied automatically. The draft is there to inspect, edit, and
+apply.
 
 ## Quick start
 
-Consider an ordinary Python tree:
+The following is an ordinary Python tree:
 
 ```python
 from dataclasses import dataclass
@@ -76,7 +59,7 @@ draft = suggest(root)
 print(draft.to_source())
 ```
 
-The deterministic analyzer proposes a conventional tree layout:
+The deterministic analyzer suggests a standard tree layout:
 
 ```python
 @spytial.orientation(
@@ -92,16 +75,16 @@ The deterministic analyzer proposes a conventional tree layout:
 @spytial.flag(name='hideDisconnected')
 ```
 
-`to_source()` emits one-line decorators with explanatory comments; they are
-expanded above for readability. Paste and edit the generated source, or apply
-the draft to the class immediately:
+`to_source()` writes each decorator on one line and adds a comment. The example
+above is expanded for readability. Paste and edit this source, or apply the
+draft to the class directly:
 
 ```python
 draft.apply()
 spytial.diagram(root)
 ```
 
-If the proposed geometry is close but wrong, state the correction:
+If the layout is close but not correct, state the correction:
 
 ```python
 from spytial.suggest import ClaudeCode
@@ -113,11 +96,11 @@ draft = suggest(
 )
 ```
 
-The admitted request selects `left + right` and uses `below`. The overlapping
-below-left and below-right rules move to `draft.alternatives` rather than being
-discarded.
+Spytial accepts the request. It selects `left + right` and uses `below`. The
+earlier below-left and below-right rules move to `draft.alternatives`. Spytial
+does not discard them.
 
-Both import styles are supported. The `suggest` subpackage is lazy and callable:
+Either import style can be used. The `suggest` subpackage is lazy and callable:
 
 ```python
 import spytial
@@ -133,7 +116,7 @@ draft = suggest(root)
 
 ## What each parameter does
 
-The complete interface is:
+The full interface is:
 
 ```python
 suggest(
@@ -148,36 +131,37 @@ suggest(
 )
 ```
 
-The inputs are different kinds of evidence. In particular, `examples=` and
-`strategy=` are not two spellings of the same idea.
+Each input provides a different kind of information. `examples=` and `strategy=`
+are not the same thing.
 
 | Parameter | Meaning | Use it when |
 | --- | --- | --- |
-| `target` | Required. A class to analyze, or an object. An object is shorthand for its class plus one concrete sample. | You always provide this. |
-| `instance` | One explicit sample for a class target. It exposes runtime structure that annotations and `__init__` do not. It is also the default selector-validation witness. | You have a representative object already. |
-| `examples` | Particular, fixed cases. Model-authored selectors must validate on every buildable example. | Awkward or important cases must not be lost during suggestion. |
-| `strategy` | A Hypothesis strategy describing a family of values. Suggestion performs bounded search for one representative witness. The special value `"auto"` uses `hypothesis.strategies.from_type(target)`. | Valid instances require generation, or a single hand-picked instance would be misleading. |
-| `enrich` | The model provider: a model identifier, a callable provider, or a built-in such as `ClaudeCode()` or `Codex()`. There is no ambient model. | Field names or domain conventions carry intent beyond structural types. |
-| `ask` | A natural-language statement of the desired layout. It is translated by `enrich=` and is authoritative over overlapping geometric suggestions. | You can describe the correction more easily than write its selector. |
-| `registry` | An alternate deterministic heuristic registry. | A project has its own field conventions or layout policy. |
+| `target` | Required. A class, or an object. An object means the class and one concrete value. | Always provide this. |
+| `instance` | One concrete value for a class target. It shows runtime structure that annotations and `__init__` do not. Spytial also uses it as the default witness for selector checks. | A representative object is already available. |
+| `examples` | Fixed, specific cases. A model-written selector shall pass on every example that Spytial can build. | Awkward or important cases need to be preserved. |
+| `strategy` | A Hypothesis strategy for a family of values. Spytial runs a bounded search for one representative witness. The value `"auto"` uses `hypothesis.strategies.from_type(target)`. | Valid values require generation, or one hand-picked value would mislead. |
+| `enrich` | The model provider. It is a model name, a callable, or a built-in such as `ClaudeCode()` or `Codex()`. There is no default model. | Field names or domain conventions carry intent that types do not show. |
+| `ask` | A plain-language statement of the required layout. `enrich=` translates it. It overrides any overlapping geometric suggestion. | The correction is easier to describe than to write as a selector. |
+| `registry` | A different registry of deterministic rules. | The project has its own field conventions or layout policy. |
 
-### Choose the evidence you have
+### Choose the input
 
-Static analysis of a type needs no instance, model, or optional dependency:
+Static analysis of a type needs no value, model, or optional dependency:
 
 ```python
 draft = suggest(TreeNode)
 ```
 
-Pass an object—or a type plus `instance=`—when runtime values reveal structure
-that static inspection cannot recover:
+Pass an object, or a type with `instance=`, when runtime values show structure
+that static inspection cannot find:
 
 ```python
 draft = suggest(root)
-draft = suggest(TreeNode, instance=root)  # equivalent evidence
+draft = suggest(TreeNode, instance=root)  # equivalent input
 ```
 
-Use `examples=` for fixed cases every authored selector must survive:
+Use `examples=` for fixed cases. Every model-written selector shall pass all of
+them:
 
 ```python
 draft = suggest(
@@ -187,8 +171,8 @@ draft = suggest(
 )
 ```
 
-Use `strategy=` for a family of valid values. One generated witness is added to
-the fixed validation set:
+Use `strategy=` for a family of valid values. Spytial adds one generated witness
+to the fixed set:
 
 ```python
 draft = suggest(
@@ -199,7 +183,7 @@ draft = suggest(
 )
 ```
 
-For a class-only request, `strategy="auto"` is implicit:
+For a request on a class alone, Spytial uses `strategy="auto"`:
 
 ```python
 draft = suggest(
@@ -209,10 +193,11 @@ draft = suggest(
 )
 ```
 
-Hypothesis derives a strategy from `TreeNode`. For a recursive class, Spytial
-first searches for a value that populates every public recursive root field,
-then for any non-leaf value, and finally for any buildable value. Supply a
-custom strategy when the type has invariants Hypothesis cannot infer.
+Hypothesis builds a strategy from `TreeNode`. For a recursive class, Spytial
+searches in three steps. First, it looks for a value that fills every public
+recursive field. Next, it looks for any non-leaf value. Last, it looks for any
+value that it can build. Supply a custom strategy when the type has invariants
+that Hypothesis cannot infer.
 
 Install witness search separately:
 
@@ -220,219 +205,54 @@ Install witness search separately:
 pip install "spytial_diagramming[suggest-search]"
 ```
 
-The ordinary `suggest(TreeNode)` path does not import Hypothesis.
+The plain `suggest(TreeNode)` path does not import Hypothesis.
 
 ## Working with `SpecDraft`
 
-`suggest()` returns a draft rather than mutating the target class. Its main
-collections expose both the proposal and the reasoning behind it:
+`suggest()` returns a draft. It does not change the target class. The main
+collections show both the suggestion and the reason for it:
 
 | Member | Contents |
 | --- | --- |
-| `draft.suggestions` | Current proposed `Suggestion` objects, including disabled low-confidence rows. |
-| `draft.enabled()` | The suggestions currently enabled by default. |
-| `draft.alternatives` | Conflict losers and superseded geometry, preserved for inspection or recovery. |
-| `draft.notes` | Missing evidence, skipped enrichment, validation results, and other diagnostics. |
+| `draft.suggestions` | The current `Suggestion` objects. This includes the disabled low-confidence rows. |
+| `draft.enabled()` | The suggestions that are enabled by default. |
+| `draft.alternatives` | Suggestions that lost a conflict, and geometry that was replaced. Spytial keeps them so they can be inspected or restored. |
+| `draft.notes` | Missing input, skipped enrichment, validation results, and other diagnostics. |
 
 Each `Suggestion` records its `directive`, `kwargs`, `confidence`, `rationale`,
-`source_field`, whether it is enabled, and whether it came from a deterministic
-rule or a model.
+and `source_field`. It also records whether it is enabled, and whether it came
+from a deterministic rule or a model.
 
-Render or apply the draft in four ways:
+The draft can be rendered or applied in four ways:
 
 | Call | Result |
 | --- | --- |
 | `draft.to_source()` | A pasteable stack of `@spytial.*` decorators. |
 | `draft.to_registry()` | A `{"constraints": [...], "directives": [...]}` registry dictionary. |
-| `draft.apply()` | Decorates the target class live and returns it. |
-| `draft` in Jupyter | A rich panel showing directives, rationales, alternatives, and notes. |
+| `draft.apply()` | Decorates the target class in place and returns it. |
+| `draft` in Jupyter | A panel that shows the directives, rationales, alternatives, and notes. |
 
-These methods use enabled suggestions by default. Pass `enabled_only=False` to
-include disabled candidates. `to_source(with_comments=False)` omits generated
-rationales.
+These methods use the enabled suggestions by default. Pass `enabled_only=False`
+to include the disabled ones. `to_source(with_comments=False)` leaves out the
+generated rationales.
 
-Review the draft before `apply()`: application installs decorators on the class
-and therefore affects subsequent diagrams of its instances.
+Review the draft before calling `apply()`. `apply()` installs decorators on the
+class. This changes every later diagram of its instances.
 
-## How deterministic suggestion decides
+## Deterministic heuristics
 
-The analyzer reads field types, names, assignments in `__init__`, and optional
-instance samples. Built-in heuristics map common structures to directives:
+Without a model, `suggest` reads the field types, the field names, the
+`__init__` assignments, and any instance values, then maps common structures to
+directives. Three examples:
 
 | Field shape | Suggested treatment |
 | --- | --- |
 | `left` and `right` of the same node type | Orient below-left and below-right. |
-| One self-referential field | Orient below. |
-| A list or dictionary of same-type children | Derive parent-child pairs and orient below. |
-| `next` and `prev` of the same type | Orient `next` right and hide the reverse link. |
-| `parent` or another back-pointer | Hide it when child edges already expose the structure; otherwise orient above. |
 | A scalar such as `value`, `key`, or `name` | Fold it into the node with `attribute`. |
-| An `Enum`-typed field | Propose one disabled `atomStyle` per member. |
-| Nullable children | Hide `NoneType` atoms. |
+| A `parent` back-pointer duplicated by child edges | Hide it. |
 
-Nullable edge selectors remove only `None` targets—for example,
-`left - (univ -> NoneType)`. This retains edges to subtype instances that an
-exact type intersection would incorrectly discard.
-
-When child edges already describe the structure, a `parent` field duplicates
-them and is hidden by default. Its “place above” orientation remains in
-`draft.alternatives`. When `parent` is the only structural link, the orientation
-wins instead.
-
-## Model providers
-
-`enrich=` always names a provider explicitly. There is no ambient model and no
-model call on the default path.
-
-### Claude Code
-
-`ClaudeCode` uses an installed and authenticated `claude` CLI, so it needs no
-Spytial model extra or API key:
-
-```python
-from spytial.suggest import ClaudeCode, suggest
-
-draft = suggest(Ticket, enrich=ClaudeCode())
-draft = suggest(Ticket, enrich=ClaudeCode(model="opus"))
-```
-
-If `ANTHROPIC_API_KEY` is set, the CLI may use metered API billing instead of a
-Claude subscription. Consult the CLI's current authentication behavior before
-choosing a provider.
-
-### Codex
-
-`Codex` uses an installed and authenticated `codex` CLI and its native
-JSON-schema output:
-
-```python
-from spytial.suggest import Codex, suggest
-
-draft = suggest(Ticket, enrich=Codex())
-```
-
-### A model identifier through `llm`
-
-A string is resolved by Simon Willison's `llm` library. This supports hosted
-providers and local models through their respective plugins:
-
-```console
-pip install "spytial_diagramming[suggest-llm]"
-llm install llm-anthropic
-llm keys set anthropic
-```
-
-```python
-draft = suggest(Ticket, enrich="claude-sonnet-4-6")
-draft = suggest(Ticket, enrich="llama3.2")  # for example, through Ollama
-```
-
-### A custom provider
-
-A provider is any callable with the signature `(prompt, *, schema) -> dict`.
-Helpers are available for text-only models:
-
-```python
-from spytial.suggest.providers import extract_json, instruct_json
-
-
-def my_provider(prompt, *, schema):
-    text = call_some_model(instruct_json(prompt, schema))
-    return extract_json(text)
-
-
-draft = suggest(Ticket, enrich=my_provider)
-```
-
-The shape tier sends class, field, and type names. When instances are present,
-the selector-authoring tier additionally sends relational names, arities, and
-atom counts. Field values stay local and are used only for selector evaluation.
-With a local provider, nothing leaves the machine.
-
-## Engineering considerations
-
-### Give inference only as much freedom as can be checked
-
-Suggestion has three layers:
-
-1. The deterministic layer recognizes common program structures and emits
-   selector forms maintained by Spytial.
-2. The model shape layer chooses `orientation`, `cyclic`, `group`, or no shape,
-   with arguments from a closed vocabulary. Spytial writes the selector.
-3. With concrete witnesses, the model may author selectors or translate
-   `ask=`. Those candidates must execute before they enter the draft.
-
-The governing principle is:
-
-> More generative freedom requires a stronger checker.
-
-Valid shape enrichment becomes the active geometry for the fields it addresses;
-the deterministic geometry it replaces becomes an alternative. If enrichment
-fails, the deterministic draft remains usable and `draft.notes` explains what
-was skipped.
-
-Model-authored selector candidates from unsolicited enrichment remain disabled
-until reviewed. An explicit `ask=`, by contrast, is enabled when admitted
-because the user requested it.
-
-### Check denotation, not just syntax
-
-A model-authored selector must:
-
-1. use a supported directive and in-vocabulary arguments;
-2. parse, return a non-empty result, and have the directive's exact arity on
-   every buildable validation example; and
-3. pass the same authoring checks as handwritten decorators.
-
-An orientation selector must denote pairs; `hideAtom` must denote atoms. This
-arity check matters because an invented bareword can parse as an arity-zero
-literal rather than fail syntactically.
-
-An explicit request gets one repair attempt using concrete validation
-diagnostics. If no part of the request can be admitted, `suggest` raises
-`spytial.suggest.AskError`. A compound request may admit the validated parts and
-record any remainder in `draft.notes`.
-
-### Preserve alternatives and make failure asymmetric
-
-When an explicit ask supersedes overlapping geometry, the previous suggestions
-move to `draft.alternatives`; they are not destroyed. Overlap is checked by
-evaluating the intersection of selectors over the available witnesses rather
-than comparing selector strings.
-
-Optional enrichment may fail and leave the deterministic draft unchanged. An
-explicit `ask=` must either install at least one validated directive or raise an
-error. The distinction prevents a requested correction from disappearing
-silently.
-
-### A witness is not a proof
-
-`examples=` checks the particular cases supplied. `strategy=` contributes one
-representative generated witness. Neither proves that a selector works for
-every value.
-
-This distinction is important for empty structures. A child selector returning
-no pairs on a leaf does not refute “put every child below its parent”; the rule
-is merely vacuous on that object. Auto-generation therefore prefers a populated
-recursive witness that exercises the selector.
-
-Evaluation can establish that a selector denotes real atoms or edges in the
-witnesses. It cannot establish that `below` expresses the user's intent. Human
-judgment remains the final specification.
-
-### Keep the default path cheap and local
-
-Static suggestion requires no model, network, Hypothesis, or headless
-evaluator. Provider resolution, witness search, and selector evaluation load
-only when their corresponding arguments request them.
-
-Selector authoring and `ask=` require a `node` runtime on `PATH` (or a binary
-named by `SPYTIAL_NODE`) so Spytial can run the vendored headless evaluator.
-
-## Extending deterministic suggestion
-
-The built-in rules are functions registered with `@heuristic`. Add project
-conventions or domain-specific field names using the same interface:
+Each rule is a function registered with `@heuristic`. Register a rule to add a
+project convention or a domain field name:
 
 ```python
 from spytial.suggest import Suggestion, heuristic
@@ -459,23 +279,176 @@ def color_by_status(field, cls_info):
     return []
 ```
 
-Field-scope heuristics receive `(FieldInfo, ClassInfo)`; class-scope heuristics
-receive `ClassInfo` and can recognize multi-field patterns. Higher priority wins
-a same-field conflict, while the losing suggestion becomes an alternative.
+A field-scope heuristic receives `(FieldInfo, ClassInfo)`. A class-scope
+heuristic receives `ClassInfo` and can find multi-field patterns. On the same
+field, the higher priority wins, and the losing suggestion becomes an
+alternative.
 
-Pass `suggest(cls, registry=my_registry)` for an isolated rule set. Use
-`DEFAULT_REGISTRY.copy()` to extend the built-ins without changing the global
-registry.
+Pass `suggest(cls, registry=my_registry)` for a separate rule set. Use
+`DEFAULT_REGISTRY.copy()` to extend the built-in rules without changing the
+global registry.
+
+## Model providers
+
+`enrich=` always names a provider. There is no default model. The default path
+makes no model call.
+
+### Claude Code
+
+`ClaudeCode` uses the installed and authenticated `claude` CLI. It needs no
+Spytial model extra and no API key:
+
+```python
+from spytial.suggest import ClaudeCode, suggest
+
+draft = suggest(Ticket, enrich=ClaudeCode())
+draft = suggest(Ticket, enrich=ClaudeCode(model="opus"))
+```
+
+If `ANTHROPIC_API_KEY` is set, the CLI can use metered API billing instead of a
+Claude subscription. Check the current authentication behavior of the CLI before
+choosing a provider.
+
+### Codex
+
+`Codex` uses the installed and authenticated `codex` CLI. It uses the native
+JSON-schema output of that CLI:
+
+```python
+from spytial.suggest import Codex, suggest
+
+draft = suggest(Ticket, enrich=Codex())
+```
+
+### A model identifier through `llm`
+
+The `llm` library by Simon Willison resolves a string name. It supports hosted
+providers and local models through plugins:
+
+```console
+pip install "spytial_diagramming[suggest-llm]"
+llm install llm-anthropic
+llm keys set anthropic
+```
+
+```python
+draft = suggest(Ticket, enrich="claude-sonnet-4-6")
+draft = suggest(Ticket, enrich="llama3.2")  # for example, through Ollama
+```
+
+### A custom provider
+
+A provider is any callable with the signature `(prompt, *, schema) -> dict`.
+Spytial provides helpers for text-only models:
+
+```python
+from spytial.suggest.providers import extract_json, instruct_json
+
+
+def my_provider(prompt, *, schema):
+    text = call_some_model(instruct_json(prompt, schema))
+    return extract_json(text)
+
+
+draft = suggest(Ticket, enrich=my_provider)
+```
+
+The shape layer sends the class, field, and type names. When values are present,
+the selector layer also sends the relation names, arities, and atom counts. The
+field values stay on the local machine. Spytial uses them only to evaluate
+selectors. With a local provider, no data leaves the machine.
+
+<!--
+## Engineering considerations
+
+### Give inference only as much freedom as can be checked
+
+Suggestion has three layers:
+
+1. The deterministic layer finds common program structures. It writes selector
+   forms that Spytial maintains.
+2. In the shape layer, a model may choose `orientation`, `cyclic`, `group`, or
+   no shape, with arguments from a fixed vocabulary. Spytial writes the
+   selector.
+3. In the selector layer, a model may write a selector, or translate an `ask=`,
+   provided concrete witnesses are present. Each candidate shall run before it
+   enters the draft.
+
+The rule is the same at each layer. More freedom to generate requires a stronger
+check. A static rule needs no check. A chosen shape cannot become an invalid
+selector. A model-written selector shall run and pass first.
+
+A valid shape becomes the active geometry for the fields it covers. The
+deterministic geometry that it replaces becomes an alternative. If enrichment
+fails, the deterministic draft still works. `draft.notes` explains what Spytial
+skipped.
+
+A model-written selector from automatic enrichment stays disabled until it is
+reviewed. An explicit `ask=` is different. Spytial enables it on acceptance,
+because it was requested.
+
+### Check denotation, not only syntax
+
+A model-written selector shall meet all of the following conditions:
+
+1. use a supported directive and arguments from the vocabulary;
+2. parse correctly, return a non-empty result, and have the exact arity of the
+   directive on every validation example that Spytial can build; and
+3. pass the same authoring checks as a handwritten decorator.
+
+An orientation selector shall denote pairs. `hideAtom` shall denote atoms. This
+arity check is important. An invented bareword can parse as an arity-zero
+literal. It does not fail as a syntax error.
+
+An explicit request receives one repair attempt. The repair uses the concrete
+validation diagnostics. If Spytial can accept no part of the request, `suggest`
+raises `spytial.suggest.AskError`. A request with several parts can accept the
+valid parts. Spytial records the rest in `draft.notes`.
+
+### Keep alternatives, and fail loudly on an explicit ask
+
+When an explicit ask replaces overlapping geometry, the earlier suggestions move
+to `draft.alternatives`. Spytial does not destroy them. To find an overlap,
+Spytial evaluates the intersection of the selectors on the available witnesses.
+It does not compare selector strings.
+
+Optional enrichment can fail. If it fails, the deterministic draft does not
+change. An explicit `ask=` shall install at least one validated directive, or
+raise an error. This difference prevents a requested correction from
+disappearing without notice.
+
+### A witness is not a proof
+
+`examples=` checks the specific cases that are supplied. `strategy=` adds one
+generated witness. Neither one proves that a selector works for every value.
+
+This matters for empty structures. On a leaf, a child selector returns no pairs.
+This does not disprove the rule "put every child below its parent." On a leaf,
+the rule simply has no children to place. For this reason, auto-generation
+prefers a filled recursive witness that exercises the selector.
+
+Evaluation can show that a selector denotes real atoms or edges in the
+witnesses. It cannot show that `below` matches the user's intent. The user makes
+the final specification.
+
+### Keep the default path cheap and local
+
+Static suggestion needs no model, network, Hypothesis, or headless evaluator.
+Provider resolution, witness search, and selector evaluation load only when the
+matching argument asks for them.
+
+Selector authoring and `ask=` require a `node` runtime on `PATH`, or a binary
+named by `SPYTIAL_NODE`. Spytial uses it to run the vendored headless evaluator.
+-->
 
 ## Limits
 
-Program structure is evidence for a spatial specification, not the
-specification itself. `suggest` cannot recover a tree represented only by index
-arithmetic in an array-backed heap. A model can choose the wrong interpretation
-of a real field. A selector can pass every supplied example and fail on the next
-one.
+Program structure is input for a layout. It is not the layout. `suggest`
+cannot recover a tree that exists only as index arithmetic in an array-backed
+heap. A model can read a real field in the wrong
+way. A selector can pass every supplied example and still fail on the next one.
 
-These limits are why the result is a `SpecDraft`: rationales and provenance are
-visible, alternatives survive, authored selectors run before admission,
-explicit asks fail loudly, and the user decides what becomes the final
-specification.
+These limits are the reason the result is a `SpecDraft`. The rationales and the
+provenance are visible. The alternatives stay available. Model-written selectors
+run before Spytial accepts them. An explicit ask fails loudly. The user decides
+what becomes the final layout.

--- a/docs/usage/diagramming.md
+++ b/docs/usage/diagramming.md
@@ -1,6 +1,8 @@
 # Diagramming
 
-`spytial.diagram()` turns Python objects into a spatial diagram. It works with built-in containers, dataclasses, custom classes, and graph-like structures.
+`spytial.diagram()` converts Python objects into a spatial diagram. It
+works with built-in containers, dataclasses, custom classes, and
+graph-like structures.
 
 ## Basic usage
 
@@ -26,7 +28,8 @@ spytial.diagram(data, width=900, height=600, title="My Diagram")
 
 ## Passing annotations with `as_type`
 
-Use `AnnotatedType` or `typing.Annotated` to attach spatial constraints to a type you want the object treated as.
+Use `AnnotatedType` or `typing.Annotated` to attach spatial constraints
+to a type. The object is then treated as that type.
 
 ```python
 from typing import Dict, List
@@ -45,9 +48,9 @@ spytial.diagram(graph, as_type=Graph)
 
 ## Common workflow
 
-For non-trivial objects, the usual workflow is:
+For complex objects, use the usual workflow:
 
-1. `spytial.evaluate(obj)` to confirm the serialized atoms and relations.
-2. `spytial.diagram(obj)` to see the layout.
-3. Add decorators or `AnnotatedType(...)` annotations if you want more control over layout or styling.
+1. Call `spytial.evaluate(obj)` to confirm the serialized atoms and relations.
+2. Call `spytial.diagram(obj)` to see the layout.
+3. Add decorators or `AnnotatedType(...)` annotations for more control over layout or styling.
 

--- a/docs/usage/evaluator.md
+++ b/docs/usage/evaluator.md
@@ -1,6 +1,8 @@
 # Evaluator
 
-`spytial.evaluate()` renders a lightweight view of the serialized data instance. Use it when you want to check how Python objects are being translated before you worry about layout.
+`spytial.evaluate()` renders a lightweight view of the serialized data
+instance. Use this function to check how Python objects translate before
+layout work begins.
 
 ## Basic usage
 
@@ -12,11 +14,11 @@ spytial.evaluate({"total": 3, "items": [1, 2, 3]})
 
 ## When it helps
 
-The evaluator is especially useful when:
+The evaluator helps in these cases:
 
-- a custom class is not relationalizing the way you expect
-- a selector is not matching what you think it is matching
-- you are writing a custom relationalizer and want to inspect the emitted atoms and relations
+- a custom class does not relationalize as expected
+- a selector does not match as expected
+- a custom relationalizer is being written, and its emitted atoms and relations need inspection
 
 ## Display methods
 

--- a/docs/usage/sequences.md
+++ b/docs/usage/sequences.md
@@ -4,10 +4,10 @@
 Sequence functionality is very much experimental.
 ```
 
-`spytial.sequence()` lets you record a series of snapshots of a data structure and play them back as an interactive step-by-step visualization. It is designed for two use cases:
+`spytial.sequence()` records a series of snapshots of a data structure. It plays the snapshots back as an interactive step-by-step visualization. The function is designed for two use cases:
 
-- **Algorithm tracing** — call `.record()` inside an algorithm as each step completes.
-- **Temporal snapshots** — record a structure at multiple points in time.
+- **Algorithm tracing**. Call `.record()` inside an algorithm as each step completes.
+- **Temporal snapshots**. Record a structure at multiple points in time.
 
 ## Basic usage
 
@@ -27,8 +27,8 @@ seq.diagram()
 
 `record()` accepts two optional keyword arguments that give frames semantic meaning in the viewer:
 
-- `label` — a short one-liner shown in the status bar (`Step 3 / 24 — rotate left at node 5`) and as the scrubber tooltip. Whitespace is stripped; truncated to 200 characters.
-- `note` — a longer description (multi-line OK) shown in a collapsible panel below the controls. Hidden on frames where no note was recorded.
+- `label`. A short single line shown in the status bar (`Step 3 / 24, rotate left at node 5`) and as the scrubber tooltip. Whitespace is stripped. The label is truncated to 200 characters.
+- `note`. A longer description (multiple lines permitted) shown in a collapsible panel below the controls. The note is hidden on frames where no note was recorded.
 
 ```python
 with spytial.sequence() as seq:
@@ -36,13 +36,13 @@ with spytial.sequence() as seq:
     rotate_left(tree, node)
     seq.record(tree, label="left-rotate at root",
                note="Promotes the right child so the new tree is height-balanced.")
-    seq.record(tree)  # no label / no note — viewer falls back to "Step 3 / 3"
+    seq.record(tree)  # no label and no note; viewer falls back to "Step 3 / 3"
 seq.diagram()
 ```
 
-Both arguments are optional and independent — a frame can have a label, a note, both, or neither. The zero-kwarg form (`seq.record(obj)`) keeps working unchanged.
+Both arguments are optional and independent. A frame can have a label, a note, both, or neither. The form with no keyword arguments (`seq.record(obj)`) continues to work unchanged.
 
-This is the recommended way to narrate algorithms. A typical pattern is to wrap `record()` in a helper that takes the label as its first argument:
+This method is recommended to narrate algorithms. A typical pattern wraps `record()` in a helper that takes the label as its first argument:
 
 ```python
 class RBTree:
@@ -72,11 +72,11 @@ The `sequence_policy` controls how the frontend positions atoms across frames:
 | `ignore_history` | Each frame is laid out independently |
 | `random_positioning` | Random placement each frame |
 
-The `sequence_policy=` argument sets the **initial** policy, but viewers can switch on the fly using a dropdown in the header — useful for comparing how each policy presents the same algorithm. Switching mid-sequence re-applies the previous → current transition with the new policy; on step 0 (which has no transition) the change takes effect on the next navigation.
+The `sequence_policy=` argument sets the **initial** policy. Viewers can switch policy with a dropdown in the header. This switch helps to compare how each policy presents the same algorithm. A switch mid-sequence re-applies the previous to current transition with the new policy. On step 0, which has no transition, the change takes effect on the next navigation.
 
 ## In-place mutation (most common)
 
-When the **same Python objects** are mutated between frames, atom IDs are stable automatically — no configuration needed. The recorder uses a single shared builder whose persistent ID table survives across `.record()` calls.
+When the **same Python objects** are mutated between frames, atom IDs are stable automatically. No configuration is needed. The recorder uses a single shared builder with a persistent ID table. The table survives across `.record()` calls.
 
 ```python
 class Node:
@@ -96,7 +96,7 @@ with spytial.sequence(sequence_policy="stability") as seq:
 seq.diagram()
 ```
 
-This pattern works well for BST insertion, sorting algorithms, graph BFS/DFS — any algorithm that operates on a shared mutable structure.
+This pattern works well for BST insertion, sorting algorithms, and graph BFS/DFS. It works for any algorithm that operates on a shared mutable structure.
 
 ## Snapshot / deepcopy workflow
 
@@ -116,11 +116,11 @@ with spytial.sequence(
 seq.diagram()
 ```
 
-`identity` must return a `str` or `None`. Objects that share the same key across frames are rendered as the same atom and animated smoothly between positions.
+`identity` shall return a `str` or `None`. Objects that share the same key across frames are rendered as the same atom and animated smoothly between positions.
 
 ## Passing `as_type`
 
-You can apply class-level spatial annotations to every recorded object via `as_type`:
+Class-level spatial annotations can be applied to every recorded object via `as_type`:
 
 ```python
 seq = spytial.sequence(as_type=MyAnnotatedType, sequence_policy="stability")
@@ -136,7 +136,7 @@ seq.diagram(method="inline")     # force Jupyter inline output
 seq.diagram(width=1200, height=800, title="My algorithm")
 ```
 
-You can also set defaults at construction time and override at render time:
+Defaults can also be set at construction time and overridden at render time:
 
 ```python
 seq = spytial.sequence(method="file", auto_open=False)
@@ -146,7 +146,7 @@ seq.diagram(title="Final render")
 
 ## Using without a context manager
 
-`SequenceRecorder` does not require `with`. The context manager is purely a readability convention — `__exit__` does nothing special.
+`SequenceRecorder` does not require `with`. The context manager is only a readability convention. `__exit__` does nothing special.
 
 ```python
 seq = spytial.sequence(sequence_policy="stability")

--- a/docs/usage/structured-input.md
+++ b/docs/usage/structured-input.md
@@ -1,8 +1,8 @@
 # Structured Input
 
-`spytial.edit()` is the interactive counterpart to [`spytial.diagram()`](diagramming.md). Where `diagram()` *shows* a value, `edit()` lets you *build or change* one visually and hand it back to Python — for **any** value, not just dataclasses.
+`spytial.edit()` is the interactive counterpart to [`spytial.diagram()`](diagramming.md). `diagram()` shows a value. `edit()` builds or changes a value visually and returns it to Python. `edit()` accepts any value, not only dataclasses.
 
-## edit() — edit, click Done, get the value back
+## edit(): edit, click Done, get the value back
 
 ```python
 from dataclasses import dataclass
@@ -15,12 +15,12 @@ class TreeNode:
     left: Optional["TreeNode"] = None
     right: Optional["TreeNode"] = None
 
-result = spytial.edit(TreeNode())   # opens the editor, blocks until you click Done
+result = spytial.edit(TreeNode())   # opens the editor; blocks until Done is clicked
 ```
 
-`edit()` serves the editor as a page — inline in a local Jupyter cell, or a browser tab from a script — **blocks** until you click **Done** (or **Cancel**), then reconstructs a fresh Python object with [`reify`](#reify-directly) and returns it. The value you passed in is never mutated.
+`edit()` serves the editor as a page. The page appears inline in a local Jupyter cell, or in a browser tab from a script. `edit()` blocks until the user clicks **Done** (or **Cancel**). `edit()` then reconstructs a fresh Python object with [`reify`](#reify-directly) and returns it. `edit()` does not mutate the input value.
 
-No Jupyter comm and no widget framework — only the standard library and a browser. It can't hang your kernel: if the editor never connects, stops responding, or you close it, `edit()` unblocks and returns per `on_cancel`. In **pyodide** and **hosted notebooks** (Colab, JupyterHub, Binder) the browser can't reach the local server, so `edit()` prints a note, shows [`edit_html()`](#standalone-html-no-server) (Export button) instead, and returns `None`.
+`edit()` uses no Jupyter comm and no widget framework. `edit()` uses only the standard library and a browser. `edit()` cannot hang the kernel. If the editor never connects, stops responding, or the user closes it, `edit()` unblocks and returns per `on_cancel`. In pyodide and hosted notebooks (Colab, JupyterHub, Binder), the browser cannot reach the local server. In this case, `edit()` prints a note, shows [`edit_html()`](#standalone-html-no-server) (Export button) instead, and returns `None`.
 
 ### Any value, not just dataclasses
 
@@ -32,11 +32,11 @@ spytial.edit([{"x": 1}, {"x": 2}])            # list
 spytial.edit(my_graph_node)                    # an arbitrary object (cycles ok)
 ```
 
-When the seed is a dataclass, declared field defaults fill for any field the round-trip dropped. Other values reconstruct via the general path (builtins rebuild as themselves; arbitrary classes via their import path).
+When the seed is a dataclass, declared field defaults fill any field that the round-trip dropped. Other values reconstruct through the general path: builtins rebuild as themselves, and arbitrary classes rebuild through their import path.
 
 ### Cancelling
 
-Click **Cancel**, close the tab, or interrupt the kernel, and `edit()` returns per `on_cancel`:
+Click **Cancel**, close the tab, or interrupt the kernel. `edit()` then returns per `on_cancel`:
 
 ```python
 spytial.edit(x)                      # -> the original x, unchanged (default: on_cancel="seed")
@@ -44,11 +44,11 @@ spytial.edit(x, on_cancel="none")    # -> None
 spytial.edit(x, on_cancel="raise")   # -> raises spytial.EditCancelled
 ```
 
-Defaulting to `"seed"` keeps `edit()` total — you always get back a usable value of the same kind, and `None` is reserved for "the committed value really is `None`."
+The default `"seed"` keeps `edit()` total. A call always returns a usable value of the same kind. `None` is reserved for the case where the committed value really is `None`.
 
 ## Reify directly
 
-If you already have a data instance (from `build_instance`, a saved file, or the editor) you can reconstruct the object without the UI:
+If a data instance already exists (from `build_instance`, a saved file, or the editor), reconstruct the object without the UI:
 
 ```python
 di  = spytial.CnDDataInstanceBuilder().build_instance(my_value)
@@ -60,7 +60,7 @@ txt = spytial.replit(di)           # repr() of what reify() would return
 
 ## Standalone HTML (no server)
 
-`spytial.edit_html()` renders the editor as standalone HTML and uses the built-in **Export** button to copy constructor code — handy where the local server isn't reachable (e.g. pyodide). It also accepts any value.
+`spytial.edit_html()` renders the editor as standalone HTML. It uses the built-in **Export** button to copy constructor code. This function is useful where the local server is not reachable (for example, pyodide). `edit_html()` also accepts any value.
 
 ```python
 spytial.edit_html(TreeNode())                 # inline iframe (notebook), else a browser tab
@@ -70,7 +70,7 @@ spytial.edit_html([1, 2, 3], method="inline") # force an inline iframe
 
 ## Naming note
 
-This module was previously `dataclass_builder` and was dataclass-only (a `DataClassBuilder` anywidget widget + a `dataclass_builder()` HTML helper). It now lives in `spytial.structured_input`, accepts any value, and exposes just two verbs: `edit()` (open editor, return the value on Done) and `edit_html()` (standalone HTML). The old `DataClassBuilder` / `dataclass_builder()` names and the anywidget widget were removed.
+This module was previously named `dataclass_builder` and supported dataclasses only (a `DataClassBuilder` anywidget widget and a `dataclass_builder()` HTML helper). The module now lives in `spytial.structured_input`, accepts any value, and exposes two verbs: `edit()` (open editor, return the value on Done) and `edit_html()` (standalone HTML). The old `DataClassBuilder` and `dataclass_builder()` names and the anywidget widget were removed.
 
 !!! tip
-    Start from a minimal seed (`TreeNode()`, `{}`, `[]`) and build up visually before clicking **Done**.
+    Start from a minimal seed (`TreeNode()`, `{}`, `[]`). Build the value visually before clicking **Done**.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,16 +10,18 @@ nav:
   - Home: index.md
   - Getting Started: getting-started.md
   - Playground: playground/index.html
-  - Diagramming: usage/diagramming.md
-  - Sequences: usage/sequences.md
-  - Evaluator: usage/evaluator.md
-  - Operations: operations.md
   - Selectors: selectors.md
-  - Structured Input: usage/structured-input.md
-  - Custom Relationalizers: relationalizers.md
-  - Suggest a Specification: suggest.md
-  - CLRS Notebook Examples: examples/spytial-clrs.md
-  - API Reference: reference/api.md
+  - Operations: operations.md
+  - Guides:
+      - Diagramming: usage/diagramming.md
+      - Sequences: usage/sequences.md
+      - Structured Input: usage/structured-input.md
+      - Custom Relationalizers: relationalizers.md
+      - Suggesting Annotations: suggest.md
+  - Reference:
+      - Evaluator: usage/evaluator.md
+      - API Reference: reference/api.md
+      - CLRS Notebook Examples: examples/spytial-clrs.md
 
 theme:
   name: material

--- a/spytial/_version.py
+++ b/spytial/_version.py
@@ -1,3 +1,3 @@
 """Package version source of truth."""
 
-__version__ = "1.9.1"
+__version__ = "1.9.2"


### PR DESCRIPTION
## What

A documentation-only pass across the MkDocs site.

**Register — Simple Technical English.** Every prose page is rewritten in a controlled ISO / ASD-STE100 register: impersonal and imperative (no second person), present tense, ISO/IEC Directives verbal forms (`shall`/`should`/`may`/`can`), short single-idea sentences, one term per concept, and no em dashes or curly quotes.

**Navigation — slimmer bar.** The top nav goes from 13 flat tabs to 5 top-level items (Home, Getting Started, Playground, Selectors, Operations) plus **Guides** and **Reference** groups holding the secondary pages. Keeps the key items prominent; folds the rest into grouped sections (sidebar at desktop width, hamburger drawer when narrow).

**Suggest page — reworked for the Python audience.**
- Retitled **"Suggesting a Spytial specification" → "Suggesting Spytial Annotations"** and dropped "specification" jargon from the prose. Python users annotate classes; they do not author specs. The `SpecDraft` class name (the real return type) stays.
- Removed the mermaid flowchart and restructured into prose.
- Rebuilt the intro around the blank-page problem — a draft that is almost right is easier to fix than a blank page is to fill.
- Tightened "How it works" from abstract framing to concrete behavior (what `suggest` returns, the deterministic default, how `enrich=` model output is validated against your example values, and that nothing auto-applies).
- Cut "How deterministic suggestion decides" to a few example mappings and folded in "register your own heuristics."
- Commented out the "Engineering considerations" internals (kept in source, not rendered).

## Why

The prior prose mixed registers and read as machine-written in places (em-dash-heavy, second-person, abstract). The controlled register is consistent and unambiguous. The suggest page in particular over-indexed on internal design rationale and "spec" terminology that Python-package users do not share.

## Notes for reviewers

- **Docs-only**, but bumps `spytial/_version.py` 1.9.1 → 1.9.2 per the per-PR release convention. If a docs-only release is not wanted, drop that one line before merge.
- `reference/api.md` is untouched — it is generated by `mkdocstrings` from docstrings, so its prose lives in Python source (separate change).
- Verified `mkdocs build` is clean; no em dashes, curly quotes, second-person "you", or requirement-"must" in rendered prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)