### PR TITLE
Refuse to walk spytial's own machinery; iterate container snapshots

### DIFF
--- a/spytial/_version.py
+++ b/spytial/_version.py
@@ -1,3 +1,3 @@
 """Package version source of truth."""
 
-__version__ = "1.10.1"
+__version__ = "1.10.2"

--- a/spytial/domain_relationalizers/dataclass_relationalizer.py
+++ b/spytial/domain_relationalizers/dataclass_relationalizer.py
@@ -49,6 +49,11 @@ class DataclassRelationalizer(RelationalizerBase):
                 # crashing the whole build.
                 continue
             vid = walker_func(value)
+            if vid is None:
+                # The walk refused the value (spytial machinery, issue #140).
+                # declared_relations above still carries the field name, so
+                # the field surfaces as an empty relation, not a misspelling.
+                continue
             relations.append(Relation(field.name, [obj_id, vid]))
 
         return [atom], relations

--- a/spytial/domain_relationalizers/dict_relationalizer.py
+++ b/spytial/domain_relationalizers/dict_relationalizer.py
@@ -20,7 +20,9 @@ class DictRelationalizer(RelationalizerBase):
 
         atoms = [Atom(id=obj_id, type=typ, label=label)]
         relations = []
-        for k, v in obj.items():
+        # Iterate a snapshot — walking a key or value runs arbitrary code that
+        # may mutate this dict, which raises RuntimeError mid-build (#140).
+        for k, v in list(obj.items()):
             # Walk every key through the normal pipeline — primitives *and*
             # complex keys (tuples, objects, …). _walk records the key's own
             # atom plus, for containers/objects, its nested structure and class
@@ -33,6 +35,11 @@ class DictRelationalizer(RelationalizerBase):
 
             # Get the value ID
             vid = walker_func._walk(v)
+
+            # None means the walk refused that side (spytial machinery) — the
+            # entry draws no tuple.
+            if key_id is None or vid is None:
+                continue
 
             # Create a ternary relation: keyval(dict, key, value)
             relations.append(Relation("kv", [obj_id, key_id, vid]))

--- a/spytial/domain_relationalizers/generic_object_relationalizer.py
+++ b/spytial/domain_relationalizers/generic_object_relationalizer.py
@@ -3,7 +3,7 @@ Relationalizer for generic objects with __dict__ or __slots__.
 
 Design Decisions:
 - Comprehensive inspection: Use inspect.getmembers to enumerate all attributes, ensuring we capture properties, descriptors, and inherited fields that serialization might include.
