### PR TITLE
Treat a field as schema: declare unpopulated ones, stop hiding underscored ones

### DIFF
--- a/docs/relationalizers.md
+++ b/docs/relationalizers.md
@@ -40,6 +40,39 @@ class WidgetRelationalizer(RelationalizerBase):
         return [atom], []
 ```
 
+## Declared relations
+
+`relationalize()` is extensional. It emits a tuple only where an instance
+holds a value. A field that no instance populates therefore leaves no trace,
+and a selector that names that field resolves to an atom literal rather than
+to a relation.
+
+A relationalizer may override `declared_relations(obj)` to name the relations
+that the type declares, whether or not any instance populates them. Spytial
+emits each declared name that no instance populated as a relation with no
+tuples, so the data instance carries the shape of the type and not only its
+contents.
+
+```python
+@relationalizer(priority=100)
+class WidgetRelationalizer(RelationalizerBase):
+    def declared_relations(self, obj):
+        return ["label", "parent"]
+```
+
+The built-in relationalizers declare:
+
+- dataclasses: every field returned by `dataclasses.fields()`
+- generic objects: every non-private name annotated or slotted across the
+  method resolution order
+
+Containers and primitives declare nothing. The default implementation returns
+an empty list, so a relationalizer that renames fields on output does not
+declare names that it never populates.
+
+A declared relation carries an arity of 2. Arity cannot be measured without a
+tuple.
+
 ## Built-in coverage first
 
 Before writing a custom relationalizer, check whether the built-ins cover

--- a/docs/relationalizers.md
+++ b/docs/relationalizers.md
@@ -63,8 +63,14 @@ class WidgetRelationalizer(RelationalizerBase):
 The built-in relationalizers declare:
 
 - dataclasses: every field returned by `dataclasses.fields()`
-- generic objects: every non-private name annotated or slotted across the
-  method resolution order
+- generic objects: every name annotated or slotted across the method
+  resolution order
+
+Both include names with a single leading underscore. A field is schema, not a
+privacy boundary: Python decides state by assignment alone, and `_next`
+participates in the structure exactly as `next` does. Names that the language
+itself hides are excluded — dunders, and name-mangled `__x` attributes stored
+as `_Class__x`. To hide a field from a diagram, use a directive.
 
 Containers and primitives declare nothing. The default implementation returns
 an empty list, so a relationalizer that renames fields on output does not

--- a/spytial/_version.py
+++ b/spytial/_version.py
@@ -1,3 +1,3 @@
 """Package version source of truth."""
 
-__version__ = "1.9.2"
+__version__ = "1.10.0"

--- a/spytial/domain_relationalizers/base.py
+++ b/spytial/domain_relationalizers/base.py
@@ -104,6 +104,31 @@ class RelationalizerBase(abc.ABC):
         """
         pass
 
+    def declared_relations(self, obj: Any) -> List[str]:
+        """
+        Return the relation names *obj*'s type declares, populated or not.
+
+        ``relationalize`` is extensional: it emits a tuple only where the
+        instance holds a value. A field that no walked instance populates
+        therefore leaves no trace at all, and a selector naming it resolves to
+        an arity-0 atom literal — indistinguishable from a misspelling. Naming
+        the field here lets the builder emit it as an empty relation instead,
+        so the data instance carries the type's shape and not only its
+        contents.
+
+        Args:
+            obj: The object whose type is being described
+
+        Returns:
+            Relation names declared by the type; the builder emits any that no
+            instance populated as a relation with no tuples.
+
+        Defaults to none. Containers and primitives have no declared schema,
+        and a relationalizer that renames fields (TupleRelationalizer emits
+        ``t0``, ``t1``, …) would otherwise declare names it never populates.
+        """
+        return []
+
     def _try_get_variable_name(
         self, obj: Any, caller_namespace: Optional[Dict] = None
     ) -> Optional[str]:

--- a/spytial/domain_relationalizers/dataclass_relationalizer.py
+++ b/spytial/domain_relationalizers/dataclass_relationalizer.py
@@ -11,6 +11,11 @@ class DataclassRelationalizer(RelationalizerBase):
     def can_handle(self, obj: Any) -> bool:
         return dataclasses.is_dataclass(obj)
 
+    def declared_relations(self, obj: Any) -> List[str]:
+        # Every declared field, matching the loop in relationalize below —
+        # including underscore-prefixed ones, for the same reason.
+        return [field.name for field in dataclasses.fields(obj)]
+
     def relationalize(self, obj: Any, walker_func) -> Tuple[List[Atom], List[Relation]]:
         obj_id = walker_func._get_id(obj)
         typ = type(obj).__name__
@@ -33,7 +38,16 @@ class DataclassRelationalizer(RelationalizerBase):
         # belongs in a directive rather than here.
         relations = []
         for field in dataclasses.fields(obj):
-            value = getattr(obj, field.name)
+            try:
+                value = getattr(obj, field.name)
+            except AttributeError:
+                # A field(init=False) its owner never assigned — legal Python
+                # (the usual __post_init__ idiom, skipped on some branch), and
+                # reading it raises. Emitting no tuple is the honest answer;
+                # declared_relations still carries the name into the instance,
+                # so the field shows up as an empty relation rather than
+                # crashing the whole build.
+                continue
             vid = walker_func(value)
             relations.append(Relation(field.name, [obj_id, vid]))
 

--- a/spytial/domain_relationalizers/generic_object_relationalizer.py
+++ b/spytial/domain_relationalizers/generic_object_relationalizer.py
@@ -15,6 +15,40 @@ import inspect
 from typing import Any, List, Tuple
 from .base import RelationalizerBase, Atom, Relation
 
+try:  # Python 3.14+ (PEP 649) exposes the annotation formats here.
+    import annotationlib
+except ImportError:  # pragma: no cover - the common path on older interpreters
+    annotationlib = None
+
+
+def _own_annotation_names(klass: type) -> List[str]:
+    """Names *klass* itself annotates, ignoring the ones it inherits.
+
+    Python 3.14 (PEP 649) keeps class annotations behind a lazily-called
+    annotate function, so ``vars(klass)`` no longer carries an
+    ``__annotations__`` entry and a plain dict lookup would report every class
+    as fieldless. ``inspect.get_annotations`` reads them through the runtime
+    API and, for a class, returns only that class's own annotations — which is
+    what the MRO walk wants, and why ``klass.__annotations__`` is not consulted
+    directly (it silently falls back to an inherited dict).
+
+    Only the names are used, so the unevaluated form is requested wherever the
+    interpreter offers the choice: under 3.14 the default format evaluates each
+    annotation, and an unresolvable forward reference would raise where a dict
+    lookup never could.
+    """
+    get_annotations = getattr(inspect, "get_annotations", None)
+    if get_annotations is None:  # Python < 3.10
+        return list(vars(klass).get("__annotations__", {}))
+
+    kwargs = {}
+    if annotationlib is not None:
+        kwargs["format"] = annotationlib.Format.STRING
+    try:
+        return list(get_annotations(klass, **kwargs))
+    except Exception:
+        return list(vars(klass).get("__annotations__", {}))
+
 
 class GenericObjectRelationalizer(RelationalizerBase):
     """Handles generic objects with __dict__ or __slots__."""
@@ -35,19 +69,15 @@ class GenericObjectRelationalizer(RelationalizerBase):
     def declared_relations(self, obj: Any) -> List[str]:
         """Annotated and slotted names across the MRO, set or not.
 
-        Reads ``vars(klass)`` rather than ``klass.__annotations__``: the latter
-        falls back to an inherited dict on a class that declares none of its
-        own, which would re-attribute a base's fields at every level. Private
-        names are filtered to match the skip rule in relationalize — declaring
-        one would emit a relation nothing can ever populate.
+        Private names are filtered to match the skip rule in relationalize —
+        declaring one would emit a relation nothing can ever populate.
         """
         names: List[str] = []
         for klass in type(obj).__mro__:
             if klass is object:
                 continue
-            attrs = vars(klass)
-            declared = list(attrs.get("__annotations__", {}))
-            slots = attrs.get("__slots__", ())
+            declared = _own_annotation_names(klass)
+            slots = vars(klass).get("__slots__", ())
             # __slots__ accepts a bare string for the single-slot case.
             declared.extend((slots,) if isinstance(slots, str) else slots)
             for name in declared:

--- a/spytial/domain_relationalizers/generic_object_relationalizer.py
+++ b/spytial/domain_relationalizers/generic_object_relationalizer.py
@@ -50,6 +50,27 @@ def _own_annotation_names(klass: type) -> List[str]:
         return list(vars(klass).get("__annotations__", {}))
 
 
+def _mangling_prefixes(cls: type) -> Tuple[str, ...]:
+    """The ``_Class__`` prefixes CPython gives ``__x`` names written in this MRO."""
+    return tuple(f"_{k.__name__.lstrip('_')}__" for k in cls.__mro__ if k is not object)
+
+
+def _is_hidden(name: str, mangling_prefixes: Tuple[str, ...]) -> bool:
+    """True for names the *language* hides, rather than ones convention marks.
+
+    A dunder is interpreter machinery, and a ``_Class__x`` name was written
+    ``__x`` — private to the class body by an explicit language rule. A single
+    leading underscore is convention only: Python decides state by assignment
+    alone, and ``_next`` participates in the structure exactly as ``next``
+    does. This is the reasoning DataclassRelationalizer already records for
+    dataclass fields; applying it here keeps a ``_next`` pointer drawing an
+    edge whether or not its class happens to be a dataclass.
+    """
+    if name.startswith("__") and name.endswith("__"):
+        return True
+    return any(name.startswith(prefix) for prefix in mangling_prefixes)
+
+
 class GenericObjectRelationalizer(RelationalizerBase):
     """Handles generic objects with __dict__ or __slots__."""
 
@@ -69,9 +90,10 @@ class GenericObjectRelationalizer(RelationalizerBase):
     def declared_relations(self, obj: Any) -> List[str]:
         """Annotated and slotted names across the MRO, set or not.
 
-        Private names are filtered to match the skip rule in relationalize —
-        declaring one would emit a relation nothing can ever populate.
+        Filtered by the same rule relationalize applies, so a declared name is
+        always one an instance could populate.
         """
+        mangling_prefixes = _mangling_prefixes(type(obj))
         names: List[str] = []
         for klass in type(obj).__mro__:
             if klass is object:
@@ -81,7 +103,7 @@ class GenericObjectRelationalizer(RelationalizerBase):
             # __slots__ accepts a bare string for the single-slot case.
             declared.extend((slots,) if isinstance(slots, str) else slots)
             for name in declared:
-                if not name.startswith("_") and name not in names:
+                if not _is_hidden(name, mangling_prefixes) and name not in names:
                     names.append(name)
         return names
 
@@ -97,10 +119,13 @@ class GenericObjectRelationalizer(RelationalizerBase):
         relations = []
 
         # Use inspect to get all members, filtering for relevant attributes
+        mangling_prefixes = _mangling_prefixes(type(obj))
         for name, value in inspect.getmembers(obj):
-            # Skip private attributes, methods, functions, modules, and built-ins
+            # Skip language-hidden names, methods, functions, modules, and built-ins.
+            # A single leading underscore is not a skip: `_next` is structure, and
+            # dropping it left a pointer drawing no edge on every non-dataclass.
             if (
-                name.startswith("_")
+                _is_hidden(name, mangling_prefixes)
                 or inspect.ismethod(value)
                 or inspect.isfunction(value)
                 or inspect.ismodule(value)

--- a/spytial/domain_relationalizers/generic_object_relationalizer.py
+++ b/spytial/domain_relationalizers/generic_object_relationalizer.py
@@ -32,6 +32,29 @@ class GenericObjectRelationalizer(RelationalizerBase):
             )
         )
 
+    def declared_relations(self, obj: Any) -> List[str]:
+        """Annotated and slotted names across the MRO, set or not.
+
+        Reads ``vars(klass)`` rather than ``klass.__annotations__``: the latter
+        falls back to an inherited dict on a class that declares none of its
+        own, which would re-attribute a base's fields at every level. Private
+        names are filtered to match the skip rule in relationalize — declaring
+        one would emit a relation nothing can ever populate.
+        """
+        names: List[str] = []
+        for klass in type(obj).__mro__:
+            if klass is object:
+                continue
+            attrs = vars(klass)
+            declared = list(attrs.get("__annotations__", {}))
+            slots = attrs.get("__slots__", ())
+            # __slots__ accepts a bare string for the single-slot case.
+            declared.extend((slots,) if isinstance(slots, str) else slots)
+            for name in declared:
+                if not name.startswith("_") and name not in names:
+                    names.append(name)
+        return names
+
     def relationalize(self, obj: Any, walker_func) -> Tuple[List[Atom], List[Relation]]:
         obj_id = walker_func._get_id(obj)
         typ = type(obj).__name__

--- a/spytial/provider_system.py
+++ b/spytial/provider_system.py
@@ -187,6 +187,10 @@ class CnDDataInstanceBuilder:
         self._seen = {}
         self._atoms = []
         self._rels = {}
+        # Relation names declared by the types walked, in first-encounter
+        # order. Any that no instance populated is emitted as an empty
+        # relation, so the instance carries each type's declared shape.
+        self._declared_rels: List[str] = []
         self._id_counter = 0
         self._preserve_object_ids = preserve_object_ids
         self._identity_resolver = identity_resolver
@@ -223,6 +227,7 @@ class CnDDataInstanceBuilder:
         self._seen.clear()
         self._atoms.clear()
         self._rels.clear()
+        self._declared_rels.clear()
         self._id_counter = 0
         self._build_identity_objects = {}
         self._collected_decorators = {"constraints": [], "directives": []}
@@ -326,6 +331,24 @@ class CnDDataInstanceBuilder:
                     "name": rel_name,
                     "types": relation_types,
                     "tuples": typed_tuples,
+                }
+            )
+
+        # Declared by a walked type but populated by no instance. Emitting the
+        # relation empty keeps the instance faithful to the type's shape: a
+        # field is schema, so `b` should be a relation that happens to hold
+        # nothing rather than a name the datum has never heard of. Arity can't
+        # be measured without a tuple, so these default to binary like the
+        # empty case above.
+        for rel_name in self._declared_rels:
+            if rel_name in self._rels:
+                continue
+            relations.append(
+                {
+                    "id": rel_name,
+                    "name": rel_name,
+                    "types": ["object", "object"],
+                    "tuples": [],
                 }
             )
 
@@ -533,6 +556,19 @@ class CnDDataInstanceBuilder:
         relationalizer = RelationalizerRegistry.find_relationalizer(obj)
         if relationalizer is None:
             raise ValueError(f"No relationalizer found for object of type {type(obj)}")
+
+        # Record the relation names this object's type declares before asking
+        # for its contents, so a field no instance ever populates still reaches
+        # the data instance (as an empty relation) instead of vanishing.
+        try:
+            for declared_name in relationalizer.declared_relations(obj):
+                if declared_name not in self._declared_rels:
+                    self._declared_rels.append(declared_name)
+        except Exception:
+            # A third-party relationalizer's schema hook must not be able to
+            # fail a build that would otherwise succeed — same posture as
+            # decorator collection above.
+            pass
 
         # Get atoms and relations from relationalizer
         atoms_list, relations_list = relationalizer.relationalize(obj, self)

--- a/test/test_declared_relations.py
+++ b/test/test_declared_relations.py
@@ -123,6 +123,37 @@ def test_inherited_annotations_are_declared():
     assert rels["own"] == [["n0", "1"]]
 
 
+def test_annotation_names_are_read_per_class_not_inherited():
+    """The MRO walk needs each class's own annotations.
+
+    Reading them off the class attribute would re-attribute a base's fields at
+    every level, because `klass.__annotations__` falls back to an inherited
+    dict on a class that declares none of its own.
+    """
+    from spytial.domain_relationalizers.generic_object_relationalizer import (
+        _own_annotation_names,
+    )
+
+    class NoOwnAnnotations(Base):
+        pass
+
+    assert _own_annotation_names(Base) == ["inherited"]
+    assert _own_annotation_names(Derived) == ["own"]
+    assert _own_annotation_names(NoOwnAnnotations) == []
+
+
+def test_annotation_names_survive_an_unresolvable_forward_reference():
+    """Python 3.14 evaluates annotations on access; only the names are wanted."""
+    from spytial.domain_relationalizers.generic_object_relationalizer import (
+        _own_annotation_names,
+    )
+
+    class Forward:
+        later: "NeverDefinedAnywhere"  # noqa: F821
+
+    assert _own_annotation_names(Forward) == ["later"]
+
+
 def test_private_annotations_are_not_declared():
     """relationalize skips underscore names, so declaring one is unpopulatable."""
 

--- a/test/test_declared_relations.py
+++ b/test/test_declared_relations.py
@@ -154,17 +154,64 @@ def test_annotation_names_survive_an_unresolvable_forward_reference():
     assert _own_annotation_names(Forward) == ["later"]
 
 
-def test_private_annotations_are_not_declared():
-    """relationalize skips underscore names, so declaring one is unpopulatable."""
+def test_single_underscore_names_are_structure_not_privacy():
+    """`_next` is state like any other — the rule dataclasses already follow."""
 
-    class Private:
-        _hidden: int
+    class Underscored:
+        _next: object
         shown: int
 
         def __init__(self):
             self.shown = 1
 
-    assert "_hidden" not in _relations(Private())
+    rels = _relations(Underscored())
+    assert rels["_next"] == []
+    assert rels["shown"] == [["n0", "1"]]
+
+
+def test_language_hidden_names_are_skipped():
+    """Dunders and name-mangled attributes are hidden by the language itself."""
+
+    class Hidden:
+        _visible: int
+
+        def __init__(self):
+            self._visible = 1
+            self.__mangled = 2  # stored as _Hidden__mangled
+
+    rels = _relations(Hidden())
+    assert rels["_visible"] == [["n0", "1"]]
+    assert "_Hidden__mangled" not in rels
+    assert not [name for name in rels if name.startswith("__")]
+
+
+def test_mangled_names_are_skipped_for_the_declaring_base():
+    """Mangling uses the class that wrote the name, not the instance's class."""
+
+    class MangledBase:
+        def __init__(self):
+            self.__owned = 1  # stored as _MangledBase__owned
+
+    class MangledChild(MangledBase):
+        pass
+
+    assert "_MangledBase__owned" not in _relations(MangledChild())
+
+
+def test_underscored_pointer_draws_an_edge_like_its_dataclass_twin():
+    """The asymmetry this closes: same shape, same relations, either spelling."""
+
+    @dataclasses.dataclass
+    class DcNode:
+        value: int
+        _next: object = None
+
+    class PlainNode:
+        def __init__(self):
+            self.value = 1
+            self._next = None
+
+    assert set(_relations(DcNode(1))) == set(_relations(PlainNode()))
 
 
 # --------------------------------------------------------------------------- #

--- a/test/test_declared_relations.py
+++ b/test/test_declared_relations.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Declared-but-unpopulated fields reach the data instance as empty relations.
+
+The relationalizers are extensional — they emit a tuple only where an instance
+holds a value. Without a schema channel, a field that no walked instance
+populates leaves no trace, and a selector naming it resolves to an arity-0 atom
+literal, indistinguishable from a misspelling. ``declared_relations`` carries
+the type's shape across so the field appears as a relation holding nothing.
+"""
+
+import dataclasses
+from typing import Optional
+
+import pytest
+
+from spytial import CnDDataInstanceBuilder, reify
+
+
+def _relations(obj):
+    """Map relation name -> list of atom-id tuples for a freshly built instance."""
+    instance = CnDDataInstanceBuilder().build_instance(obj)
+    return {r["name"]: [t["atoms"] for t in r["tuples"]] for r in instance["relations"]}
+
+
+# --------------------------------------------------------------------------- #
+# Dataclasses
+# --------------------------------------------------------------------------- #
+
+
+@dataclasses.dataclass
+class OptionalField:
+    a: int
+    b: Optional[int] = None
+
+
+@dataclasses.dataclass
+class UnsetInitFalse:
+    a: int
+    b: int = dataclasses.field(init=False)
+
+
+def test_dataclass_none_valued_field_is_populated_not_empty():
+    """A field holding None is populated — it points at the NoneType atom."""
+    rels = _relations(OptionalField(a=1))
+    assert rels["b"] == [["n0", "None"]]
+
+
+def test_dataclass_unassigned_init_false_field_is_declared_but_empty():
+    """field(init=False) the owner never assigned: no tuple, but the name survives."""
+    rels = _relations(UnsetInitFalse(a=1))
+    assert rels["b"] == []
+    assert rels["a"] == [["n0", "1"]]
+
+
+def test_dataclass_unassigned_init_false_field_does_not_raise():
+    """Reading such a field raises AttributeError; the build must not propagate it."""
+    CnDDataInstanceBuilder().build_instance(UnsetInitFalse(a=1))
+
+
+# --------------------------------------------------------------------------- #
+# Plain classes
+# --------------------------------------------------------------------------- #
+
+
+class AnnotatedOnly:
+    """`b` is annotated at class level but only assigned on one branch."""
+
+    b: int
+
+    def __init__(self, a, set_b=False):
+        self.a = a
+        if set_b:
+            self.b = 99
+
+
+class Slotted:
+    __slots__ = ("a", "b")
+
+    def __init__(self, a):
+        self.a = a
+
+
+class SingleSlot:
+    __slots__ = "only"
+
+
+class Base:
+    inherited: int
+
+
+class Derived(Base):
+    own: int
+
+    def __init__(self):
+        self.own = 1
+
+
+def test_plain_class_annotation_only_field_is_declared_but_empty():
+    rels = _relations(AnnotatedOnly(1))
+    assert rels["b"] == []
+
+
+def test_plain_class_assigned_field_is_unaffected():
+    rels = _relations(AnnotatedOnly(1, set_b=True))
+    assert rels["b"] == [["n0", "99"]]
+
+
+def test_unassigned_slot_is_declared_but_empty():
+    rels = _relations(Slotted(1))
+    assert rels["b"] == []
+
+
+def test_slots_accepts_a_bare_string():
+    """__slots__ = "only" is the legal single-slot spelling, not an iterable of chars."""
+    rels = _relations(SingleSlot())
+    assert rels["only"] == []
+    assert "o" not in rels
+
+
+def test_inherited_annotations_are_declared():
+    rels = _relations(Derived())
+    assert rels["inherited"] == []
+    assert rels["own"] == [["n0", "1"]]
+
+
+def test_private_annotations_are_not_declared():
+    """relationalize skips underscore names, so declaring one is unpopulatable."""
+
+    class Private:
+        _hidden: int
+        shown: int
+
+        def __init__(self):
+            self.shown = 1
+
+    assert "_hidden" not in _relations(Private())
+
+
+# --------------------------------------------------------------------------- #
+# Interaction with populated instances
+# --------------------------------------------------------------------------- #
+
+
+def test_partial_population_across_instances_keeps_the_tuples():
+    """One instance populating `b` means `b` is not empty — the other adds no tuple."""
+    rels = _relations([AnnotatedOnly(1), AnnotatedOnly(2, set_b=True)])
+    assert rels["b"] == [["n2", "99"]]
+
+
+def test_declared_relation_is_not_duplicated_when_populated():
+    instance = CnDDataInstanceBuilder().build_instance(AnnotatedOnly(1, set_b=True))
+    names = [r["name"] for r in instance["relations"]]
+    assert names.count("b") == 1
+
+
+def test_empty_relation_declares_binary_arity():
+    """Arity is unmeasurable without a tuple; empties default to binary."""
+    instance = CnDDataInstanceBuilder().build_instance(AnnotatedOnly(1))
+    empty = next(r for r in instance["relations"] if r["name"] == "b")
+    assert empty["types"] == ["object", "object"]
+    assert empty["id"] == "b"
+
+
+# --------------------------------------------------------------------------- #
+# Containers declare nothing
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("value", [[1, 2], {"k": 1}, {1, 2}, (1, 2), 42, "s", None])
+def test_containers_and_primitives_declare_no_relations(value):
+    """Only the tuples they actually emit — no phantom schema names."""
+    instance = CnDDataInstanceBuilder().build_instance(value)
+    assert all(r["tuples"] for r in instance["relations"])
+
+
+# --------------------------------------------------------------------------- #
+# Builder state and round-trip
+# --------------------------------------------------------------------------- #
+
+
+def test_declared_names_do_not_leak_across_builds():
+    """A reused builder must not carry a prior object's schema into the next."""
+    builder = CnDDataInstanceBuilder()
+    builder.build_instance(AnnotatedOnly(1))
+    second = builder.build_instance([1, 2])
+    assert "b" not in [r["name"] for r in second["relations"]]
+
+
+def test_empty_relation_does_not_disturb_reify():
+    """An empty relation contributes no tuple, so reconstruction is unchanged."""
+    instance = CnDDataInstanceBuilder().build_instance(AnnotatedOnly(1))
+    restored = reify(instance)
+    assert restored.a == 1
+    # Extensionally faithful: the instance never had `b`, so neither does the copy.
+    assert not hasattr(restored, "b")
+
+
+def test_none_valued_field_still_round_trips():
+    restored = reify(CnDDataInstanceBuilder().build_instance(OptionalField(a=1)))
+    assert restored.a == 1
+    assert restored.b is None
+
+
+# --------------------------------------------------------------------------- #
+# Extension point
+# --------------------------------------------------------------------------- #
+
+
+def test_custom_relationalizer_schema_hook_failure_does_not_fail_the_build():
+    """A third-party declared_relations that raises must not take down a build."""
+    from spytial.domain_relationalizers import GenericObjectRelationalizer
+
+    class Exploding(GenericObjectRelationalizer):
+        def declared_relations(self, obj):
+            raise RuntimeError("boom")
+
+    builder = CnDDataInstanceBuilder()
+    atoms, relations = Exploding().relationalize(AnnotatedOnly(1), builder)
+    assert atoms  # relationalize itself is unaffected
+
+    # And through the builder, where the hook is called defensively.
+    import spytial.provider_system as ps
+
+    original = ps.RelationalizerRegistry.find_relationalizer
+    ps.RelationalizerRegistry.find_relationalizer = staticmethod(
+        lambda obj: Exploding() if isinstance(obj, AnnotatedOnly) else original(obj)
+    )
+    try:
+        instance = CnDDataInstanceBuilder().build_instance(AnnotatedOnly(1))
+    finally:
+        ps.RelationalizerRegistry.find_relationalizer = original
+    assert [r["name"] for r in instance["relations"]] == ["a"]


### PR DESCRIPTION
A field is schema, not a privacy boundary and not a summary of what one instance happens to hold. The data instance did not reflect that in two independent ways, and this PR fixes both.

## 1. A declared field that no instance populates vanishes

The relationalizers are **extensional** — they emit a tuple only where an instance holds a value, and `relations` is derived entirely from emitted tuples.

The consequence downstream is that a selector naming such a field resolves to an arity-0 atom literal — exactly the signature of a *misspelled* name, as `_eval.SelectorVerdict.resolves` already documents:

> An unknown bareword (a hallucinated relation name) does **not** error and is **not** empty — the evaluator parses it as an atom literal that resolves to itself.

So "the field is empty here" and "that field does not exist" were the same observation.

| | before | after |
|---|---|---|
| plain class, annotated but assigned on one branch of `__init__` | silently absent | `"b": []` |
| `__slots__` member never assigned | silently absent | `"b": []` |
| dataclass `field(init=False)` never assigned | **`AttributeError` crash** | `"b": []` |

The third crashed the build outright on an unguarded `getattr`. That idiom is normal Python — a value computed in `__post_init__`, skipped on some branch.

This also resolves an asymmetry with `suggest()`, which reads the *schema* (`dataclasses.fields`, `__annotations__`, an AST scan of `__init__`) and so happily emits `@spytial.attribute(field='b')` for a field the relationalizer never materializes. Nothing reconciled the two views.

`Relation.__post_init__` rejects fewer than 2 atoms, so an empty relation cannot be expressed as a `Relation` — it needed its own channel:

- **`RelationalizerBase.declared_relations(obj)`** — new overridable hook, defaults to `[]`.
- **`DataclassRelationalizer`** — declares every `dataclasses.fields()` name. Its `getattr` is now guarded.
- **`GenericObjectRelationalizer`** — declares every name annotated or slotted across the MRO.
- **`CnDDataInstanceBuilder`** — collects declared names in first-encounter order during `_walk`, then emits any absent from `_rels` as `{tuples: []}`.

**The default is empty rather than inferred centrally.** Containers and primitives have no declared schema, and `TupleRelationalizer` renames fields to `t0`/`t1` — a blanket implementation would declare names it can never populate. Keeping the knowledge in the relationalizer also lets third-party ones opt in.

## 2. An underscored field is hidden on plain objects but not on dataclasses

`DataclassRelationalizer` already documents the rule: a field is schema, not a privacy boundary, `_x` participates in `__init__`/`__repr__`/`__eq__` like any other field, and skipping it "dropped structure from the diagram (a `_next` pointer drew no edge)" and let reify restore a class-level default over the instance's real value.

`GenericObjectRelationalizer` contradicted it, so the same shape relationalized differently depending only on whether its class happened to be a dataclass:

```
dataclass emits: ['value', '_next']
plain    emits: ['value']
```

Now filtered on what the *language* hides rather than what convention marks: dunders, and name-mangled `__x` stored as `_Class__x`, with prefixes computed from the MRO so a base's mangled name is recognised on a subclass. Hiding a field by convention is a display decision, which is where the dataclass comment already sends it — a directive.

`declared_relations` applies the identical rule, so a declared name is always one an instance could populate. Of 598 tests the only failure was the new one that had encoded the old rule.

## Also from review

**Class annotations are read through the runtime API** (`f31f2bc`, reported by Codex). Python 3.14 (PEP 649) keeps annotations behind a lazily-called annotate function, so `vars(klass)` no longer carries `__annotations__` and would silently report every class as fieldless. Now `inspect.get_annotations`, which gives the per-class behaviour the MRO walk needs — verified on 3.13 that a subclass declaring no annotations of its own returns `[]` rather than leaking its base's. The unevaluated format is requested where available, since only names are used and 3.14 would otherwise raise on an unresolvable forward reference. Falls back to the class dict below 3.10, which the package still supports.

**Relation-level `types` left as `["object", "object"]`.** This matches what populated relations already emit — that field is all-`object` throughout, with real types living per-tuple, and `object` isn't even in the datum's type list. Doing better for an empty relation means threading the declared type through `declared_relations` *and* having the core accept a type name with zero atoms — the known arity-error hazard. Same follow-up as the arity note below.

## Downstream

Selector evaluation improves without touching the evaluator:

```
before:  'b' → ok=True  empty=False  arity=0     # atom literal — reads as a typo
after:   'b' → ok=True  empty=True   arity=0     # a relation that holds nothing
```

`diagnostic()` now says "resolved to the empty set on this example" instead of "unknown or misspelled name". Arity still reads 0 — it cannot be measured without a tuple. Left for the evaluator pass.

Both Python consumers of `relation["tuples"]` (reify's relation map and root inference) no-op on an empty list, verified before landing.

## Verification

601 tests pass, of which 26 are new in `test/test_declared_relations.py`: all three gap shapes, the bare-string `__slots__` spelling, MRO inheritance, per-class annotation reading, forward references, underscore and mangled-name handling, partial population across instances, no-duplicate-when-populated, builder state not leaking across builds, reify round-trips, and a third-party hook that raises not failing the build.

Minor rather than patch: this adds public API surface (`declared_relations`) and changes emitted data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)