-- Filtering for relevance: Skip private attributes (starting with "_"), methods, functions, and modules to focus on meaningful data for visualization.
+- Filtering for relevance: Skip language-hidden names (dunders and name-mangled `_Class__x` privates — single-underscore names are structure and stay), plus methods, functions, and modules, to focus on meaningful data for visualization. Values the walker refuses (spytial's own machinery) draw no edge.
 - Serialization alignment: Include attributes even if not obviously serializable, as the relationalizer creates relations and the provider system handles serialization downstream.
 - Property/descriptor handling: Evaluate properties and descriptors on the instance to get actual values, preventing issues with dynamic attributes.
 - Performance: Limit to small/medium objects (<1 second) by using try-except for safe access and avoiding deep recursion.
@@ -141,11 +141,15 @@ class GenericObjectRelationalizer(RelationalizerBase):
                     if actual_value is value:
                         continue
                     vid = walker_func(actual_value)
+                    if vid is None:  # refused: spytial machinery, no edge
+                        continue
                     relations.append(Relation(name, [obj_id, vid]))
                 except (AttributeError, TypeError, ValueError):
                     continue
             else:
                 vid = walker_func(value)
+                if vid is None:  # refused: spytial machinery, no edge
+                    continue
                 relations.append(Relation(name, [obj_id, vid]))
 
         return [atom], relations

--- a/spytial/domain_relationalizers/list_relationalizer.py
+++ b/spytial/domain_relationalizers/list_relationalizer.py
@@ -17,17 +17,20 @@ class ListRelationalizer(RelationalizerBase):
 
         atoms = [atom]
         relations = []
-        for i, elt in enumerate(obj):
+        # Iterate a snapshot: walking an element runs arbitrary code (property
+        # getters, custom relationalizers) that may append to this very list,
+        # and a list that grows under its own loop never finishes (issue #140).
+        for i, elt in enumerate(tuple(obj)):
+            # Get the element ID; None means the walk refused the element
+            # (spytial machinery) — no index atom, no tuple.
+            eid = walker_func(elt)
+            if eid is None:
+                continue
+
             # Create an atom for the index
             idx_id = walker_func._get_id(i)
-
-            # Wait, only create the atom for the index if it's not already created?
-
             idx_atom = Atom(id=idx_id, type="int", label=str(i))
             atoms.append(idx_atom)
-
-            # Get the element ID
-            eid = walker_func(elt)
 
             # Create a ternary relation: idx(list, index, element)
             relations.append(Relation("idx", [obj_id, idx_id, eid]))

--- a/spytial/domain_relationalizers/set_relationalizer.py
+++ b/spytial/domain_relationalizers/set_relationalizer.py
@@ -20,8 +20,12 @@ class SetRelationalizer(RelationalizerBase):
         atom = Atom(id=obj_id, type=typ, label=label)
 
         relations = []
-        for element in obj:
+        # Iterate a snapshot — walking an element runs arbitrary code that may
+        # mutate this set, which raises RuntimeError mid-build (#140).
+        for element in tuple(obj):
             element_id = walker_func(element)
+            if element_id is None:  # refused: spytial machinery, no edge
+                continue
             relations.append(Relation("contains", [obj_id, element_id]))
 
         return [atom], relations

--- a/spytial/domain_relationalizers/tuple_relationalizer.py
+++ b/spytial/domain_relationalizers/tuple_relationalizer.py
@@ -25,6 +25,8 @@ class TupleRelationalizer(RelationalizerBase):
 
             # Get the element ID
             eid = walker_func(elt)
+            if eid is None:  # refused: spytial machinery, no edge
+                continue
 
             relations.append(Relation(f"t{i}", [obj_id, eid]))
 

--- a/spytial/provider_system.py
+++ b/spytial/provider_system.py
@@ -73,6 +73,30 @@ def default_max_depth() -> int:
     )
 
 
+# Classes defined inside spytial that are nevertheless user *data* — the reify
+# proxy is the one case today — opt out of the infrastructure refusal below by
+# setting this attribute. A dunder so `_is_hidden` keeps it out of the walk.
+_WALK_AS_DATA_ATTR = "__spytial_walk_as_data__"
+
+
+def _is_spytial_infrastructure(obj: Any) -> bool:
+    """True when *obj* is a piece of spytial itself rather than user data.
+
+    Since sidprasad/spytial#137 exposed single-underscore attributes, a
+    back-reference like ``node._seq`` leads the walk into the recorder — and
+    from there into the builder currently performing the walk, whose
+    collections grow on every walked value, so the walk never terminates
+    (sidprasad/spytial#140). Even when such a chain does terminate, atoms for
+    spytial's own machinery are meaningless in a diagram of the user's data.
+    The type's defining module is the test: infrastructure is anything
+    spytial defines, not just the two classes known to bite today.
+    """
+    if getattr(type(obj), _WALK_AS_DATA_ATTR, False):
+        return False
+    module = getattr(type(obj), "__module__", None) or ""
+    return module == "spytial" or module.startswith("spytial.")
+
+
 def _resolve_named(module_name: Optional[str], qualname: Optional[str]) -> Optional[Any]:
     """Resolve any module attribute from its module + qualified name.
 
@@ -288,6 +312,18 @@ class CnDDataInstanceBuilder:
                 f"{e} (while building a data instance for a "
                 f"{type(obj).__name__})"
             ).with_traceback(e.__traceback__) from None
+
+        if root_atom_id is None:
+            # Only the identity refusals apply at the root, so this is someone
+            # handing the builder itself (or one of its collections) back to
+            # build_instance. Walking that state while it accumulates cannot
+            # terminate, so it is an error rather than an empty instance.
+            raise ValueError(
+                "Refusing to build a data instance of the active "
+                "CnDDataInstanceBuilder or its internal state: the walk "
+                "would ingest its own accumulating collections and never "
+                "terminate."
+            )
 
         # Cache the root so a later reify() call can reconstruct the same
         # object even when the graph is cyclic (topology alone can't pick the
@@ -513,8 +549,44 @@ class CnDDataInstanceBuilder:
             self._id_counter += 1
         return self._seen[oid]
 
-    def _walk(self, obj: Any, max_depth: Optional[int] = None) -> str:
+    def _refuses_to_walk(self, obj: Any) -> bool:
+        """True when the walk must not ingest *obj* (sidprasad/spytial#140).
+
+        Two layers. Identity first: this builder and its accumulating
+        collections mutate on every walked value, and iterating a list that
+        grows under the loop never terminates — ``_seen`` can't help (each
+        step mints new atoms, nothing repeats) and the depth guard never
+        trips (it's a flat loop, not deep recursion). Then provenance: any
+        other spytial-defined object (a recorder, another builder, …) is
+        machinery, not data — its atoms would be meaningless even where the
+        walk terminates. The root is exempt from the provenance test only:
+        passing a spytial object to ``build_instance`` is an explicit request,
+        but walking the active builder cannot work at any depth.
+        """
+        if obj is self:
+            return True
+        for live_state in (
+            self._seen,
+            self._atoms,
+            self._rels,
+            self._declared_rels,
+            self._collected_decorators,
+            self._type_label_counters,
+            self._build_identity_objects,
+            self._persistent_object_ids,
+            self._persistent_atom_labels,
+        ):
+            if obj is live_state:
+                return True
+        return self._current_depth > 1 and _is_spytial_infrastructure(obj)
+
+    def _walk(self, obj: Any, max_depth: Optional[int] = None) -> Optional[str]:
         """Walk an object using the appropriate provider.
+
+        Returns the atom ID for *obj*, or ``None`` when the walk refuses it
+        (spytial's own machinery — see :meth:`_refuses_to_walk`). On ``None``
+        a relationalizer emits no relation for the value; any tuple that
+        carries a ``None`` anyway is dropped centrally in this method.
 
         ``max_depth`` defaults to :func:`default_max_depth`, derived from the
         interpreter's recursion limit so this guard trips before CPython's.
@@ -529,6 +601,10 @@ class CnDDataInstanceBuilder:
                 f"{sys.getrecursionlimit()}). Raise the recursion limit to "
                 f"walk deeper."
             )
+
+        if self._refuses_to_walk(obj):
+            self._current_depth -= 1
+            return None
 
         oid = id(obj)
         if oid in self._seen:
@@ -622,6 +698,12 @@ class CnDDataInstanceBuilder:
             # Relations now come as (name, atom1, atom2, ...) tuples
             rel_name = rel_data[0]
             atom_ids = list(rel_data[1:])  # All atoms after the name
+            # A None means the walk refused that value (spytial machinery).
+            # Built-in relationalizers skip these tuples themselves; dropping
+            # the stragglers here keeps third-party relationalizers that
+            # don't check the walker's return safe too.
+            if any(atom_id is None for atom_id in atom_ids):
+                continue
             self._rels.setdefault(rel_name, []).append(atom_ids)
 
         # Decrement depth after processing
@@ -630,8 +712,11 @@ class CnDDataInstanceBuilder:
         # Return the ID of the primary atom
         return primary_atom_id
 
-    def __call__(self, obj: Any) -> str:
-        """Allow the builder to be called as a function for recursive walking."""
+    def __call__(self, obj: Any) -> Optional[str]:
+        """Allow the builder to be called as a function for recursive walking.
+
+        ``None`` means the walk refused the object — emit no relation for it.
+        """
         return self._walk(obj)
 
     def _get_atom_type(self, atom_id: str) -> str:
@@ -1154,6 +1239,12 @@ class CnDDataInstanceBuilder:
 
         # Fallback: structural attribute-bag proxy.
         class ReconstructedObject:
+            # Defined in a spytial module but standing in for the user's own
+            # object — re-walking a reified graph must treat it as data, not
+            # trip the infrastructure refusal. (_WALK_AS_DATA_ATTR; a dunder,
+            # so the walk's attribute filter never surfaces it as an edge.)
+            __spytial_walk_as_data__ = True
+
             def __init__(self):
                 pass
 

--- a/test/test_walk_self_ingestion.py
+++ b/test/test_walk_self_ingestion.py
@@ -1,0 +1,230 @@
+"""The walk must not ingest spytial's own machinery (issue #140).
+
+#137 exposed single-underscore attributes, which opened a path from user data
+into the recorder that is *currently building the frame*:
+
+    Node ._seq → SequenceRecorder ._builder → CnDDataInstanceBuilder ._atoms
+
+``_atoms`` grows on every walked value, and iterating a list that grows under
+its own loop never terminates. Neither existing guard applies: ``_seen`` stops
+repeats but every step mints new atoms, and the depth guard never trips
+because the loop is flat (depth stays ~5). The fix is refusal — the walker
+returns None for spytial infrastructure reached through user data (no atom,
+no edge) — plus snapshot iteration in the container relationalizers so a
+mid-walk mutation from any other source degrades to stale output, not a hang.
+"""
+
+import contextlib
+import signal
+
+import pytest
+
+import spytial
+from spytial.provider_system import CnDDataInstanceBuilder
+from spytial.domain_relationalizers.dict_relationalizer import DictRelationalizer
+from spytial.domain_relationalizers.list_relationalizer import ListRelationalizer
+from spytial.domain_relationalizers.set_relationalizer import SetRelationalizer
+
+
+@contextlib.contextmanager
+def finishes_within(seconds):
+    """Fail fast instead of hanging the suite if the walk regresses."""
+    if not hasattr(signal, "SIGALRM"):  # pragma: no cover - non-POSIX
+        yield
+        return
+
+    def _timed_out(signum, frame):
+        raise TimeoutError(f"walk did not finish within {seconds}s")
+
+    previous = signal.signal(signal.SIGALRM, _timed_out)
+    signal.alarm(seconds)
+    try:
+        yield
+    finally:
+        signal.alarm(0)
+        signal.signal(signal.SIGALRM, previous)
+
+
+def relation_names(instance):
+    return {rel["name"] for rel in instance["relations"]}
+
+
+def atom_types(instance):
+    return {atom["type"] for atom in instance["atoms"]}
+
+
+# ---------------------------------------------------------------------------
+# The reported shape: an object records itself and keeps the recorder.
+# ---------------------------------------------------------------------------
+
+
+def test_record_with_backref_to_recorder_terminates():
+    # Verbatim shape from #140 — record() called from inside __init__, with
+    # the recorder kept as an attribute. Used to spin forever.
+    class Node:
+        def __init__(self, data, seq):
+            self.data = list(data)
+            self._seq = seq
+            seq.record(self, label="frame 0")
+
+    seq = spytial.sequence()
+    with finishes_within(30):
+        Node([1, 2, 3], seq)
+
+    [frame] = seq._data_instances
+    assert "SequenceRecorder" not in atom_types(frame)
+    assert "CnDDataInstanceBuilder" not in atom_types(frame)
+    # The refused back-reference draws no edge; the real data still does.
+    assert "_seq" not in relation_names(frame)
+    assert "data" in relation_names(frame)
+
+
+def test_instrumented_mutation_records_every_frame():
+    # The spytial-clrs pattern that silently hung: snap from inside the
+    # mutating object on every step.
+    class Sorter:
+        def __init__(self, values, seq):
+            self.values = values
+            self._seq = seq
+
+        def sort(self):
+            self._seq.record(self, note="start")
+            for i in range(len(self.values)):
+                for j in range(len(self.values) - 1 - i):
+                    if self.values[j] > self.values[j + 1]:
+                        self.values[j], self.values[j + 1] = (
+                            self.values[j + 1],
+                            self.values[j],
+                        )
+                self._seq.record(self)
+
+    seq = spytial.sequence()
+    sorter = Sorter([3, 1, 2], seq)
+    with finishes_within(30):
+        sorter.sort()
+
+    assert len(seq._data_instances) == 4
+    assert all(
+        "SequenceRecorder" not in atom_types(frame) for frame in seq._data_instances
+    )
+
+
+# ---------------------------------------------------------------------------
+# Refusal is general, not recorder-specific.
+# ---------------------------------------------------------------------------
+
+
+def test_backref_to_the_active_builder_terminates():
+    class Holder:
+        pass
+
+    builder = CnDDataInstanceBuilder()
+    holder = Holder()
+    holder.payload = [1, 2]
+    holder.builder = builder
+
+    with finishes_within(30):
+        instance = builder.build_instance(holder)
+
+    assert "payload" in relation_names(instance)
+    assert "builder" not in relation_names(instance)
+    assert "CnDDataInstanceBuilder" not in atom_types(instance)
+
+
+def test_infrastructure_inside_containers_is_skipped():
+    seq = spytial.sequence()
+    instance = CnDDataInstanceBuilder().build_instance([1, seq, 2])
+
+    assert "SequenceRecorder" not in atom_types(instance)
+    idx = next(rel for rel in instance["relations"] if rel["name"] == "idx")
+    # Tuples exist only for the two ints; the refused element draws nothing.
+    assert len(idx["tuples"]) == 2
+
+
+def test_building_the_builder_itself_is_an_error():
+    builder = CnDDataInstanceBuilder()
+    with pytest.raises(ValueError, match="active\\s+CnDDataInstanceBuilder"):
+        builder.build_instance(builder)
+    with pytest.raises(ValueError, match="internal state"):
+        builder.build_instance(builder._atoms)
+
+
+def test_spytial_object_as_explicit_root_still_walks():
+    # Refusal is for machinery reached *through* user data. Handing a spytial
+    # object to build_instance directly is an explicit request and stays
+    # honored — its own spytial-typed attributes are skipped, so it ends.
+    seq = spytial.sequence()
+    with finishes_within(30):
+        instance = CnDDataInstanceBuilder().build_instance(seq)
+
+    root = next(a for a in instance["atoms"] if a["id"] == instance["rootId"])
+    assert root["type"] == "SequenceRecorder"
+    assert "CnDDataInstanceBuilder" not in atom_types(instance)
+
+
+def test_reified_proxy_is_data_not_infrastructure():
+    # The reify fallback proxy is defined inside spytial.provider_system, but
+    # it stands in for the user's object — re-walking a reified graph must
+    # keep it (the __spytial_walk_as_data__ marker).
+    class Local:  # <locals> qualname → not importable → proxy on reify
+        def __init__(self, x):
+            self.x = x
+
+    builder = CnDDataInstanceBuilder()
+    reified = builder.reify(builder.build_instance([Local(5)]))
+    proxy = reified[0]
+    assert type(proxy).__module__.startswith("spytial")  # the hazard is real
+
+    rewalked = CnDDataInstanceBuilder().build_instance([proxy])
+    assert "x" in relation_names(rewalked)
+
+
+# ---------------------------------------------------------------------------
+# Containers iterate snapshots: mutation mid-walk must not hang or raise.
+# ---------------------------------------------------------------------------
+
+
+def test_list_relationalizer_iterates_a_snapshot():
+    grown = [1, 2, 3]
+
+    class GrowingWalker:
+        def _get_id(self, obj):
+            return str(obj)
+
+        def __call__(self, obj):
+            grown.append(len(grown))  # element walk appends to the list
+            return str(obj)
+
+    with finishes_within(30):
+        _, relations = ListRelationalizer().relationalize(grown, GrowingWalker())
+    assert len(relations) == 3
+
+
+def test_dict_relationalizer_iterates_a_snapshot():
+    grown = {"a": 1}
+
+    class GrowingWalker:
+        def _get_id(self, obj):
+            return str(obj)
+
+        def _walk(self, obj):
+            grown[len(grown)] = None  # key/value walk inserts a new entry
+            return str(obj)
+
+    _, relations = DictRelationalizer().relationalize(grown, GrowingWalker())
+    assert len(relations) == 1
+
+
+def test_set_relationalizer_iterates_a_snapshot():
+    grown = {1, 2, 3}
+
+    class GrowingWalker:
+        def _get_id(self, obj):
+            return str(obj)
+
+        def __call__(self, obj):
+            grown.add(len(grown) + 10)  # element walk inserts a new member
+            return str(obj)
+
+    _, relations = SetRelationalizer().relationalize(grown, GrowingWalker())
+    assert len(relations) == 3


### PR DESCRIPTION
Fixes #140.

Since #137 stopped hiding single-underscore attributes, an object holding a back-reference to the `SequenceRecorder` recording it led the walk into the **live** `CnDDataInstanceBuilder`, and `ListRelationalizer` then iterated `_atoms` while every step appended to it — a flat loop neither `_seen` (new atoms every step, nothing repeats) nor the depth guard (depth pinned at 5–6) could stop. This lands both suggested fixes, generalized so the whole class of self-ingestion is gone, not just the recorder instance.

## The walker refuses spytial's own machinery

`_walk` now returns `None` — no atom, no edge — for:

- **The active builder and its accumulating collections, by identity, at any depth.** Walking them cannot terminate. Handing the builder itself to `build_instance` raises a clear `ValueError` instead of hanging.
- **Any other spytial-defined value reached *through* user data, by provenance** (the type's defining module is `spytial` or `spytial.*`). A recorder, an idle builder, or any future internal object draws nothing — its atoms were meaningless even when the walk happened to terminate. The root is exempt: passing a spytial object to `build_instance` directly is an explicit request and still works.

Built-in relationalizers skip refused values (the list relationalizer also skips the orphaned index atom), and the builder drops any relation tuple carrying a `None` centrally — so a third-party relationalizer that never learned about refusal stays safe too.

One carve-out: the reify fallback proxy (`ReconstructedObject`) lives in `spytial.provider_system` but stands in for the user's own object. A `__spytial_walk_as_data__` marker exempts it, so re-walking a reified graph keeps proxy structure (covered by a test). The marker is a dunder, so the attribute filter never surfaces it as an edge.

## Containers iterate snapshots

`ListRelationalizer` iterates `tuple(obj)`, `DictRelationalizer` iterates `list(obj.items())`, `SetRelationalizer` iterates `tuple(obj)`. Walking an element runs arbitrary code (property getters, custom relationalizers); if that code mutates the container being iterated, the walk now degrades to stale-but-finite output instead of a hang (list) or a mid-build `RuntimeError` (dict/set). Defense in depth behind the refusal, as the issue notes — on its own it would only convert the hang into garbage atoms.

## Also

- The issue's repro completes immediately and yields only `Node`/`list`/`int` atoms with `data` + `idx` relations — no `_seq` edge, no recorder atom.
- New regression tests in `test/test_walk_self_ingestion.py` (10), including the exact #140 shape, the spytial-clrs record-from-inside-the-mutating-object pattern, refusal generality (builder back-ref, infrastructure inside containers), the explicit-root exemption, the reified-proxy carve-out, and snapshot iteration for all three containers. Termination tests run under a SIGALRM watchdog so a regression fails in 30s instead of hanging CI.
- Updated the `generic_object_relationalizer` module docstring, which still described the pre-#137 underscore filter.
- Version bumped to 1.10.2.

Full suite: 636 passed, 12 skipped, 2 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)